### PR TITLE
Fix row counts bottleneck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,8 @@ dmypy.json
 # Local dev
 dev/
 benchmarks.py
+ibm/
+dev.py
 
 # Pycharm
 .idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datagrunt"
-version = "0.0.0"
+version = "0.1.12"
 description = "Read CSV files and convert to other file formats easily"
 readme = "README.md"
 authors = [{ name = "Martin Graham", email = "datagrunt@datagrunt.io" }]
@@ -43,7 +43,7 @@ include = ["datagrunt*"]
 exclude = ["tests*"]
 
 [tool.bumpver]
-current_version = "0.0.0"
+current_version = "0.1.12"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datagrunt"
-version = "0.1.12"
+version = "0.1.13"
 description = "Read CSV files and convert to other file formats easily"
 readme = "README.md"
 authors = [{ name = "Martin Graham", email = "datagrunt@datagrunt.io" }]
@@ -43,7 +43,7 @@ include = ["datagrunt*"]
 exclude = ["tests*"]
 
 [tool.bumpver]
-current_version = "0.1.12"
+current_version = "0.1.13"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datagrunt"
-version = "0.1.14"
+version = "0.0.0"
 description = "Read CSV files and convert to other file formats easily"
 readme = "README.md"
 authors = [{ name = "Martin Graham", email = "datagrunt@datagrunt.io" }]
@@ -43,7 +43,7 @@ include = ["datagrunt*"]
 exclude = ["tests*"]
 
 [tool.bumpver]
-current_version = "0.1.14"
+current_version = "0.0.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datagrunt"
-version = "0.0.0"
+version = "0.0.1"
 description = "Read CSV files and convert to other file formats easily"
 readme = "README.md"
 authors = [{ name = "Martin Graham", email = "datagrunt@datagrunt.io" }]
@@ -43,7 +43,7 @@ include = ["datagrunt*"]
 exclude = ["tests*"]
 
 [tool.bumpver]
-current_version = "0.0.0"
+current_version = "0.0.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datagrunt"
-version = "0.1.13"
+version = "0.1.14"
 description = "Read CSV files and convert to other file formats easily"
 readme = "README.md"
 authors = [{ name = "Martin Graham", email = "datagrunt@datagrunt.io" }]
@@ -43,7 +43,7 @@ include = ["datagrunt*"]
 exclude = ["tests*"]
 
 [tool.bumpver]
-current_version = "0.1.13"
+current_version = "0.1.14"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/datagrunt/__init__.py
+++ b/src/datagrunt/__init__.py
@@ -23,7 +23,7 @@ Attributes:
     __license__: The license under which the package is released.
 """
 
-__version__ = "0.1.14"
+__version__ = "0.0.1"
 __author__ = "Martin Graham"
 __license__ = "MIT"
 

--- a/src/datagrunt/__init__.py
+++ b/src/datagrunt/__init__.py
@@ -23,7 +23,7 @@ Attributes:
     __license__: The license under which the package is released.
 """
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 __author__ = "Martin Graham"
 __license__ = "MIT"
 

--- a/src/datagrunt/__init__.py
+++ b/src/datagrunt/__init__.py
@@ -23,7 +23,7 @@ Attributes:
     __license__: The license under which the package is released.
 """
 
-__version__ = "0.0.0"
+__version__ = "0.1.12"
 __author__ = "Martin Graham"
 __license__ = "MIT"
 

--- a/src/datagrunt/__init__.py
+++ b/src/datagrunt/__init__.py
@@ -23,7 +23,7 @@ Attributes:
     __license__: The license under which the package is released.
 """
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 __author__ = "Martin Graham"
 __license__ = "MIT"
 

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -236,8 +236,6 @@ class CSVProperties(FileProperties):
                 'newline_delimiter': dialect.lineterminator,
                 'skipinitialspace': dialect.skipinitialspace,
                 'quoting': self.QUOTING_MAP.get(dialect.quoting),
-                'row_count_with_header': self.row_count_with_header,
-                'row_count_without_header': self.row_count_without_header,
                 'columns_schema': columns,
                 'columns_original_format': self.first_row,
                 'columns_list': columns_list,

--- a/tests/test_csvfile.py
+++ b/tests/test_csvfile.py
@@ -13,12 +13,12 @@ import duckdb
 import polars as pl
 
 # local libraries
-from datagrunt.core.engines import CSVReaderDuckDBEngine, CSVReaderPolarsEngine
-from datagrunt.core.engines import CSVWriterDuckDBEngine, CSVWriterPolarsEngine
-from datagrunt.csvfile import CSVReader, CSVWriter
-from datagrunt.core.databases import DuckDBDatabase
-from datagrunt.core.fileproperties import FileProperties, CSVProperties
-from datagrunt.core.logger import *
+from src.datagrunt.core.engines import CSVReaderDuckDBEngine, CSVReaderPolarsEngine
+from src.datagrunt.core.engines import CSVWriterDuckDBEngine, CSVWriterPolarsEngine
+from src.datagrunt import CSVReader, CSVWriter
+from src.datagrunt.core.databases import DuckDBDatabase
+from src.datagrunt.core.fileproperties import FileProperties, CSVProperties
+from src.datagrunt.core.logger import *
 # from datagrunt.core.queries import DuckDBQueries
 
 class TestDuckDBDatabase(unittest.TestCase):
@@ -465,63 +465,63 @@ class TestCSVReader(unittest.TestCase):
             """Reader engine 'invalid' is not 'duckdb' or 'polars'. Pass either 'duckdb' or 'polars' as valid engine params."""
         )
 
-    @patch('datagrunt.csvfile.CSVReaderPolarsEngine.get_sample')
+    @patch('src.datagrunt.csvfile.CSVReaderPolarsEngine.get_sample')
     def test_get_sample_polars(self, mock_get_sample):
         """Test that the get_sample method calls the Polars engine."""
         reader = CSVReader(self.filepath)
         reader.get_sample()
         mock_get_sample.assert_called_once()
 
-    @patch('datagrunt.csvfile.CSVReaderDuckDBEngine.get_sample')
+    @patch('src.datagrunt.csvfile.CSVReaderDuckDBEngine.get_sample')
     def test_get_sample_duckdb(self, mock_get_sample):
         """Test that the get_sample method calls the DuckDB engine."""
         reader = CSVReader(self.filepath, engine='duckdb')
         reader.get_sample()
         mock_get_sample.assert_called_once()
 
-    @patch('datagrunt.csvfile.CSVReaderPolarsEngine.to_dataframe')
+    @patch('src.datagrunt.csvfile.CSVReaderPolarsEngine.to_dataframe')
     def test_to_dataframe_polars(self, mock_to_dataframe):
         """Test that the to_dataframe method calls the Polars engine."""
         reader = CSVReader(self.filepath)
         reader.to_dataframe()
         mock_to_dataframe.assert_called_once()
 
-    @patch('datagrunt.csvfile.CSVReaderDuckDBEngine.to_dataframe')
+    @patch('src.datagrunt.csvfile.CSVReaderDuckDBEngine.to_dataframe')
     def test_to_dataframe_duckdb(self, mock_to_dataframe):
         """Test that the to_dataframe method calls the DuckDB engine."""
         reader = CSVReader(self.filepath, engine='duckdb')
         reader.to_dataframe()
         mock_to_dataframe.assert_called_once()
 
-    @patch('datagrunt.csvfile.CSVReaderPolarsEngine.to_arrow_table')
+    @patch('src.datagrunt.csvfile.CSVReaderPolarsEngine.to_arrow_table')
     def test_to_arrow_table_polars(self, mock_to_arrow_table):
         """Test that the to_arrow_table method calls the Polars engine."""
         reader = CSVReader(self.filepath)
         reader.to_arrow_table()
         mock_to_arrow_table.assert_called_once()
 
-    @patch('datagrunt.csvfile.CSVReaderDuckDBEngine.to_arrow_table')
+    @patch('src.datagrunt.csvfile.CSVReaderDuckDBEngine.to_arrow_table')
     def test_to_arrow_table_duckdb(self, mock_to_arrow_table):
         """Test that the to_arrow_table method calls the DuckDB engine."""
         reader = CSVReader(self.filepath, engine='duckdb')
         reader.to_arrow_table()
         mock_to_arrow_table.assert_called_once()
 
-    @patch('datagrunt.csvfile.CSVReaderPolarsEngine.to_dicts')
+    @patch('src.datagrunt.csvfile.CSVReaderPolarsEngine.to_dicts')
     def test_to_dicts_polars(self, mock_to_dicts):
         """Test that the to_dicts method calls the Polars engine."""
         reader = CSVReader(self.filepath)
         reader.to_dicts()
         mock_to_dicts.assert_called_once()
 
-    @patch('datagrunt.csvfile.CSVReaderDuckDBEngine.to_dicts')
+    @patch('src.datagrunt.csvfile.CSVReaderDuckDBEngine.to_dicts')
     def test_to_dicts_duckdb(self, mock_to_dicts):
         """Test that the to_dicts method calls the DuckDB engine."""
         reader = CSVReader(self.filepath, engine='duckdb')
         reader.to_dicts()
         mock_to_dicts.assert_called_once()
 
-    @patch('datagrunt.csvfile.duckdb.sql')
+    @patch('src.datagrunt.csvfile.duckdb.sql')
     def test_query_data(self, mock_sql):
         """Test that the query_data method calls DuckDB SQL with the correct query."""
         reader = CSVReader(self.filepath)


### PR DESCRIPTION
This is a patch for fixing this issue: [Inefficient CSV attribute retrieval causing bottleneck in large file processing](https://github.com/pmgraham/datagrunt/issues/13). The steps to fix the issue are as follows:

- Remove the `row_count_with_header` and the `row_count_without_header` from the `_get_attributes` method. Given that we already have access to the row counts as file properties, I didn't see any reason to keep them inside of the dict returned by the `get_attributes` method given the bottleneck experienced with large files.

Two other changes were applied outside of the specific issue:

- **Updated the `.gitignore`** file to ignore local dev resources in specific directories or with specific names
- **Fixed imports in the unit test methods.** On initial release, when, by convention, we moved the core components of the module to the `src` directory, all unit tests had been run and passed, and all that was left was to publish to testpypi to ensure the package worked as expected. We never ran the unit tests after the fact. When running unit tests after making the code changes for this issue, the tests failed and I realized it was because the imports for the tests were never adjusted after publishing.

Procedure after the Pull Request has been merged:
- Given that we don't have automated CI/CD yet, after the PR is merged, @pmgraham will deploy a patch update by rebuilding the module, bumping the version to 0.0.1, and publishing the updated version to PyPi.