### PR TITLE
16 handle empty file attribute and read errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ dev.py
 
 # Pycharm
 .idea/
+.replit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datagrunt"
-version = "0.0.2"
+version = "0.0.3"
 description = "Read CSV files and convert to other file formats easily"
 readme = "README.md"
 authors = [{ name = "Martin Graham", email = "datagrunt@datagrunt.io" }]
@@ -43,7 +43,7 @@ include = ["datagrunt*"]
 exclude = ["tests*"]
 
 [tool.bumpver]
-current_version = "0.0.2"
+current_version = "0.0.3"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/datagrunt/__init__.py
+++ b/src/datagrunt/__init__.py
@@ -23,7 +23,7 @@ Attributes:
     __license__: The license under which the package is released.
 """
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 __author__ = "Martin Graham"
 __license__ = "MIT"
 

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -171,7 +171,7 @@ class CSVProperties(FileProperties):
                 f"File extension '{self.extension_string}' is not a valid CSV file extension."
                              )
 
-    def _return_empty_file_object(self):
+    def _return_empty_file_attributes(self):
         """Return an empty file object."""
         return {
             'delimiter': self.DEFAULT_DELIMITER,
@@ -240,7 +240,7 @@ class CSVProperties(FileProperties):
     def _get_attributes(self):
         """Generate a dictionary of CSV attributes."""
         if self.is_empty:
-            attributes = self._return_empty_file_object()
+            attributes = self._return_empty_file_attributes()
         else:
             columns_list = self.first_row.split(self.delimiter)
             columns = {c: 'VARCHAR' for c in columns_list}

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -171,6 +171,24 @@ class CSVProperties(FileProperties):
                 f"File extension '{self.extension_string}' is not a valid CSV file extension."
                              )
 
+    def _return_empty_file_object(self):
+        """Return an empty file object."""
+        return {
+            'delimiter': self.DEFAULT_DELIMITER,
+            'quotechar': '"',
+            'escapechar': None,
+            'doublequote': True,
+            'newline_delimiter': '\n',
+            'skipinitialspace': False,
+            'quoting': 'quote all',
+            'columns_schema': {},
+            'columns_original_format': '',
+            'columns_list': [],
+            'columns_string': '',
+            'columns_byte_string': b'',
+            'column_count': 0
+        }
+
     def _get_first_row_from_file(self):
         """Reads and returns the first line of a file.
 
@@ -221,28 +239,30 @@ class CSVProperties(FileProperties):
 
     def _get_attributes(self):
         """Generate a dictionary of CSV attributes."""
-        columns_list = self.first_row.split(self.delimiter)
-        columns = {c: 'VARCHAR' for c in columns_list}
-        with open(self.filepath, 'r', encoding=self.DEFAULT_ENCODING) as csvfile:
-            # Sniff the file to detect parameters
-            dialect = csv.Sniffer().sniff(csvfile.read(self.CSV_SNIFF_SAMPLE_ROWS))
-            csvfile.seek(0)  # Reset file pointer to the beginning
-
-            attributes = {
-                'delimiter': self.delimiter,
-                'quotechar': dialect.quotechar,
-                'escapechar': dialect.escapechar,
-                'doublequote': dialect.doublequote,
-                'newline_delimiter': dialect.lineterminator,
-                'skipinitialspace': dialect.skipinitialspace,
-                'quoting': self.QUOTING_MAP.get(dialect.quoting),
-                'columns_schema': columns,
-                'columns_original_format': self.first_row,
-                'columns_list': columns_list,
-                'columns_string': ", ".join(columns_list),
-                'columns_byte_string': ", ".join(columns_list).encode(),
-                'column_count': len(columns_list)
-            }
+        if self.is_empty:
+            attributes = self._return_empty_file_object()
+        else:
+            columns_list = self.first_row.split(self.delimiter)
+            columns = {c: 'VARCHAR' for c in columns_list}
+            with open(self.filepath, 'r', encoding=self.DEFAULT_ENCODING) as csvfile:
+                # Sniff the file to detect parameters
+                dialect = csv.Sniffer().sniff(csvfile.read(self.CSV_SNIFF_SAMPLE_ROWS))
+                csvfile.seek(0)  # Reset file pointer to the beginning
+                attributes = {
+                        'delimiter': self.delimiter,
+                        'quotechar': dialect.quotechar,
+                        'escapechar': dialect.escapechar,
+                        'doublequote': dialect.doublequote,
+                        'newline_delimiter': dialect.lineterminator,
+                        'skipinitialspace': dialect.skipinitialspace,
+                        'quoting': self.QUOTING_MAP.get(dialect.quoting),
+                        'columns_schema': columns,
+                        'columns_original_format': self.first_row,
+                        'columns_list': columns_list,
+                        'columns_string': ", ".join(columns_list),
+                        'columns_byte_string': ", ".join(columns_list).encode(),
+                        'column_count': len(columns_list)
+                    }
 
         return attributes
 

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -127,8 +127,19 @@ class FileProperties:
 
     @property
     def is_empty(self):
-        """Check if the file is empty."""
+        """Check if the file is empty. Empty files have a size of 0 bytes."""
         return self.size_in_bytes == 0
+
+    @property
+    def is_blank(self):
+        """Check if the file is blank. Blank files contain only whitespace."""
+        # Read the file as text first
+        with open(self.filepath, 'r') as f:
+            # Remove whitespace, newlines, and other invisible characters
+            content = f.read().strip()
+            if not content:  # If file is completely empty
+                return True
+        return False
 
     @property
     def is_large(self):
@@ -229,7 +240,7 @@ class CSVProperties(FileProperties):
         """
         delimiter_candidates = self._get_most_common_non_alpha_numeric_character_from_string()
 
-        if self.is_empty:
+        if self.is_empty or self.is_blank:
             delimiter = self.DEFAULT_DELIMITER
         elif len(delimiter_candidates) == 0:
             delimiter = ' '
@@ -239,7 +250,7 @@ class CSVProperties(FileProperties):
 
     def _get_attributes(self):
         """Generate a dictionary of CSV attributes."""
-        if self.is_empty:
+        if self.is_empty or self.is_blank:
             attributes = self._return_empty_file_attributes()
         else:
             columns_list = self.first_row.split(self.delimiter)

--- a/src/datagrunt/csvfile.py
+++ b/src/datagrunt/csvfile.py
@@ -65,7 +65,7 @@ class CSVReader(CSVProperties):
         Returns:
             A PyArrow table.
         """
-        if self.is_empty:
+        if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pl.DataFrame().to_arrow())
         return self._set_reader_engine().to_arrow_table()
 

--- a/src/datagrunt/csvfile.py
+++ b/src/datagrunt/csvfile.py
@@ -76,7 +76,7 @@ class CSVReader(CSVProperties):
             A list of dictionaries.
         """
         if self.is_empty:
-            return self._return_empty_file_object(dict())
+            return self._return_empty_file_object(list())
         return self._set_reader_engine().to_dicts()
 
     def query_data(self, sql_query):

--- a/src/datagrunt/csvfile.py
+++ b/src/datagrunt/csvfile.py
@@ -4,6 +4,7 @@
 
 # third party libraries
 import duckdb
+import polars as pl
 
 # local libraries
 from .core.fileproperties import CSVProperties
@@ -40,6 +41,10 @@ class CSVReader(CSVProperties):
             engine = CSVReaderPolarsEngine(self.filepath)
         return engine
 
+    def _return_empty_file_object(self, object):
+        """Return an empty file object."""
+        return object
+
     def get_sample(self):
         """Return a sample of the CSV file."""
         self._set_reader_engine().get_sample()
@@ -50,6 +55,8 @@ class CSVReader(CSVProperties):
         Returns:
             A Polars dataframe.
         """
+        if self.is_empty:
+            return self._return_empty_file_object(pl.DataFrame())
         return self._set_reader_engine().to_dataframe()
 
     def to_arrow_table(self):
@@ -58,6 +65,8 @@ class CSVReader(CSVProperties):
         Returns:
             A PyArrow table.
         """
+        if self.is_empty:
+            return self._return_empty_file_object(pl.DataFrame().to_arrow())
         return self._set_reader_engine().to_arrow_table()
 
     def to_dicts(self):
@@ -66,6 +75,8 @@ class CSVReader(CSVProperties):
         Returns:
             A list of dictionaries.
         """
+        if self.is_empty:
+            return self._return_empty_file_object(dict())
         return self._set_reader_engine().to_dicts()
 
     def query_data(self, sql_query):
@@ -82,6 +93,8 @@ class CSVReader(CSVProperties):
             query = "SELECT col1, col2 FROM {dg.db_table}" # f string assumed
             dg.query_csv_data(query)
         """
+        if self.is_empty:
+            return self._return_empty_file_object(list())
         queries = DuckDBQueries(self.filepath)
         duckdb.sql(queries.import_csv_query(self.delimiter))
         return duckdb.sql(sql_query)

--- a/src/datagrunt/csvfile.py
+++ b/src/datagrunt/csvfile.py
@@ -55,7 +55,7 @@ class CSVReader(CSVProperties):
         Returns:
             A Polars dataframe.
         """
-        if self.is_empty:
+        if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pl.DataFrame())
         return self._set_reader_engine().to_dataframe()
 
@@ -75,7 +75,7 @@ class CSVReader(CSVProperties):
         Returns:
             A list of dictionaries.
         """
-        if self.is_empty:
+        if self.is_empty or self.is_blank:
             return self._return_empty_file_object(list())
         return self._set_reader_engine().to_dicts()
 
@@ -93,7 +93,7 @@ class CSVReader(CSVProperties):
             query = "SELECT col1, col2 FROM {dg.db_table}" # f string assumed
             dg.query_csv_data(query)
         """
-        if self.is_empty:
+        if self.is_empty or self.is_blank:
             return self._return_empty_file_object(list())
         queries = DuckDBQueries(self.filepath)
         duckdb.sql(queries.import_csv_query(self.delimiter))

--- a/tests/test_csv_properties_empty.py
+++ b/tests/test_csv_properties_empty.py
@@ -1,0 +1,103 @@
+import pytest
+import tempfile
+import os
+from src.datagrunt.csvfile import CSVReader
+
+@pytest.fixture
+def empty_csv_file():
+    """Creates a completely empty CSV file"""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as f:
+        path = f.name
+    yield path
+    os.unlink(path)
+
+@pytest.fixture
+def blank_csv_file():
+    """Creates a CSV file with only whitespace and newlines"""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as f:
+        f.write("\n\n   \n")
+        path = f.name
+    yield path
+    os.unlink(path)
+
+def test_empty_csv_reader_polars():
+    """Test CSVReader with empty file using Polars engine"""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as f:
+        path = f.name
+
+    try:
+        reader = CSVReader(path, engine='polars')
+
+        # Test properties
+        assert reader.is_empty is True
+        assert reader.is_blank is True
+
+        # Test conversions return empty objects
+        assert reader.to_dataframe().is_empty()
+        assert len(reader.to_dicts()) == 0
+        assert reader.to_arrow_table().num_rows == 0
+
+    finally:
+        os.unlink(path)
+
+def test_blank_csv_reader_polars():
+    """Test CSVReader with blank file using Polars engine"""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as f:
+        f.write("\n\n   \n")
+        path = f.name
+
+    try:
+        reader = CSVReader(path, engine='polars')
+
+        # Test properties
+        assert reader.is_empty is False
+        assert reader.is_blank is True
+
+        # Test conversions return empty objects
+        assert reader.to_dataframe().is_empty()
+        assert len(reader.to_dicts()) == 0
+        assert reader.to_arrow_table().num_rows == 0
+
+    finally:
+        os.unlink(path)
+
+def test_empty_csv_reader_duckdb():
+    """Test CSVReader with empty file using DuckDB engine"""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as f:
+        path = f.name
+
+    try:
+        reader = CSVReader(path, engine='duckdb')
+
+        # Test properties
+        assert reader.is_empty is True
+        assert reader.is_blank is True
+
+        # Test conversions return empty objects
+        assert reader.to_dataframe().is_empty()
+        assert len(reader.to_dicts()) == 0
+        assert reader.to_arrow_table().num_rows == 0
+
+    finally:
+        os.unlink(path)
+
+def test_blank_csv_reader_duckdb():
+    """Test CSVReader with blank file using DuckDB engine"""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as f:
+        f.write("\n\n   \n")
+        path = f.name
+
+    try:
+        reader = CSVReader(path, engine='duckdb')
+
+        # Test properties
+        assert reader.is_empty is False
+        assert reader.is_blank is True
+
+        # Test conversions return empty objects
+        assert reader.to_dataframe().is_empty()
+        assert len(reader.to_dicts()) == 0
+        assert reader.to_arrow_table().num_rows == 0
+
+    finally:
+        os.unlink(path)


### PR DESCRIPTION
Empty files were causing file attribute errors when certain attributes like `column` were invoked. This was caused because there was no attribute or checks in place for files that are blank vs empty. This commit corrects that error and all file attributes should now return with their values or with empty objects accordingly.