### PR TITLE
Refactor fileproperties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ dev/
 benchmarks.py
 ibm/
 dev.py
+dev.ipynb
 
 # Pycharm
 .idea/

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -4,57 +4,130 @@
 import os
 from pathlib import Path
 
+class BlankFile:
+    """Class for checking if a file is blank."""
+    def __init__(self, filepath):
+        self.filepath = filepath
+
+    @property
+    def is_blank(self):
+        """Check if the file is blank. Blank files contain only whitespace."""
+        with open(self.filepath, 'r') as f:
+            content = f.read().strip()
+            if not content:
+                return True
+        return False
+
+class EmptyFile:
+    """Class for checking if a file is empty."""
+    def __init__(self, filepath):
+        self.filepath = filepath
+
+    @property
+    def is_empty(self):
+        """Check if the file is empty."""
+        return FileStatistics(self.filepath).size_in_bytes == 0
+
+class FileStatistics:
+    """Class for getting file statistics."""
+
+    FILE_SIZE_DIVISOR = 1_000
+    EXCEL_ROW_LIMIT = 1_048_576
+
+    def __init__(self, filepath):
+        """Initialize the FileStatistics object."""
+        self.filepath = filepath
+        self.size_in_bytes = os.path.getsize(self.filepath)
+        self.size_in_kb = round((self.size_in_bytes / self.FILE_SIZE_DIVISOR), 5)
+        self.size_in_mb = round((self.size_in_kb / self.FILE_SIZE_DIVISOR), 5)
+        self.size_in_gb = round((self.size_in_mb / self.FILE_SIZE_DIVISOR), 5)
+        self.size_in_tb = round((self.size_in_gb / self.FILE_SIZE_DIVISOR), 5)
+
+    @property
+    def modified_time(self):
+        """Get the file modified time."""
+        return os.path.getmtime(self.filepath)
+
+    @property
+    def is_large(self):
+        """Check if the file is empty. Empty files have a size of 0 bytes."""
+        return self.size_in_gb >= 1.0
+
+class FileExtensions:
+    """Class for getting file extensions."""
+    def __init__(self, filepath):
+        self.filepath = filepath
+
+    @property
+    def extension(self):
+        """Get the file extensions."""
+        return Path(self.filepath).suffixes
+
+    @property
+    def csv_extensions(self):
+        """Get the file extension."""
+        return ['csv']
+
+    @property
+    def tsv_extensions(self):
+        """Get the file extension."""
+        return ['tsv']
+
+    @property
+    def excel_extensions(self):
+        """Get the file extension."""
+        return [
+            'xlsx',
+            'xlsm',
+            'xlsb',
+            'xltx',
+            'xltm',
+            'xls',
+            'xlt',
+            'xls'
+        ]
+
+    @property
+    def tabular_extensions(self):
+        """Get the file extension."""
+        return list(set(self.csv_extensions + self.tsv_extensions + self.excel_extensions))
+
+    @property
+    def apache_extensions(self):
+        """Get the file extension."""
+        return ['parquet', 'avro']
+
+    @property
+    def semi_structured_extensions(self):
+        """Get the file extension."""
+        return list(set(['json', 'jsonl']))
+
+    @property
+    def standard_extensions(self):
+        """Get all file extensions."""
+        return list(set(self.csv_extensions +
+                        self.tsv_extensions +
+                        self.apache_extensions +
+                        self.semi_structured_extensions))
+
+    @property
+    def structured_extensions(self):
+        """Get the file extension."""
+        return list(set(self.csv_extensions +
+                        self.tsv_extensions +
+                        self.excel_extensions +
+                        self.apache_extensions +
+                        self.tabular_extensions))
+
+    @property
+    def proprietary_extensions(self):
+        """Get all file extensions."""
+        return list(set(self.excel_extensions))
+
 class FileProperties:
     """Base class for file objects."""
 
-    FILE_SIZE_DIVISOR = 1000
     DEFAULT_ENCODING = 'utf-8'
-    EXCEL_FILE_EXTENSIONS = [
-        'xlsx',
-        'xlsm',
-        'xlsb',
-        'xltx',
-        'xltm',
-        'xls',
-        'xlt',
-        'xls'
-    ]
-
-    CSV_FILE_EXTENSIONS = ['csv']
-    TAB_SEPARATED_FILES = ['tsv']
-
-    TABULAR_FILES = list(set(CSV_FILE_EXTENSIONS +
-                             EXCEL_FILE_EXTENSIONS +
-                             TAB_SEPARATED_FILES
-                             )
-                        )
-    TABULAR_FILES.sort()
-
-    APACHE_FILE_EXTENSIONS = ['parquet', 'avro']
-
-    STRUCTURED_FILE_EXTENSIONS = list(set(CSV_FILE_EXTENSIONS +
-                                          EXCEL_FILE_EXTENSIONS +
-                                          TABULAR_FILES +
-                                          TAB_SEPARATED_FILES +
-                                          APACHE_FILE_EXTENSIONS
-                                          )
-                                    )
-    STRUCTURED_FILE_EXTENSIONS.sort()
-
-    SEMI_STRUCTURED_FILE_EXTENSIONS = ['json', 'jsonl']
-
-    STANDARD_FILE_EXTENSIONS = list(set(CSV_FILE_EXTENSIONS +
-                                        TAB_SEPARATED_FILES +
-                                        SEMI_STRUCTURED_FILE_EXTENSIONS +
-                                        APACHE_FILE_EXTENSIONS
-                                        )
-                                    )
-
-    STANDARD_FILE_EXTENSIONS.sort()
-
-    PROPRIETARY_FILE_EXTENSIONS = EXCEL_FILE_EXTENSIONS
-
-    EXCEL_ROW_LIMIT = 1_048_576
 
     def __init__(self, filepath):
         """
@@ -67,75 +140,70 @@ class FileProperties:
         self.filename = Path(filepath).name
         self.extension = Path(filepath).suffix
         self.extension_string = self.extension.replace('.', '')
-        self.size_in_bytes = os.path.getsize(filepath)
-        self.size_in_kb = round((self.size_in_bytes / self.FILE_SIZE_DIVISOR), 5)
-        self.size_in_mb = round((self.size_in_kb / self.FILE_SIZE_DIVISOR), 5)
-        self.size_in_gb = round((self.size_in_mb / self.FILE_SIZE_DIVISOR), 5)
-        self.size_in_tb = round((self.size_in_gb / self.FILE_SIZE_DIVISOR), 5)
+        self.size_in_bytes = FileStatistics(self.filepath).size_in_bytes
+        self.size_in_kb = FileStatistics(self.filepath).size_in_kb
+        self.size_in_mb = FileStatistics(self.filepath).size_in_mb
+        self.size_in_gb = FileStatistics(self.filepath).size_in_gb
+        self.size_in_tb = FileStatistics(self.filepath).size_in_tb
 
     @property
     def is_structured(self):
         """Check if the file is structured."""
-        return self.extension_string.lower() in self.STRUCTURED_FILE_EXTENSIONS
+        return self.extension_string.lower() in FileExtensions(self.filepath).structured_extensions
 
     @property
     def is_semi_structured(self):
         """Check if the file is semi-structured."""
-        return self.extension_string.lower() in self.SEMI_STRUCTURED_FILE_EXTENSIONS
+        return self.extension_string.lower() in FileExtensions(self.filepath).semi_structured_extensions
 
     @property
     def is_unstructured(self):
         """Check if the file is unstructured."""
-        return self.extension_string.lower() not in self.STRUCTURED_FILE_EXTENSIONS and \
-               self.extension_string.lower() not in self.SEMI_STRUCTURED_FILE_EXTENSIONS
+
+        return self.extension_string.lower() not in FileExtensions(self.filepath).standard_extensions and \
+               self.extension_string.lower() not in FileExtensions(self.filepath).semi_structured_extensions
 
     @property
     def is_standard(self):
         """Check if the file is standard."""
-        return self.extension_string.lower() in self.STANDARD_FILE_EXTENSIONS
+        return self.extension_string.lower() in FileExtensions(self.filepath).standard_extensions
 
     @property
     def is_proprietary(self):
         """Check if the file is proprietary."""
-        return self.extension_string.lower() in self.PROPRIETARY_FILE_EXTENSIONS
+        return self.extension_string.lower() in FileExtensions(self.filepath).proprietary_extensions
 
     @property
     def is_csv(self):
         """Check if the file is a CSV file."""
-        return self.extension_string.lower() in self.CSV_FILE_EXTENSIONS
+        return self.extension_string.lower() in FileExtensions(self.filepath).csv_extensions
 
     @property
     def is_excel(self):
         """Check if the file is an Excel file."""
-        return self.extension_string.lower() in self.EXCEL_FILE_EXTENSIONS
+        return self.extension_string.lower() in FileExtensions(self.filepath).excel_extensions
 
     @property
     def is_apache(self):
         """Check if the file is an Apache formatted file."""
-        return self.extension_string.lower() in self.APACHE_FILE_EXTENSIONS
+        return self.extension_string.lower() in FileExtensions(self.filepath).apache_extensions
 
     @property
     def is_empty(self):
         """Check if the file is empty. Empty files have a size of 0 bytes."""
-        return self.size_in_bytes == 0
+        return EmptyFile(self.filepath).is_empty
 
     @property
     def is_blank(self):
         """Check if the file is blank. Blank files contain only whitespace."""
-        # Read the file as text first
-        with open(self.filepath, 'r') as f:
-            # Remove whitespace, newlines, and other invisible characters
-            content = f.read().strip()
-            if not content:  # If file is completely empty
-                return True
-        return False
+        return BlankFile(self.filepath).is_blank
 
     @property
     def is_large(self):
         """Check if the file is greater than or equal to 1 GB."""
-        return self.size_in_gb >= 1.0
+        return FileStatistics(self.filepath).is_large
 
     @property
     def is_tabular(self):
         """Check if the file is tabular."""
-        return self.extension_string.lower() in self.TABULAR_FILES
+        return self.extension_string.lower() in FileExtensions(self.filepath).tabular_extensions

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -39,8 +39,7 @@ class FileExtensions:
             'xltx',
             'xltm',
             'xls',
-            'xlt',
-            'xls'
+            'xlt'
         ]
 
     @property

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -51,7 +51,7 @@ class FileStatistics:
 
     @property
     def is_large(self):
-        """Check if the file is empty. Empty files have a size of 0 bytes."""
+        """Check if the file is at least one gigabyte or larger."""
         return self.size_in_gb >= 1.0
 
 class FileExtensions:
@@ -66,17 +66,17 @@ class FileExtensions:
 
     @property
     def csv_extensions(self):
-        """Get the file extension."""
+        """Define CSV extensions."""
         return ['csv']
 
     @property
     def tsv_extensions(self):
-        """Get the file extension."""
+        """Define TSV extensions."""
         return ['tsv']
 
     @property
     def excel_extensions(self):
-        """Get the file extension."""
+        """Define Excel extensions."""
         return [
             'xlsx',
             'xlsm',
@@ -90,22 +90,22 @@ class FileExtensions:
 
     @property
     def tabular_extensions(self):
-        """Get the file extension."""
+        """Define tabular extensions."""
         return list(set(self.csv_extensions + self.tsv_extensions + self.excel_extensions))
 
     @property
     def apache_extensions(self):
-        """Get the file extension."""
+        """Define Apache extensions."""
         return ['parquet', 'avro']
 
     @property
     def semi_structured_extensions(self):
-        """Get the file extension."""
+        """Define semi-structured extensions."""
         return list(set(['json', 'jsonl']))
 
     @property
     def standard_extensions(self):
-        """Get all file extensions."""
+        """Define standard (non proprietary) extensions."""
         return list(set(self.csv_extensions +
                         self.tsv_extensions +
                         self.apache_extensions +
@@ -113,7 +113,7 @@ class FileExtensions:
 
     @property
     def structured_extensions(self):
-        """Get the file extension."""
+        """Define structured extensions."""
         return list(set(self.csv_extensions +
                         self.tsv_extensions +
                         self.excel_extensions +
@@ -122,7 +122,7 @@ class FileExtensions:
 
     @property
     def proprietary_extensions(self):
-        """Get all file extensions."""
+        """Define proprietary extensions."""
         return list(set(self.excel_extensions))
 
 class FileProperties:

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -4,59 +4,14 @@
 import os
 from pathlib import Path
 
-class BlankFile:
-    """Class for checking if a file is blank."""
-    def __init__(self, filepath):
-        self.filepath = filepath
-
-    @property
-    def is_blank(self):
-        """Check if the file is blank. Blank files contain only whitespace."""
-        with open(self.filepath, 'r') as f:
-            content = f.read().strip()
-            if not content:
-                return True
-        return False
-
-class EmptyFile:
-    """Class for checking if a file is empty."""
-    def __init__(self, filepath):
-        self.filepath = filepath
-
-    @property
-    def is_empty(self):
-        """Check if the file is empty."""
-        return FileStatistics(self.filepath).size_in_bytes == 0
-
-class FileStatistics:
-    """Class for getting file statistics."""
-
-    FILE_SIZE_DIVISOR = 1_000
-    EXCEL_ROW_LIMIT = 1_048_576
-    FILE_SIZE_ROUND_FACTOR = 5
-
-    def __init__(self, filepath):
-        """Initialize the FileStatistics object."""
-        self.filepath = filepath
-        self.size_in_bytes = os.path.getsize(self.filepath)
-        self.size_in_kb = round((self.size_in_bytes / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
-        self.size_in_mb = round((self.size_in_kb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
-        self.size_in_gb = round((self.size_in_mb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
-        self.size_in_tb = round((self.size_in_gb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
-
-    @property
-    def modified_time(self):
-        """Get the file modified time."""
-        return os.path.getmtime(self.filepath)
-
-    @property
-    def is_large(self):
-        """Check if the file is at least one gigabyte or larger."""
-        return self.size_in_gb >= 1.0
-
 class FileExtensions:
     """Class for getting file extensions."""
     def __init__(self, filepath):
+        """Initialize the FileExtensions object.
+
+        Args:
+            filepath (str): Path to the file.
+        """
         self.filepath = filepath
 
     @property
@@ -125,6 +80,70 @@ class FileExtensions:
         """Define proprietary extensions."""
         return list(set(self.excel_extensions))
 
+class FileStatistics:
+    """Class for getting file statistics."""
+
+    FILE_SIZE_DIVISOR = 1_000
+    EXCEL_ROW_LIMIT = 1_048_576
+    FILE_SIZE_ROUND_FACTOR = 5
+
+    def __init__(self, filepath):
+        """Initialize the FileStatistics object.
+
+        Args:
+            filepath (str): Path to the file.
+        """
+        self.filepath = filepath
+        self.size_in_bytes = os.path.getsize(self.filepath)
+        self.size_in_kb = round((self.size_in_bytes / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
+        self.size_in_mb = round((self.size_in_kb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
+        self.size_in_gb = round((self.size_in_mb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
+        self.size_in_tb = round((self.size_in_gb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
+
+    @property
+    def modified_time(self):
+        """Get the file modified time."""
+        return os.path.getmtime(self.filepath)
+
+    @property
+    def is_large(self):
+        """Check if the file is at least one gigabyte or larger."""
+        return self.size_in_gb >= 1.0
+
+class BlankFile:
+    """Class for checking if a file is blank."""
+    def __init__(self, filepath):
+        """Initialize the BlankFile object.
+
+        Args:
+            filepath (str): Path to the file.
+        """
+        self.filepath = filepath
+
+    @property
+    def is_blank(self):
+        """Check if the file is blank. Blank files contain only whitespace."""
+        with open(self.filepath, 'r') as f:
+            content = f.read().strip()
+            if not content:
+                return True
+        return False
+
+class EmptyFile:
+    """Class for checking if a file is empty."""
+    def __init__(self, filepath):
+        """Initialize the EmptyFile object.
+
+        Args:
+            filepath (str): Path to the file.
+        """
+        self.filepath = filepath
+
+    @property
+    def is_empty(self):
+        """Check if the file is empty."""
+        return FileStatistics(self.filepath).size_in_bytes == 0
+
 class FileProperties:
     """Base class for file objects."""
 
@@ -160,7 +179,6 @@ class FileProperties:
     @property
     def is_unstructured(self):
         """Check if the file is unstructured."""
-
         return self.extension_string.lower() not in FileExtensions(self.filepath).standard_extensions and \
                self.extension_string.lower() not in FileExtensions(self.filepath).semi_structured_extensions
 

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -33,15 +33,16 @@ class FileStatistics:
 
     FILE_SIZE_DIVISOR = 1_000
     EXCEL_ROW_LIMIT = 1_048_576
+    FILE_SIZE_ROUND_FACTOR = 5
 
     def __init__(self, filepath):
         """Initialize the FileStatistics object."""
         self.filepath = filepath
         self.size_in_bytes = os.path.getsize(self.filepath)
-        self.size_in_kb = round((self.size_in_bytes / self.FILE_SIZE_DIVISOR), 5)
-        self.size_in_mb = round((self.size_in_kb / self.FILE_SIZE_DIVISOR), 5)
-        self.size_in_gb = round((self.size_in_mb / self.FILE_SIZE_DIVISOR), 5)
-        self.size_in_tb = round((self.size_in_gb / self.FILE_SIZE_DIVISOR), 5)
+        self.size_in_kb = round((self.size_in_bytes / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
+        self.size_in_mb = round((self.size_in_kb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
+        self.size_in_gb = round((self.size_in_mb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
+        self.size_in_tb = round((self.size_in_gb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
 
     @property
     def modified_time(self):

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -86,6 +86,7 @@ class FileStatistics:
     FILE_SIZE_DIVISOR = 1_000
     EXCEL_ROW_LIMIT = 1_048_576
     FILE_SIZE_ROUND_FACTOR = 5
+    LARGE_FILE_FACTOR = 1.0 # size in GB
 
     def __init__(self, filepath):
         """Initialize the FileStatistics object.
@@ -108,7 +109,7 @@ class FileStatistics:
     @property
     def is_large(self):
         """Check if the file is at least one gigabyte or larger."""
-        return self.size_in_gb >= 1.0
+        return self.size_in_gb >= self.LARGE_FILE_FACTOR
 
 class BlankFile:
     """Class for checking if a file is blank."""

--- a/src/datagrunt/core/queries.py
+++ b/src/datagrunt/core/queries.py
@@ -154,7 +154,9 @@ class DuckDBQueries:
         consistent naming conventions across different processing engines.
         """
         duckdb.sql(self.import_csv_query())
-        for old_name, new_name in zip(CSVColumns(self.filepath).columns, CSVColumnNameNormalizer(self.filepath).columns_normalized):
+        for old_name, new_name in zip(CSVColumns(self.filepath).columns,
+                                      CSVColumnNameNormalizer(self.filepath).columns_normalized
+                                      ):
             sql_string = f"ALTER TABLE {self.database_table_name} RENAME COLUMN '{old_name}' TO '{new_name}'"
             duckdb.sql(sql_string)
 


### PR DESCRIPTION
Refactor the `fileproperties` module into separate, single responsibility classes. Also cleaned up some docstrings or added missing docstrings, and wrapped code to conform a line length of 120 columns or less.