### PR TITLE
updated imports for local unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from src.datagrunt.core import CSVEngineFactory
+from datagrunt.core import CSVEngineFactory
 
 @pytest.fixture
 def sample_csv(tmp_path):

--- a/tests/core_tests/test_csvcomponents.py
+++ b/tests/core_tests/test_csvcomponents.py
@@ -1,4 +1,4 @@
-from src.datagrunt.core import (
+from datagrunt.core import (
     CSVDelimiter,
     CSVDialect,
     CSVRows,

--- a/tests/core_tests/test_engines.py
+++ b/tests/core_tests/test_engines.py
@@ -5,7 +5,7 @@ import polars as pl
 import pyarrow as pa
 import pytest
 
-from src.datagrunt.core.engines import (
+from datagrunt.core.engines import (
     CSVReaderDuckDBEngine,
     CSVReaderPolarsEngine,
     CSVWriterDuckDBEngine,

--- a/tests/csvfiles_tests/test_csvreader.py
+++ b/tests/csvfiles_tests/test_csvreader.py
@@ -2,7 +2,7 @@ import polars as pl
 import pyarrow as pa
 from duckdb import DuckDBPyRelation
 
-from src.datagrunt import CSVReader
+from datagrunt import CSVReader
 
 class TestCSVReader:
     """Test suite for CSVReader class."""

--- a/tests/csvfiles_tests/test_csvwriter.py
+++ b/tests/csvfiles_tests/test_csvwriter.py
@@ -3,7 +3,7 @@ import polars as pl
 import pyarrow.parquet as pq
 from pathlib import Path
 
-from src.datagrunt import CSVWriter
+from datagrunt import CSVWriter
 
 class TestCSVWriter:
 


### PR DESCRIPTION
Updated pathing so that locally we can run `pip install -e .` from the project directory and then run unit tests and functional tests.