### PR TITLE
27 slow instantiation of csvreader and csvwriter with large csv files

### DIFF
--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -114,6 +114,9 @@ class FileStatistics:
 
 class BlankFile:
     """Class for checking if a file is blank."""
+
+    FILE_SIZE_MB_FACTOR = 10
+
     def __init__(self, filepath):
         """Initialize the BlankFile object.
 
@@ -128,8 +131,8 @@ class BlankFile:
 
         filestats = FileStatistics(self.filepath)
 
-        # Very low probability of being blank if file is 1GB or larger in size
-        if filestats.size_in_gb >= filestats.LARGE_FILE_FACTOR:
+        # Very low probability of being blank if file is 10MB or larger in size
+        if filestats.size_in_mb >= self.FILE_SIZE_MB_FACTOR:
             return False
         with open(self.filepath, 'r') as f:
             content = f.read().strip()

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -1,5 +1,7 @@
+from dill.tests.test_recursive import fib
 """Module for deriving and evaluating file properties."""
 
+from importlib.metadata import files
 # standard library
 import os
 from pathlib import Path
@@ -123,6 +125,11 @@ class BlankFile:
     @property
     def is_blank(self):
         """Check if the file is blank. Blank files contain only whitespace."""
+        filestats = FileStatistics(self.filepath)
+
+        # Very low probability of being blank if file is 1GB or larger in size
+        if filestats.size_in_gb >= filestats.LARGE_FILE_FACTOR:
+            return False
         with open(self.filepath, 'r') as f:
             content = f.read().strip()
             if not content:

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -113,7 +113,7 @@ class FileStatistics:
 class BlankFile:
     """Class for checking if a file is blank."""
 
-    FILE_SIZE_MB_FACTOR = 10
+    FILE_SIZE_MB_FACTOR = 10.0
 
     def __init__(self, filepath):
         """Initialize the BlankFile object.

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -1,7 +1,5 @@
-from dill.tests.test_recursive import fib
 """Module for deriving and evaluating file properties."""
 
-from importlib.metadata import files
 # standard library
 import os
 from pathlib import Path

--- a/src/datagrunt/core/fileproperties.py
+++ b/src/datagrunt/core/fileproperties.py
@@ -125,6 +125,7 @@ class BlankFile:
     @property
     def is_blank(self):
         """Check if the file is blank. Blank files contain only whitespace."""
+
         filestats = FileStatistics(self.filepath)
 
         # Very low probability of being blank if file is 1GB or larger in size


### PR DESCRIPTION
## Brief History and Explanation

I found that the issue with slow instantiation was rooted in the `BlankFile` class with the `is_blank` method. For every file, regardless of size, Datagrunt was parsing the entire file during object instantiation just to produce the class property `is_blank`.  

The `is_blank` method checks the file to see if only invisible characters exist. During testing when originally creating Datagrunt, we found that simply checking for empty files (files with a size of 0 bytes) wasn't sufficient. We had instances where files were not empty and were failing to parse. Upon further discovery, we found a couple of the test files we created for use during the development process had accidentally been saved with invisible characters. As a result, file parsing failed b/c it wasn't blank, but the CSV parser didn't know how to process the data b/c all of the characters were invisible and not structured. Given that this scenario is possible "in the wild", we added a blank file check to avoid parsing errors if this scenario arises.

## The Fix

The fix for slow instantiation was to add a check for the file size in the `BlankFile` class. If a file size is 10mb or larger, it's just about statistically impossible that the file will be blank unless someone intentionally generated a blank file of that size (and even then the likelihood of that happening is astronomically small).

The fix was simple: add a class constant for the size in mb for the file check to avoid hard coding integer values in class methods, create an instance of the `FileStatistics` class, and add a simple `if` statement. After making this change, a local file that's more than 8GB in size with over 62 million rows was instantly instantiating whereas before the fix it was taking up to 1 minute or longer to instantiate on a local Mac Mini M4.