### PR TITLE
Fix column normalizer

### DIFF
--- a/src/datagrunt/core/queries.py
+++ b/src/datagrunt/core/queries.py
@@ -157,7 +157,7 @@ class DuckDBQueries:
         for old_name, new_name in zip(CSVColumns(self.filepath).columns,
                                       CSVColumnNameNormalizer(self.filepath).columns_normalized
                                       ):
-            sql_string = f"ALTER TABLE {self.database_table_name} RENAME COLUMN '{old_name}' TO '{new_name}'"
+            sql_string = f'ALTER TABLE {self.database_table_name} RENAME COLUMN "{old_name}" TO "{new_name}"'
             duckdb.sql(sql_string)
 
     def create_table(self, normalize_columns=False):

--- a/tests/core_tests/test_engines.py
+++ b/tests/core_tests/test_engines.py
@@ -13,7 +13,7 @@ from datagrunt.core.engines import (
     EngineProperties
 )
 
-from src.datagrunt.core.factories import CSVEngineFactory
+from datagrunt.core.factories import CSVEngineFactory
 
 class TestEngines:
     def test_engine_properties(self):

--- a/tests/core_tests/test_fileproperties.py
+++ b/tests/core_tests/test_fileproperties.py
@@ -1,5 +1,5 @@
 import pytest
-from src.datagrunt.core import FileProperties
+from datagrunt.core import FileProperties
 
 class TestFileProperties:
     """Test suite for FileProperties"""


### PR DESCRIPTION
There was a but in this string syntax that caused intermittent failures. That has been corrected. Also, a couple of the unit test files had broken imports. Those have also been corrected.