### PR TITLE
update string filepaths with pathlib [patch]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Datagrunt is not an extension of or a replacement for DuckDB, Polars, or PyArrow
 ## Key Features
 
 - **Intelligent Delimiter Inference:** Datagrunt automatically detects and applies the correct delimiter for your CSV files.
+- **Path Object Support:** Full support for both string paths and `pathlib.Path` objects for modern, cross-platform file handling.
 - **Multiple Processing Engines:** Choose from three powerful engines - [DuckDB](https://duckdb.org), [Polars](https://pola.rs), and [PyArrow](https://arrow.apache.org/docs/python/) - to handle your data processing needs.
 - **Flexible Data Transformation:** Easily convert your processed CSV data into various formats including CSV, Excel, JSON, JSONL, and Parquet.
 - **AI-Powered Schema Analysis:** Use Google's Gemini models to automatically generate detailed schema reports for your CSV files, including data types, column classifications, and data quality checks.
@@ -47,13 +48,16 @@ pip install datagrunt
 
 ```python
 from datagrunt import CSVReader
+from pathlib import Path
 
 # Load your CSV file with different engines
+# Accepts both string paths and Path objects
 csv_file = 'electric_vehicle_population_data.csv'
+csv_path = Path('electric_vehicle_population_data.csv')
 
 # Choose your engine: 'polars' (default), 'duckdb', or 'pyarrow'
-reader_polars = CSVReader(csv_file, engine='polars')    # Default - fast DataFrame ops
-reader_duckdb = CSVReader(csv_file, engine='duckdb')    # Best for SQL queries
+reader_polars = CSVReader(csv_file, engine='polars')    # String path - fast DataFrame ops
+reader_duckdb = CSVReader(csv_path, engine='duckdb')    # Path object - best for SQL queries
 reader_pyarrow = CSVReader(csv_file, engine='pyarrow')  # Arrow ecosystem integration
 
 # Get a sample of the data
@@ -93,9 +97,11 @@ print(df)
 
 ```python
 from datagrunt import CSVWriter
+from pathlib import Path
 
-# Create writer with your preferred engine
-writer = CSVWriter('input.csv', engine='duckdb')  # Default for exports
+# Create writer with your preferred engine (accepts both strings and Path objects)
+input_file = Path('input.csv')
+writer = CSVWriter(input_file, engine='duckdb')  # Default for exports
 
 # Export to various formats
 writer.write_csv('output.csv')          # Clean CSV export
@@ -104,7 +110,7 @@ writer.write_json('output.json')        # JSON format
 writer.write_parquet('output.parquet')  # Parquet for analytics
 
 # Use PyArrow engine for optimized Parquet exports
-writer_arrow = CSVWriter('input.csv', engine='pyarrow')
+writer_arrow = CSVWriter('input.csv', engine='pyarrow')  # String path also works
 writer_arrow.write_parquet('optimized.parquet')  # Native Arrow Parquet
 ```
 
@@ -112,13 +118,15 @@ writer_arrow.write_parquet('optimized.parquet')  # Native Arrow Parquet
 
 ```python
 from datagrunt import CSVSchemaReportAIGenerated
+from pathlib import Path
 import os
 
-# Generate detailed schema reports with AI
+# Generate detailed schema reports with AI (accepts both strings and Path objects)
 api_key = os.environ.get("GEMINI_API_KEY")
+data_file = Path('your_data.csv')
 
 schema_analyzer = CSVSchemaReportAIGenerated(
-    filepath='your_data.csv',
+    filepath=data_file,  # Path object works seamlessly
     engine='google',
     api_key=api_key
 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ simplicity and ease of use. We will extend functionality where it makes sense to
 ### Key Features
 
 - **Intelligent Delimiter Inference:** Datagrunt automatically detects and applies the correct delimiter for your CSV files.
+- **Path Object Support:** Full support for both string paths and `pathlib.Path` objects for modern, cross-platform file handling.
 - **Multiple Processing Engines:** Choose from three powerful engines - [DuckDB](https://duckdb.org), [Polars](https://pola.rs), and [PyArrow](https://arrow.apache.org/docs/python/) - to handle your data processing needs.
 - **Flexible Data Transformation:** Easily convert your processed CSV data into various formats including CSV, Excel, JSON, JSONL, and Parquet.
 - **AI-Powered Schema Analysis:** Use Google's Gemini models to automatically generate detailed schema reports for your CSV files, including data types, column classifications, and data quality checks.
@@ -86,11 +87,58 @@ pip install datagrunt
 # Getting Started with Datagrunt
 This section provides a comprehensive guide to using Datagrunt effectively. Here's what you'll learn:
 
+- **[Path Object Support](#path-object-support)** - Modern file path handling with pathlib
 - **[Datagrunt Engines](#datagrunt-engines)** - Choose the right engine for your needs
 - **[Column Name Normalization](#normalizing-column-names)** - Clean and standardize column names
 - **[AI-Powered Analysis](#artificial-intelligence-features)** - Generate schema reports with AI
 - **[Usage Examples](#usage-examples)** - Practical code examples
 - **[Primary Classes](#primary-classes)** - Detailed API reference
+
+## Path Object Support
+
+Datagrunt fully supports both string paths and `pathlib.Path` objects, providing modern, cross-platform file handling capabilities. All classes (`CSVReader`, `CSVWriter`, `CSVSchemaReportAIGenerated`) seamlessly accept either input type.
+
+### Benefits of Path Objects
+- **Cross-platform compatibility**: Automatic handling of path separators (`/` vs `\`)
+- **Better readability**: Intuitive path operations like `path.stem`, `path.suffix`
+- **Type safety**: Clear distinction between strings and paths
+- **Modern Python standards**: Following current best practices
+
+### Usage Examples
+
+```python
+from datagrunt import CSVReader, CSVWriter
+from pathlib import Path
+
+# All of these work identically
+csv_reader_str = CSVReader('data/file.csv')                    # String path
+csv_reader_path = CSVReader(Path('data/file.csv'))             # Path object
+csv_reader_resolved = CSVReader(Path('data').resolve() / 'file.csv')  # Complex Path
+
+# Writers work the same way
+csv_writer = CSVWriter(Path('output/results.csv'))
+
+# Mixing is fine too
+input_path = Path('input.csv')
+reader = CSVReader(input_path)
+writer = CSVWriter('output.csv')  # String path
+```
+
+### Internal Conversion
+When you pass a string path to any Datagrunt class, it's automatically converted to a `Path` object internally:
+
+```python
+from datagrunt import CSVReader
+from pathlib import Path
+
+reader = CSVReader('my_file.csv')  # String input
+print(type(reader.filepath))       # <class 'pathlib.PosixPath'> (or WindowsPath)
+print(reader.filepath.name)        # 'my_file.csv'
+print(reader.filepath.suffix)      # '.csv'
+```
+
+### Backward Compatibility
+✅ **Fully backward compatible** - all existing string-based code continues to work unchanged while gaining the benefits of Path objects under the hood.
 
 ## Datagrunt Engines
 
@@ -179,9 +227,10 @@ Currently there is only one class that supports integration with Google Gemini: 
 ### Reading and Querying CSV Data
 ```python
 from datagrunt import CSVReader
+from pathlib import Path
 
-# Load your CSV file
-csv_file = 'examples/data/electric_vehicle_population_data.csv'
+# Load your CSV file (accepts both string and Path objects)
+csv_file = Path('examples/data/electric_vehicle_population_data.csv')
 
 # Choose your engine: 'polars' (default), 'duckdb', or 'pyarrow'
 reader = CSVReader(csv_file, engine='duckdb')
@@ -262,10 +311,11 @@ print(df)
 ### Generating an AI-Powered Schema Report
 ```python
 from datagrunt import CSVSchemaReportAIGenerated
+from pathlib import Path
 import os
 
-# Load your CSV file
-csv_file = 'examples/data/electric_vehicle_population_data.csv'
+# Load your CSV file (accepts both string and Path objects)
+csv_file = Path('examples/data/electric_vehicle_population_data.csv')
 
 # --- Option 1: Use a Google Gemini API Key ---
 # Make sure to set your API Key as an environment variable
@@ -460,9 +510,10 @@ This will produce a detailed JSON report analyzing the CSV's schema, data types,
 ### Using the PyArrow Engine
 ```python
 from datagrunt import CSVReader, CSVWriter
+from pathlib import Path
 
-# Reading with PyArrow engine
-reader = CSVReader('path/to/file.csv', engine='pyarrow')
+# Reading with PyArrow engine (accepts both strings and Path objects)
+reader = CSVReader(Path('path/to/file.csv'), engine='pyarrow')
 
 # Get data as PyArrow table (native format)
 arrow_table = reader.to_arrow_table(normalize_columns=True)
@@ -472,7 +523,7 @@ polars_df = reader.to_dataframe()  # Returns Polars DataFrame
 dict_list = reader.to_dicts()      # Returns list of dictionaries
 
 # Writing with PyArrow engine
-writer = CSVWriter('path/to/file.csv', engine='pyarrow')
+writer = CSVWriter(Path('path/to/file.csv'), engine='pyarrow')
 
 # Export to various formats with PyArrow's optimized writers
 writer.write_parquet('output.parquet')  # Efficient native Parquet export
@@ -486,9 +537,10 @@ Datagrunt can be combined with other libraries. For example, you could use Datag
 
 ```python
 from datagrunt import CSVReader
+from pathlib import Path
 import pandas as pd
 
-reader = CSVReader('path/to/file.csv')
+reader = CSVReader(Path('path/to/file.csv'))
 df = pd.read_csv(reader.filepath, sep=reader.delimiter)  # filepath and delimiter are CSVReader attributes
 ```
 
@@ -497,9 +549,10 @@ df = pd.read_csv(reader.filepath, sep=reader.delimiter)  # filepath and delimite
 Sometimes, the delimiter may not be correctly identified by Datagrunt. In such cases, you can reassign the delimiter attribute to correct it.
 ```python
 from datagrunt import CSVReader
+from pathlib import Path
 import pandas as pd
 
-reader = CSVReader('path/to/file.csv')
+reader = CSVReader(Path('path/to/file.csv'))
 
 # Let's assume the delimiter was incorrectly inferred as a space. Reassign it to correct the issue.
 reader.delimiter = ','
@@ -512,17 +565,20 @@ By updating the delimiter attribute, you ensure the `CSVReader` object will read
 Datagrunt provides three primary classes for interacting with data: `CSVReader`, `CSVWriter`, and `CSVSchemaReportAIGenerated`. These classes are designed to simplify the process of reading, writing, and analyzing CSV files.
 
 ### CSVReader
-The `CSVReader` class is used to read data from a CSV file. It provides a simple interface for reading data from a CSV file and converting it into various formats. You instantiate the `CSVReader` class as follows:
+The `CSVReader` class is used to read data from a CSV file. It accepts both string paths and `pathlib.Path` objects, providing a simple interface for reading data from a CSV file and converting it into various formats. You instantiate the `CSVReader` class as follows:
 ```python
 from datagrunt import CSVReader
-reader = CSVReader('path/to/file.csv')
+from pathlib import Path
+
+reader = CSVReader('path/to/file.csv')          # String path
+reader = CSVReader(Path('path/to/file.csv'))    # Path object
 ```
 
 You may optionally specify the engine to use for reading the CSV file. The three options are `polars` (default), `duckdb`, and `pyarrow`.
 ```python
-reader = CSVReader('path/to/file.csv', engine='duckdb')   # DuckDB engine
-reader = CSVReader('path/to/file.csv', engine='pyarrow')  # PyArrow engine
-reader = CSVReader('path/to/file.csv')                    # Default: Polars engine
+reader = CSVReader(Path('path/to/file.csv'), engine='duckdb')   # DuckDB engine
+reader = CSVReader('path/to/file.csv', engine='pyarrow')        # PyArrow engine
+reader = CSVReader(Path('path/to/file.csv'))                    # Default: Polars engine
 ```
 
 The primary methods of the `CSVReader` class are:
@@ -533,13 +589,15 @@ The primary methods of the `CSVReader` class are:
 - `query_data(sql_query, normalize_columns=False)`: Executes a SQL query on the data in the CSV file.
 
 ### CSVWriter
-The `CSVWriter` class is used to convert and export CSV data to various file formats. It supports three engines: `duckdb` (default), `polars`, and `pyarrow`.
+The `CSVWriter` class is used to convert and export CSV data to various file formats. It accepts both string paths and `pathlib.Path` objects and supports three engines: `duckdb` (default), `polars`, and `pyarrow`.
 
 ```python
 from datagrunt import CSVWriter
-writer = CSVWriter('path/to/file.csv', engine='duckdb')   # Default: DuckDB engine
-writer = CSVWriter('path/to/file.csv', engine='polars')   # Polars engine
-writer = CSVWriter('path/to/file.csv', engine='pyarrow')  # PyArrow engine
+from pathlib import Path
+
+writer = CSVWriter(Path('path/to/file.csv'), engine='duckdb')   # Default: DuckDB engine
+writer = CSVWriter('path/to/file.csv', engine='polars')        # Polars engine
+writer = CSVWriter(Path('path/to/file.csv'), engine='pyarrow') # PyArrow engine
 ```
 
 The primary methods of the `CSVWriter` class are:
@@ -696,11 +754,45 @@ The current implementation leveraging an LLM to evaluate a CSV file is a simple 
 
 AI Agents may be added in the future, but this is currently being debated among the maintainers of Datagrunt. We will post more details on this decision in the future.
 
+## Migration Guide
+
+### Path Object Changes (Version 2.1.1+)
+
+As of version 2.1.0, Datagrunt uses `pathlib.Path` objects internally for all file operations, providing better cross-platform compatibility and more intuitive path handling.
+
+#### What Changed
+- All filepath parameters now accept both string paths and `pathlib.Path` objects
+- Internally, string paths are automatically converted to `Path` objects
+- The `filepath` attribute on all classes now returns a `Path` object instead of a string
+
+#### Backward Compatibility
+✅ **No breaking changes** - all existing code continues to work:
+
+```python
+# This still works exactly the same
+reader = CSVReader('my_file.csv')
+writer = CSVWriter('output.csv')
+```
+
+#### What You Might Notice
+If you access the `filepath` attribute directly, it now returns a `Path` object:
+
+```python
+reader = CSVReader('my_file.csv')
+print(type(reader.filepath))  # <class 'pathlib.PosixPath'> (was <class 'str'>)
+print(reader.filepath.name)   # 'my_file.csv' - now available directly
+```
+
+#### Benefits
+- Better cross-platform path handling
+- More intuitive path operations (`path.name`, `path.suffix`, etc.)
+- No changes required to existing code
+
 ## File and CSV Attributes
 Exposed in both the `CSVReader` and `CSVWriter` classes are a number of attributes that allow you to access and manipulate file and CSV-specific information:
 
 **File Attributes:**
-- `filepath`: The absolute path to the file.
+- `filepath`: The `pathlib.Path` object representing the file path.
 - `filename`: The name of the file.
 - `extension`: The file extension (e.g., `.csv`).
 - `size_in_bytes`, `size_in_kb`, `size_in_mb`, `size_in_gb`, `size_in_tb`: File size in various units.

--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -5,6 +5,7 @@ import csv
 import re
 from collections import Counter, OrderedDict
 from functools import cached_property
+from pathlib import Path
 
 # third party libraries
 import polars as pl
@@ -23,9 +24,9 @@ class CSVStringSample:
         """Initialize the CSVString object.
 
         Args:
-            filepath (str): The path to the CSV file.
+            filepath (str or Path): The path to the CSV file.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
 
     @cached_property
     def csv_string_sample(self):
@@ -66,12 +67,13 @@ class CSVDelimiter:
     DEFAULT_TAB_DELIMITER = "\t"
 
     def __init__(self, filepath):
-        super().__init__()
         """Initialize the CSVDelimiter class.
 
         Args:
-            filepath (str): The path to the CSV file.
+            filepath (str or Path): The path to the CSV file.
         """
+        super().__init__()
+        filepath = Path(filepath)
         self.file_properties = FileProperties(filepath)
         self.first_row = CSVRows(filepath).first_row
         self.delimiter = self.infer_csv_file_delimiter()
@@ -119,9 +121,9 @@ class CSVDialect:
         """Initialize the CSVDialect object.
 
         Args:
-            filepath (str): The path to the CSV file.
+            filepath (str or Path): The path to the CSV file.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
         self.dialect = self._get_csv_dialect()
 
     def _get_csv_dialect(self):
@@ -341,8 +343,9 @@ class CSVComponents(FileProperties):
         """Initialize the CSVComponents object.
 
         Args:
-            filepath (str): Path to the CSV file.
+            filepath (str or Path): Path to the CSV file.
         """
+        filepath = Path(filepath)
         super().__init__(filepath)
         self._delimiter = CSVDelimiter(filepath)
         self._dialect = CSVDialect(filepath)

--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -181,9 +181,9 @@ class CSVRows:
         """Initialize the CSVRows object.
 
         Args:
-            filepath: The path to the CSV file.
+            filepath (str or Path): The path to the CSV file.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
         self.first_row = self._get_first_row_from_file()
 
     def _get_first_row_from_file(self):
@@ -213,8 +213,12 @@ class CSVColumns:
     """Class for parsing CSV columns."""
 
     def __init__(self, filepath):
-        """Initialize the CSVColumns class."""
-        self.filepath = filepath
+        """Initialize the CSVColumns class.
+
+        Args:
+            filepath (str or Path): The path to the CSV file.
+        """
+        self.filepath = Path(filepath)
         self.columns = self._get_columns()
 
     def _get_columns(self):
@@ -253,9 +257,13 @@ class CSVColumnNameNormalizer:
     MULTI_UNDERSCORE_PATTERN = re.compile(r"_+")
 
     def __init__(self, filepath):
-        """Initialize the CSVColumnNameNormalizer with a filepath."""
-        self.filepath = filepath
-        self.columns_normalized = self._normalize_column_names(CSVColumns(filepath).columns)
+        """Initialize the CSVColumnNameNormalizer with a filepath.
+
+        Args:
+            filepath (str or Path): The path to the CSV file.
+        """
+        self.filepath = Path(filepath)
+        self.columns_normalized = self._normalize_column_names(CSVColumns(self.filepath).columns)
 
     def _normalize_single_column_name(self, column_name):
         """
@@ -345,14 +353,14 @@ class CSVComponents(FileProperties):
         Args:
             filepath (str or Path): Path to the CSV file.
         """
-        filepath = Path(filepath)
-        super().__init__(filepath)
-        self._delimiter = CSVDelimiter(filepath)
-        self._dialect = CSVDialect(filepath)
-        self._rows = CSVRows(filepath)
-        self._columns = CSVColumns(filepath)
-        self._normalizer = CSVColumnNameNormalizer(filepath)
-        self._sample = CSVStringSample(filepath)
+        super().__init__(filepath)  # Parent class handles Path conversion
+        # Use self.filepath (now a Path object) for all component instantiation
+        self._delimiter = CSVDelimiter(self.filepath)
+        self._dialect = CSVDialect(self.filepath)
+        self._rows = CSVRows(self.filepath)
+        self._columns = CSVColumns(self.filepath)
+        self._normalizer = CSVColumnNameNormalizer(self.filepath)
+        self._sample = CSVStringSample(self.filepath)
         self.delimiter = self._delimiter.delimiter
 
     @cached_property

--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -72,7 +72,6 @@ class CSVDelimiter:
         Args:
             filepath (str or Path): The path to the CSV file.
         """
-        super().__init__()
         filepath = Path(filepath)
         self.file_properties = FileProperties(filepath)
         self.first_row = CSVRows(filepath).first_row

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -2,9 +2,9 @@
 
 # standard library
 import json
-import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List, Union
 
 # third party libraries
@@ -24,7 +24,7 @@ from datagrunt.core.databases import DuckDBQueries
 class CSVEngineProperties:
     """Base properties for CSV operations."""
 
-    filepath: str
+    filepath: Path
     dataframe_sample_rows: int = 20
     csv_export_filename: str = "output.csv"
     excel_export_filename: str = "output.xlsx"
@@ -46,13 +46,13 @@ class CSVBaseReaderEngine(ABC):
         """Initialize the CSVReader class.
 
         Args:
-            filepath (str): Path to the file to read.
+            filepath (str or Path): Path to the file to read.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
         self.queries = DuckDBQueries(self.filepath)
         self.db_table = DuckDBQueries(self.filepath).database_table_name
         self.delimiter = CSVDelimiter(self.filepath).delimiter
-        if not os.path.exists(self.filepath):
+        if not self.filepath.exists():
             raise FileNotFoundError
 
     @abstractmethod
@@ -114,12 +114,12 @@ class CSVBaseWriterEngine(ABC):
         Initialize the CSV Writer DuckDB Engine class.
 
         Args:
-            filepath (str): Path to the file to write.
+            filepath (str or Path): Path to the file to write.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
         self.queries = DuckDBQueries(self.filepath)
         self.db_table = DuckDBQueries(self.filepath).database_table_name
-        if not os.path.exists(self.filepath):
+        if not self.filepath.exists():
             raise FileNotFoundError
 
     @abstractmethod

--- a/src/datagrunt/core/csv_io/factories.py
+++ b/src/datagrunt/core/csv_io/factories.py
@@ -1,7 +1,7 @@
 """Factory module for creating CSV factory instances."""
 
 # standard library
-import os
+from pathlib import Path
 
 # third party libraries
 # local libraries
@@ -37,13 +37,13 @@ class CSVEngineFactory:
         Initialize the Engine Factory class.
 
         Args:
-            filepath (str): Path to the file to read.
+            filepath (str or Path): Path to the file to read.
             engine (str): type of engine to create by the factory.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
         self.engine = engine.lower().replace(" ", "")
         self.db_table = DuckDBQueries(self.filepath).database_table_name
-        if not os.path.exists(self.filepath):
+        if not self.filepath.exists():
             raise FileNotFoundError
         if self.engine not in CSVEngineProperties.valid_engines:
             raise ValueError(CSVEngineProperties.value_error_message.format(engine=self.engine))

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -1,7 +1,6 @@
 """Module for interfacing with databases."""
 
 # standard library
-import os
 import re
 from pathlib import Path
 
@@ -25,9 +24,9 @@ class DuckDBDatabase:
         Initialize the FileDatabase class.
 
         Args:
-            filepath (str): Path to the file.
+            filepath (str or Path): Path to the file.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
         self.database_filename = self._set_database_filename()
         self.database_table_name = self._set_database_table_name()
         self.database_connection = self._set_database_connection()
@@ -37,12 +36,12 @@ class DuckDBDatabase:
         Close the database connection and delete .db files after use.
         """
         self.database_connection.close()
-        if os.path.exists(self.database_filename):
-            os.remove(self.database_filename)
+        if Path(self.database_filename).exists():
+            Path(self.database_filename).unlink()
 
     def _format_filename_string(self):
         """Remove all non alphanumeric characters from filename."""
-        return re.sub(r"[^a-zA-Z0-9]", "", Path(self.filepath).stem)
+        return re.sub(r"[^a-zA-Z0-9]", "", self.filepath.stem)
 
     def _set_database_filename(self):
         """Return name of duckdb file created at runtime."""
@@ -71,9 +70,9 @@ class DuckDBQueries:
         Initialize the DuckDBQueries class.
 
         Args:
-            filepath (str): Path to the file.
+            filepath (str or Path): Path to the file.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
         self.delimiter = CSVDelimiter(filepath).delimiter
         self.database_table_name = DuckDBDatabase(filepath).database_table_name
 

--- a/src/datagrunt/core/file_io/fileproperties.py
+++ b/src/datagrunt/core/file_io/fileproperties.py
@@ -1,7 +1,6 @@
 """Module for deriving and evaluating file properties."""
 
 # standard library
-import os
 from functools import cached_property
 from pathlib import Path
 
@@ -13,9 +12,9 @@ class FileExtensions:
         """Initialize the FileExtensions object.
 
         Args:
-            filepath (str): Path to the file.
+            filepath (str or Path): Path to the file.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
 
     @cached_property
     def extension(self):
@@ -90,10 +89,10 @@ class FileStatistics:
         """Initialize the FileStatistics object.
 
         Args:
-            filepath (str): Path to the file.
+            filepath (str or Path): Path to the file.
         """
-        self.filepath = filepath
-        self.size_in_bytes = os.path.getsize(self.filepath)
+        self.filepath = Path(filepath)
+        self.size_in_bytes = self.filepath.stat().st_size
         self.size_in_kb = round((self.size_in_bytes / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
         self.size_in_mb = round((self.size_in_kb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
         self.size_in_gb = round((self.size_in_mb / self.FILE_SIZE_DIVISOR), self.FILE_SIZE_ROUND_FACTOR)
@@ -102,7 +101,7 @@ class FileStatistics:
     @cached_property
     def modified_time(self):
         """Get the file modified time."""
-        return os.path.getmtime(self.filepath)
+        return self.filepath.stat().st_mtime
 
     @cached_property
     def is_large(self):
@@ -119,9 +118,9 @@ class BlankFile:
         """Initialize the BlankFile object.
 
         Args:
-            filepath (str): Path to the file.
+            filepath (str or Path): Path to the file.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
 
     @cached_property
     def is_blank(self):
@@ -146,9 +145,9 @@ class EmptyFile:
         """Initialize the EmptyFile object.
 
         Args:
-            filepath (str): Path to the file.
+            filepath (str or Path): Path to the file.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
 
     @cached_property
     def is_empty(self):
@@ -166,11 +165,11 @@ class FileProperties:
         Initialize the FileBase class.
 
         Args:
-            filepath (str): Path to the file.
+            filepath (str or Path): Path to the file.
         """
-        self.filepath = filepath
-        self.filename = Path(filepath).name
-        self.extension = Path(filepath).suffix
+        self.filepath = Path(filepath)
+        self.filename = self.filepath.name
+        self.extension = self.filepath.suffix
         self.extension_string = self.extension.replace(".", "")
 
         # Instantiate helper classes

--- a/src/datagrunt/csv_api/csvai.py
+++ b/src/datagrunt/csv_api/csvai.py
@@ -2,6 +2,7 @@
 
 # standard library imports
 import json
+from pathlib import Path
 
 # local imports
 from datagrunt.core import AIEngineFactory, AIEngineProperties, CSVStringSample, prompts
@@ -12,7 +13,7 @@ class CSVSchemaReportAIGenerated:
 
     def __init__(self, filepath, engine, api_key=None, **kwargs):
         """Initialize the CSV Schema Report class."""
-        self.filepath = filepath
+        self.filepath = Path(filepath)
         self.engine = engine.lower().replace(" ", "")
         self.api_key = api_key
         self.kwargs = kwargs

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -4,6 +4,7 @@ objects.
 """
 
 # standard library
+from pathlib import Path
 
 # third party libraries
 import polars as pl
@@ -20,10 +21,11 @@ class CSVReader(CSVComponents):
         Initialize the CSV Reader class.
 
         Args:
-            filepath (str): Path to the file to read.
+            filepath (str or Path): Path to the file to read.
             engine (str, default 'polars'): Determines which reader engine
             class to instantiate.
         """
+        filepath = Path(filepath)
         super().__init__(filepath)
         self.db_table = DuckDBQueries(self.filepath).database_table_name
         self.engine = engine.lower().replace(" ", "")

--- a/src/datagrunt/csv_api/csvwriter.py
+++ b/src/datagrunt/csv_api/csvwriter.py
@@ -1,9 +1,9 @@
 """Module for writing CSV files and converting to different file formats."""
 
 # standard library
+from pathlib import Path
 
 # third party libraries
-
 # local libraries
 from datagrunt.core import CSVComponents, CSVEngineFactory, DuckDBQueries
 
@@ -19,10 +19,11 @@ class CSVWriter(CSVComponents):
         Initialize the CSV Writer class.
 
         Args:
-            filepath (str): Path to the file to write.
+            filepath (str or Path): Path to the file to write.
             engine (str, default 'duckdb'): Determines which writer engine
             class to instantiate.
         """
+        filepath = Path(filepath)
         super().__init__(filepath)
         self.db_table = DuckDBQueries(self.filepath).database_table_name
         self.engine = engine.lower().replace(" ", "")

--- a/tests/csv_api_tests/test_csvai.py
+++ b/tests/csv_api_tests/test_csvai.py
@@ -1,6 +1,7 @@
 """This module contains tests for the CSV AI functionality."""
 
 import json
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
@@ -17,7 +18,7 @@ class TestCSVSchemaReportAIGenerated:
     def test_init_with_valid_parameters(self):
         """Test initialization with valid parameters."""
         csv_ai = CSVSchemaReportAIGenerated(filepath="test.csv", engine=ALL_AI_ENGINES[0], api_key="test_key")
-        assert csv_ai.filepath == "test.csv"
+        assert csv_ai.filepath == Path("test.csv")
         assert csv_ai.engine == ALL_AI_ENGINES[0]
         assert csv_ai.api_key == "test_key"
         assert csv_ai.kwargs == {}
@@ -188,7 +189,7 @@ class TestCSVSchemaReportAIGenerated:
         result = csv_ai.generate_csv_schema_report("model")
 
         assert result == {"schema": "data"}
-        mock_csv_sample_class.assert_called_once_with("test.csv")
+        mock_csv_sample_class.assert_called_once_with(Path("test.csv"))
         mock_prompts.CSV_SCHEMA_PROMPT.format.assert_called_once_with(csv_sample_string="sample,csv,data\n1,2,3")
 
     @patch("datagrunt.csv_api.csvai.AIEngineFactory")
@@ -262,7 +263,7 @@ class TestCSVSchemaReportAIGenerated:
     def test_filepath_attribute_access(self):
         """Test that filepath attribute can be accessed."""
         csv_ai = CSVSchemaReportAIGenerated(filepath="/path/to/test.csv", engine=ALL_AI_ENGINES[0], api_key="test_key")
-        assert csv_ai.filepath == "/path/to/test.csv"
+        assert csv_ai.filepath == Path("/path/to/test.csv")
 
     def test_multiple_engine_name_normalizations(self):
         """Test various engine name normalizations."""


### PR DESCRIPTION
# Convert filepath variables from strings to Path objects by default

## Summary
This PR converts the entire codebase to use `pathlib.Path` objects by default for all filepath handling, while maintaining backward compatibility by accepting both string and Path inputs.

## 🎯 Motivation
The codebase previously had inconsistent filepath handling with a mix of:
- `os.path.*` functions 
- String-based path operations
- Some existing `pathlib.Path` usage

This inconsistency led to:
- Cross-platform compatibility issues
- Code maintenance challenges  
- Missed opportunities for more intuitive path operations

## 🔧 Changes Made

### Core API Classes
- **CSVReader**: Now converts filepath input to Path object internally
- **CSVWriter**: Now converts filepath input to Path object internally
- **CSVSchemaReportAIGenerated**: Now converts filepath input to Path object internally

### File I/O Operations Modernized
```python
# Before
os.path.exists(self.filepath)
os.path.getsize(self.filepath)  
os.path.getmtime(self.filepath)
os.remove(self.database_filename)

# After  
self.filepath.exists()
self.filepath.stat().st_size
self.filepath.stat().st_mtime
Path(self.database_filename).unlink()