### PR TITLE
 Fix: Ensure `to_arrow_table()` returns a `pyarrow.Table` across all platforms

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -208,8 +208,10 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         Returns:
             A PyArrow table.
         """
-        reader = self.queries.create_table(normalize_columns).arrow()
-        return reader.read_all()
+        result = self.queries.create_table(normalize_columns).arrow()
+        if isinstance(result, pa.Table):
+            return result
+        return result.read_all()
 
     def to_dicts(self, normalize_columns=False):
         """

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -208,7 +208,8 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         Returns:
             A PyArrow table.
         """
-        return self.queries.create_table(normalize_columns).arrow()
+        reader = self.queries.create_table(normalize_columns).arrow()
+        return reader.read_all()
 
     def to_dicts(self, normalize_columns=False):
         """

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 # third party libraries
 import polars as pl
+import pyarrow as pa
 
 # local libraries
 from datagrunt.core import CSVComponents, CSVEngineFactory, DuckDBQueries
@@ -65,7 +66,7 @@ class CSVReader(CSVComponents):
             A PyArrow table.
         """
         if self.is_empty or self.is_blank:
-            return self._return_empty_file_object(pl.DataFrame().to_arrow())
+            return self._return_empty_file_object(pa.Table.from_pydict({}))
         return self._create_reader().to_arrow_table(normalize_columns)
 
     def to_dicts(self, normalize_columns=False):


### PR DESCRIPTION
**Description:**

This pull request addresses an issue where unit tests were failing on Linux due to platform-specific behavior of the `pyarrow` library. The `to_arrow_table()` method was returning a `pyarrow.lib.RecordBatchReader` on Linux, while on macOS and Windows it was returning a `pyarrow.Table`, causing inconsistencies and test failures.

**The Problem:**

The core of the issue was that our tests and downstream code expected a `pyarrow.Table` object from the `to_arrow_table()` method. However, the underlying `duckdb.arrow()` method exhibited different behavior depending on the operating system:

*   **On Linux:** It returned a `pyarrow.lib.RecordBatchReader`, which is a stream of data batches.
*   **On macOS and Windows:** It returned a `pyarrow.Table`, which is a fully materialized table in memory.

This discrepancy led to `AttributeError` exceptions when our tests tried to access `Table`-specific attributes (like `.num_rows`) on a `RecordBatchReader` object, and `isinstance()` checks would fail.

**The Solution:**

To resolve this, I've implemented a more robust, platform-agnostic solution within the `CSVReaderDuckDBEngine.to_arrow_table()` method. The new implementation now performs a runtime type check on the object returned by `duckdb.arrow()`:

1.  It inspects the returned object's type.
2.  If the object is already a `pyarrow.Table`, it is returned directly without any changes.
3.  If the object is a `pyarrow.RecordBatchReader`, the `.read_all()` method is called on it to convert it into a `pyarrow.Table` before being returned.

This ensures that the `to_arrow_table()` method has a consistent and predictable return value (`pyarrow.Table`) across all operating systems, making the API more reliable.

**Changes Made:**

*   **`src/datagrunt/core/csv_io/engines.py`:**
    *   Modified `CSVReaderDuckDBEngine.to_arrow_table()` to include type-checking logic that handles both `pyarrow.Table` and `pyarrow.RecordBatchReader` return types.
*   **`src/datagrunt/csv_api/csvreader.py`:**
    *   Added `import pyarrow as pa` to resolve a `NameError`.
    *   Modified the `to_arrow_table()` method to return an empty `pyarrow.Table` for empty or blank files, ensuring type consistency.

**How to Test:**

1.  Run the unit tests on a Linux environment to confirm that all tests pass.
2.  Run the unit tests on a macOS or Windows environment to confirm that all tests still pass.
3.  Manually inspect the return type of `CSVReader.to_arrow_table()` on different platforms to verify it is always a `pyarrow.Table`.

**Conclusion:**

This fix makes our CSV reading functionality more robust and reliable across different platforms, ensuring a consistent experience for all users. It addresses the immediate test failures on Linux while preventing regressions on other operating systems.