### PR TITLE
De-duplicate extracted PDF images

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ writer.write_json("report.json", image_output_dir="report_images")
 writer.extract_images(output_dir="report_images")
 ```
 
+When images are written to disk, byte-identical duplicates (common with repeated
+icons or backgrounds) are collapsed to a single file and all references are
+repointed to it. Pass `dedupe=False` / `dedupe_images=False` to keep every copy.
+
 ## Engine Comparison
 
 | Feature | Polars | DuckDB | PyArrow |

--- a/src/datagrunt/core/__init__.py
+++ b/src/datagrunt/core/__init__.py
@@ -35,6 +35,7 @@ from datagrunt.core.pdf_io import (
     PDFEngineProperties,
     PDFReaderPyMuPDFEngine,
     PDFWriterPyMuPDFEngine,
+    dedupe_document_images,
     flatten_document_elements,
     parse_document,
     parse_page,
@@ -82,5 +83,6 @@ __all__ = [
     "parse_page",
     "parse_document",
     "flatten_document_elements",
+    "dedupe_document_images",
     "set_export_filename",
 ]

--- a/src/datagrunt/core/pdf_io/__init__.py
+++ b/src/datagrunt/core/pdf_io/__init__.py
@@ -12,6 +12,7 @@ from datagrunt.core.pdf_io.factories import PDFEngineFactory
 from datagrunt.core.pdf_io.pdfcomponents import (
     PDFComponents,
     combine_pages,
+    dedupe_document_images,
     flatten_document_elements,
     parse_document,
     parse_page,
@@ -23,6 +24,7 @@ __all__ = [
     "parse_document",
     "combine_pages",
     "flatten_document_elements",
+    "dedupe_document_images",
     "PDFEngineProperties",
     "PDFBaseReaderEngine",
     "PDFBaseWriterEngine",

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -143,17 +143,17 @@ class PDFBaseWriterEngine(ABC):
             raise FileNotFoundError
 
     @abstractmethod
-    def write_json(self, export_filename=None, image_output_dir=None):
+    def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True):
         """Write the unified document JSON to disk."""
         pass
 
     @abstractmethod
-    def write_json_newline_delimited(self, export_filename=None, image_output_dir=None):
+    def write_json_newline_delimited(self, export_filename=None, image_output_dir=None, dedupe_images=True):
         """Write one element per line as JSON Lines."""
         pass
 
     @abstractmethod
-    def extract_images(self, output_dir=None):
+    def extract_images(self, output_dir=None, dedupe=True):
         """Write embedded images to disk; return their paths."""
         pass
 
@@ -164,7 +164,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
     def _reader(self):
         return PDFReaderPyMuPDFEngine(self.filepath, workers=self.workers)
 
-    def write_json(self, export_filename=None, image_output_dir=None):
+    def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True):
         """Parse the PDF and write the unified document JSON.
 
         Args:
@@ -172,32 +172,48 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
             image_output_dir (optional, str): If provided, embedded images are
                 written here and referenced in the JSON; otherwise image
                 ``file_path`` values are null.
+            dedupe_images (bool, default True): When images are written, collapse
+                byte-identical duplicates to a single file and repoint references.
         """
         filename = set_export_filename(self.properties.json_export_filename, export_filename)
         document = self._reader().to_dicts(image_output_dir=image_output_dir)
+        if image_output_dir and dedupe_images:
+            pdfcomponents.dedupe_document_images(document)
         with open(filename, "w") as f:
             json.dump(document, f, indent=2)
         return filename
 
-    def write_json_newline_delimited(self, export_filename=None, image_output_dir=None):
+    def write_json_newline_delimited(self, export_filename=None, image_output_dir=None, dedupe_images=True):
         """Parse the PDF and write one flattened element per line (JSONL)."""
         filename = set_export_filename(self.properties.json_newline_export_filename, export_filename)
         document = self._reader().to_dicts(image_output_dir=image_output_dir)
+        if image_output_dir and dedupe_images:
+            pdfcomponents.dedupe_document_images(document)
         records = pdfcomponents.flatten_document_elements(document)
         with open(filename, "w") as f:
             for record in records:
                 f.write(json.dumps(record) + "\n")
         return filename
 
-    def extract_images(self, output_dir=None):
-        """Parse the PDF, write embedded images to disk, return their paths."""
+    def extract_images(self, output_dir=None, dedupe=True):
+        """Parse the PDF, write embedded images to disk, return their paths.
+
+        Args:
+            output_dir (optional, str): Output directory; defaults to output_images.
+            dedupe (bool, default True): Collapse byte-identical duplicate images
+                to a single file before returning paths.
+        """
         directory = output_dir if output_dir else self.properties.images_export_dir
         document = self._reader().to_dicts(image_output_dir=directory)
+        if dedupe:
+            pdfcomponents.dedupe_document_images(document)
         paths = []
+        seen = set()
         for page in document.get("document", {}).get("pages", []):
             for elem in page.get("elements", []):
                 if elem.get("type") == "image":
                     fp = (elem.get("metadata") or {}).get("file_path")
-                    if fp:
+                    if fp and fp not in seen:
+                        seen.add(fp)
                         paths.append(fp)
         return paths

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -1,7 +1,9 @@
 """PDF component assembly: page parsing, document combination, flattening."""
 
 # standard library
+import hashlib
 import json
+import os
 import time
 from functools import cached_property
 from pathlib import Path
@@ -239,6 +241,51 @@ def flatten_document_elements(document: dict) -> list:
                 }
             )
     return records
+
+
+def dedupe_document_images(document: dict) -> int:
+    """Remove byte-duplicate extracted image files, repointing references.
+
+    Walks the document's image elements, hashes each on-disk file referenced by
+    ``metadata.file_path``, and for any content already seen, repoints the
+    element at the first file and deletes the redundant copy from disk.
+    Elements with no ``file_path`` (metadata-only reads) or whose file is
+    missing are skipped.
+
+    Args:
+        document: A parsed document dict (mutated in place).
+
+    Returns:
+        The number of duplicate image files removed from disk.
+    """
+    seen = {}  # md5 digest -> first file_path that produced it
+    removed = 0
+    pages = document.get("document", {}).get("pages", [])
+    for page in pages:
+        for elem in page.get("elements", []):
+            if elem.get("type") != "image":
+                continue
+            meta = elem.get("metadata") or {}
+            path = meta.get("file_path")
+            if not path or not os.path.isfile(path):
+                continue
+            with open(path, "rb") as f:
+                digest = hashlib.md5(f.read()).hexdigest()
+            first = seen.get(digest)
+            if first is None:
+                seen[digest] = path
+                continue
+            if first == path:
+                # Same file already referenced; repoint is a no-op, never delete.
+                continue
+            meta["file_path"] = first
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+            else:
+                removed += 1
+    return removed
 
 
 class PDFComponents(FileProperties):

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -27,40 +27,46 @@ class PDFWriter(PDFComponents):
         """Create a writer engine instance."""
         return PDFEngineFactory(self.filepath, self.engine, self.workers).create_writer()
 
-    def write_json(self, export_filename=None, image_output_dir=None):
+    def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True):
         """Parse the PDF and write the unified document JSON to disk.
 
         Args:
             export_filename (optional, str): Output path; defaults to output.json.
             image_output_dir (optional, str): If provided, embedded images are
                 written there and referenced in the JSON.
+            dedupe_images (bool, default True): When images are written, collapse
+                byte-identical duplicates to a single file and repoint references.
 
         Returns:
             str: The path of the written JSON file.
         """
-        return self._create_writer().write_json(export_filename, image_output_dir)
+        return self._create_writer().write_json(export_filename, image_output_dir, dedupe_images)
 
-    def write_json_newline_delimited(self, export_filename=None, image_output_dir=None):
+    def write_json_newline_delimited(self, export_filename=None, image_output_dir=None, dedupe_images=True):
         """Parse the PDF and write one flattened element per line (JSONL).
 
         Args:
             export_filename (optional, str): Output path; defaults to output.jsonl.
             image_output_dir (optional, str): If provided, embedded images are
                 written there.
+            dedupe_images (bool, default True): When images are written, collapse
+                byte-identical duplicates to a single file and repoint references.
 
         Returns:
             str: The path of the written JSONL file.
         """
-        return self._create_writer().write_json_newline_delimited(export_filename, image_output_dir)
+        return self._create_writer().write_json_newline_delimited(export_filename, image_output_dir, dedupe_images)
 
-    def extract_images(self, output_dir=None):
+    def extract_images(self, output_dir=None, dedupe=True):
         """Parse the PDF and write embedded image files to disk.
 
         Args:
             output_dir (optional, str): Output directory; defaults to
                 output_images.
+            dedupe (bool, default True): Collapse byte-identical duplicate images
+                to a single file before returning paths.
 
         Returns:
             list: Paths of the written image files.
         """
-        return self._create_writer().extract_images(output_dir)
+        return self._create_writer().extract_images(output_dir, dedupe)

--- a/tests/core_tests/pdf_io_tests/test_engines.py
+++ b/tests/core_tests/pdf_io_tests/test_engines.py
@@ -104,3 +104,59 @@ class TestPDFWriterEngine:
         paths = engine.extract_images(output_dir=str(out))
         assert len(paths) >= 1
         assert all(os.path.isfile(p) for p in paths)
+
+
+class TestPDFWriterDedupe:
+    """Test suite for image de-duplication in the writer engine."""
+
+    @staticmethod
+    def _two_page_dupe_pdf(tmp_path):
+        """Build a 2-page PDF with the same image embedded on each page."""
+        import pymupdf
+
+        doc = pymupdf.open()
+        pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 120, 120))
+        pix.set_rect(pix.irect, (0, 128, 255))
+        img = pix.tobytes("png")
+        for _ in range(2):
+            page = doc.new_page(width=300, height=300)
+            page.insert_image(pymupdf.Rect(50, 50, 170, 170), stream=img)
+        path = tmp_path / "dupe.pdf"
+        doc.save(str(path))
+        doc.close()
+        return str(path)
+
+    def test_extract_images_dedupes_by_default(self, tmp_path):
+        pdf = self._two_page_dupe_pdf(tmp_path)
+        out = tmp_path / "imgs"
+        engine = PDFWriterPyMuPDFEngine(pdf)
+        paths = engine.extract_images(output_dir=str(out))
+        # The two byte-identical images collapse to a single file.
+        assert len(paths) == 1
+        assert os.path.isfile(paths[0])
+        assert len([f for f in os.listdir(out) if f.endswith(".png")]) == 1
+
+    def test_extract_images_dedupe_disabled(self, tmp_path):
+        pdf = self._two_page_dupe_pdf(tmp_path)
+        out = tmp_path / "imgs2"
+        engine = PDFWriterPyMuPDFEngine(pdf)
+        paths = engine.extract_images(output_dir=str(out), dedupe=False)
+        assert len(paths) == 2
+
+    def test_write_json_dedupes_image_references(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        pdf = self._two_page_dupe_pdf(tmp_path)
+        engine = PDFWriterPyMuPDFEngine(pdf)
+        jpath = engine.write_json(image_output_dir=str(tmp_path / "imgs3"))
+        with open(jpath) as f:
+            doc = json.load(f)
+        img_paths = [
+            e["metadata"]["file_path"]
+            for pg in doc["document"]["pages"]
+            for e in pg["elements"]
+            if e["type"] == "image"
+        ]
+        # Both image elements reference the same (single) on-disk file.
+        assert len(img_paths) == 2
+        assert len(set(img_paths)) == 1
+        assert all(os.path.isfile(p) for p in img_paths)

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -56,3 +56,82 @@ class TestPDFComponents:
         comp = pdfcomponents.PDFComponents(sample_pdf)
         assert comp.is_pdf
         assert comp.total_pages == 1
+
+
+class TestDedupeImages:
+    """Test suite for dedupe_document_images."""
+
+    @staticmethod
+    def _img_element(file_path):
+        return {
+            "id": "elem",
+            "type": "image",
+            "content": None,
+            "page": 1,
+            "position": {"x": 0, "y": 0, "w": 0, "h": 0},
+            "confidence": 1.0,
+            "metadata": {
+                "file_path": file_path,
+                "format": "png",
+                "width_px": 100,
+                "height_px": 100,
+            },
+        }
+
+    def test_dedupes_identical_images(self, tmp_path):
+        a = tmp_path / "a.png"
+        a.write_bytes(b"IMG-DATA-1")
+        b = tmp_path / "b.png"
+        b.write_bytes(b"IMG-DATA-1")  # byte-identical to a
+        c = tmp_path / "c.png"
+        c.write_bytes(b"IMG-DATA-2")  # unique
+        document = {
+            "document": {
+                "pages": [
+                    {
+                        "page_number": 1,
+                        "elements": [
+                            self._img_element(str(a)),
+                            self._img_element(str(b)),
+                            self._img_element(str(c)),
+                        ],
+                    }
+                ]
+            }
+        }
+
+        removed = pdfcomponents.dedupe_document_images(document)
+
+        assert removed == 1
+        # The redundant duplicate file is deleted; the first + unique remain.
+        assert a.exists()
+        assert not b.exists()
+        assert c.exists()
+        # The duplicate element is repointed at the first occurrence.
+        elems = document["document"]["pages"][0]["elements"]
+        assert elems[1]["metadata"]["file_path"] == str(a)
+        assert elems[0]["metadata"]["file_path"] == str(a)
+        assert elems[2]["metadata"]["file_path"] == str(c)
+
+    def test_skips_none_and_missing_paths(self, tmp_path):
+        a = tmp_path / "a.png"
+        a.write_bytes(b"ONLY")
+        document = {
+            "document": {
+                "pages": [
+                    {
+                        "page_number": 1,
+                        "elements": [
+                            self._img_element(None),
+                            self._img_element(str(tmp_path / "gone.png")),
+                            self._img_element(str(a)),
+                        ],
+                    }
+                ]
+            }
+        }
+
+        removed = pdfcomponents.dedupe_document_images(document)
+
+        assert removed == 0
+        assert a.exists()

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -54,3 +54,47 @@ class TestPDFWriter:
     def test_engine_normalized(self, sample_pdf):
         writer = PDFWriter(sample_pdf, engine="Py Mu PDF")
         assert writer.engine == "pymupdf"
+
+    @staticmethod
+    def _two_page_dupe_pdf(tmp_path):
+        """Build a 2-page PDF with the same image embedded on each page."""
+        import pymupdf
+
+        doc = pymupdf.open()
+        pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 120, 120))
+        pix.set_rect(pix.irect, (0, 128, 255))
+        img = pix.tobytes("png")
+        for _ in range(2):
+            page = doc.new_page(width=300, height=300)
+            page.insert_image(pymupdf.Rect(50, 50, 170, 170), stream=img)
+        path = tmp_path / "dupe.pdf"
+        doc.save(str(path))
+        doc.close()
+        return str(path)
+
+    def test_extract_images_dedupes_by_default(self, tmp_path):
+        pdf = self._two_page_dupe_pdf(tmp_path)
+        writer = PDFWriter(pdf)
+        paths = writer.extract_images(output_dir=str(tmp_path / "imgs"))
+        assert len(paths) == 1
+
+    def test_extract_images_dedupe_can_be_disabled(self, tmp_path):
+        pdf = self._two_page_dupe_pdf(tmp_path)
+        writer = PDFWriter(pdf)
+        paths = writer.extract_images(output_dir=str(tmp_path / "imgs2"), dedupe=False)
+        assert len(paths) == 2
+
+    def test_write_json_dedupes_by_default(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        pdf = self._two_page_dupe_pdf(tmp_path)
+        writer = PDFWriter(pdf)
+        jpath = writer.write_json(image_output_dir=str(tmp_path / "imgs3"))
+        with open(jpath) as f:
+            doc = json.load(f)
+        img_paths = [
+            e["metadata"]["file_path"]
+            for pg in doc["document"]["pages"]
+            for e in pg["elements"]
+            if e["type"] == "image"
+        ]
+        assert len(img_paths) == 2 and len(set(img_paths)) == 1


### PR DESCRIPTION
## Summary

Adds **MD5-based de-duplication** of extracted PDF images. Many PDFs (especially design-heavy documents) embed the same icon/background repeatedly; image extraction previously wrote every copy. This collapses byte-identical files to one and repoints all references.

- New `dedupe_document_images(document)` in `core/pdf_io/pdfcomponents.py` — hashes on-disk files referenced by image elements, repoints duplicates to the first copy, deletes the redundant files, returns the count removed. Skips metadata-only reads (`file_path is None`) and missing files.
- Wired into the writer engine + public `PDFWriter`: `write_json(...)`, `write_json_newline_delimited(...)` (when `image_output_dir` is set), and `extract_images(...)`. **On by default**, with `dedupe=False` / `dedupe_images=False` to opt out.
- This restores behavior that existed in the original [pdf-parser-python](https://github.com/pmgraham/pdf-parser-python) pipeline — its MD5 dedup lived in the GCS-upload path that was dropped as cloud-specific. **No extraction logic changed.**

## Impact (real document)

On the 24-page *Root – Learn to Play* rulebook: extracted images **353 → 146 (~59% fewer files)**, JSON shrinks accordingly, and all 353 image references resolve to the 146 unique files.

## ✅ Test status — all unit tests written and passing

**`uv run pytest` → 198 passed, 0 failed** (190 prior + **8 new**, TDD). New coverage:
- `test_pdfcomponents.py::TestDedupeImages` — dedupes identical files / repoints references / deletes the redundant copy; skips `None` and missing paths
- `test_engines.py::TestPDFWriterDedupe` — writer dedupes by default, `dedupe=False` keeps both, `write_json` references collapse to one file
- `test_pdfwriter.py` — public `PDFWriter` passthrough (default-on + opt-out)

`uv run ruff check src tests` clean.

## Test Plan

- [x] `uv run pytest` — 198 passed
- [x] `uv run ruff check src tests` — clean
- [x] Verified end-to-end on a real 11 MB PDF (353 → 146 images; all JSON refs resolve)
- [ ] Reviewer: confirm `dedupe=False` preserves every extracted copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)