### PR TITLE
fix: per-instance DuckDB connections + unique table names; get_sample returns data

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Dict, List, Union
 
 # third party libraries
-import duckdb
 import polars as pl
 import pyarrow as pa
 import pyarrow.csv as pacsv
@@ -56,11 +55,14 @@ class CSVBaseReaderEngine(ABC):
             raise FileNotFoundError
 
     @abstractmethod
-    def get_sample(self, normalize_columns: bool = False) -> None:
-        """Return a sample of the data.
+    def get_sample(self, normalize_columns: bool = False) -> pl.DataFrame:
+        """Return a sample of the data as a Polars DataFrame.
 
         Args:
             normalize_columns (bool): Whether to normalize column names.
+
+        Returns:
+            A Polars DataFrame containing the sample rows.
         """
         pass
 
@@ -181,8 +183,12 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         Args:
             normalize_columns (optional, bool): Whether to normalize column
             names.
+
+        Returns:
+            A Polars DataFrame containing the sample rows.
         """
-        self.queries.create_table(normalize_columns).show()
+        relation = self.queries.create_table(normalize_columns)
+        return relation.limit(CSVEngineProperties.dataframe_sample_rows).pl()
 
     def to_dataframe(self, normalize_columns=False):
         """
@@ -262,8 +268,10 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         # so the user's query can reference them.
         self.queries.create_table(normalize_columns=False)
 
-        # Execute the user's query
-        result_relation = duckdb.sql(sql_query)
+        # Execute the user's query on the same per-instance connection that
+        # holds the table. The returned relation keeps this connection alive,
+        # so it remains valid after this engine instance is garbage collected.
+        result_relation = self.queries.connection.sql(sql_query)
 
         if normalize_columns:
             result_relation = self._normalize_relation_columns(result_relation)
@@ -325,8 +333,7 @@ class CSVReaderPolarsEngine(CSVBaseReaderEngine):
         Returns:
             A Polars dataframe.
         """
-        df = self._create_dataframe_sample(normalize_columns)
-        print(df)
+        return self._create_dataframe_sample(normalize_columns)
 
     def to_dataframe(self, normalize_columns=False):
         """
@@ -409,7 +416,7 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.csv_export_filename, export_filename)
         self.queries.create_table(normalize_columns)
-        duckdb.sql(self.queries.export_csv_query(filename))
+        self.queries.connection.sql(self.queries.export_csv_query(filename))
 
     def write_excel(self, export_filename=None, normalize_columns=False):
         """
@@ -422,7 +429,7 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.excel_export_filename, export_filename)
         self.queries.create_table(normalize_columns)
-        duckdb.sql(self.queries.export_excel_query(filename))
+        self.queries.connection.sql(self.queries.export_excel_query(filename))
 
     def write_json(self, export_filename=None, normalize_columns=False):
         """
@@ -435,7 +442,7 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.json_export_filename, export_filename)
         self.queries.create_table(normalize_columns)
-        duckdb.sql(self.queries.export_json_query(filename))
+        self.queries.connection.sql(self.queries.export_json_query(filename))
 
     def write_json_newline_delimited(self, export_filename=None, normalize_columns=False):
         """
@@ -448,7 +455,7 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.json_newline_export_filename, export_filename)
         self.queries.create_table(normalize_columns)
-        duckdb.sql(self.queries.export_json_newline_delimited_query(filename))
+        self.queries.connection.sql(self.queries.export_json_newline_delimited_query(filename))
 
     def write_parquet(self, export_filename=None, normalize_columns=False):
         """
@@ -461,7 +468,7 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.parquet_export_filename, export_filename)
         self.queries.create_table(normalize_columns)
-        duckdb.sql(self.queries.export_parquet_query(filename))
+        self.queries.connection.sql(self.queries.export_parquet_query(filename))
 
 
 class CSVWriterPolarsEngine(CSVBaseWriterEngine):
@@ -618,13 +625,16 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
         Args:
             normalize_columns (optional, bool): Whether to normalize column
             names.
+
+        Returns:
+            A Polars DataFrame containing the sample rows.
         """
         table = self._create_table_sample(normalize_columns)
-        # Convert to Polars DataFrame for display
+        # Convert to a Polars DataFrame for a consistent return type
         df = pl.from_arrow(table)
         if isinstance(df, pl.Series):
             df = df.to_frame()
-        print(df)
+        return df
 
     def to_dataframe(self, normalize_columns=False) -> pl.DataFrame:
         """

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -1,6 +1,7 @@
 """Module for interfacing with databases."""
 
 # standard library
+import hashlib
 import re
 from pathlib import Path
 
@@ -69,12 +70,41 @@ class DuckDBQueries:
         """
         Initialize the DuckDBQueries class.
 
+        Each instance owns a private in-memory DuckDB connection so that
+        concurrent readers/writers - or simply multiple instances in the
+        same process - never share global state. Combined with a table name
+        that is unique per file path, this prevents one file's table from
+        silently overwriting another's.
+
         Args:
             filepath (str or Path): Path to the file.
         """
         self.filepath = Path(filepath)
         self.delimiter = CSVDelimiter(filepath).delimiter
-        self.database_table_name = DuckDBDatabase(filepath).database_table_name
+        self.database_table_name = self._set_database_table_name()
+        self.connection = duckdb.connect(":memory:")
+
+    def _format_filename_string(self):
+        """Remove all non alphanumeric characters from the file stem."""
+        return re.sub(r"[^a-zA-Z0-9]", "", self.filepath.stem)
+
+    def _set_database_table_name(self):
+        """Return a unique, deterministic table name for this file.
+
+        The name combines the sanitized file stem with a short hash of the
+        file's absolute path. The hash is deterministic, so every
+        DuckDBQueries instance created for the same file agrees on the same
+        table name (callers can therefore still reference ``db_table`` in
+        their queries). At the same time, two different files that happen to
+        share a stem (e.g. ``dirA/data.csv`` and ``dirB/data.csv``) resolve
+        to distinct tables and cannot overwrite each other.
+
+        Returns:
+            str: The unique table name.
+        """
+        stem = self._format_filename_string()
+        path_hash = hashlib.sha1(str(self.filepath.resolve()).encode()).hexdigest()[:8]  # noqa: E501
+        return f"{stem}_{path_hash}"
 
     def set_export_filename(self, default_filename, export_filename=None):
         """
@@ -217,11 +247,11 @@ class DuckDBQueries:
         this method uses the CSVColumnNameNormalizer class to ensure
         consistent naming conventions across different processing engines.
         """
-        duckdb.sql(self.import_csv_query())
-        table_columns = duckdb.sql(f"SELECT * FROM {self.database_table_name} LIMIT 0").columns
+        self.connection.sql(self.import_csv_query())
+        table_columns = self.connection.sql(f"SELECT * FROM {self.database_table_name} LIMIT 0").columns
         for old_name, new_name in zip(table_columns, CSVColumnNameNormalizer(self.filepath).columns_normalized):
             sql_string = f'ALTER TABLE {self.database_table_name} RENAME COLUMN "{old_name}" TO "{new_name}"'
-            duckdb.sql(sql_string)
+            self.connection.sql(sql_string)
 
     def create_table(self, normalize_columns=False):
         """Create a DuckDB table from the CSV file.
@@ -232,8 +262,8 @@ class DuckDBQueries:
         if normalize_columns:
             self.update_and_normalize_column_names()
         else:
-            duckdb.sql(self.import_csv_query())
-        return duckdb.sql(self.select_from_duckdb_table()).execute()
+            self.connection.sql(self.import_csv_query())
+        return self.connection.sql(self.select_from_duckdb_table()).execute()
 
     def _normalize_dataframe_columns(self, dataframe):
         """Applies column name normalization to a Polars DataFrame.
@@ -261,10 +291,10 @@ class DuckDBQueries:
             polars.DataFrame: The resulting DataFrame.
         """
         # Ensure the table is created with original column names for querying
-        duckdb.sql(self.import_csv_query())
+        self.connection.sql(self.import_csv_query())
 
         # Execute the user's query
-        result_df = duckdb.sql(sql_query).pl()
+        result_df = self.connection.sql(sql_query).pl()
 
         if normalize_columns:
             result_df = self._normalize_dataframe_columns(result_df)

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -40,8 +40,15 @@ class CSVReader(CSVComponents):
         return CSVEngineFactory(self.filepath, self.engine).create_reader()
 
     def get_sample(self, normalize_columns=False):
-        """Return a sample of the CSV file."""
-        self._create_reader().get_sample(normalize_columns)
+        """Return a sample of the CSV file.
+
+        Args:
+            normalize_columns (bool): Whether to normalize column names.
+
+        Returns:
+            A Polars DataFrame containing the sample rows.
+        """
+        return self._create_reader().get_sample(normalize_columns)
 
     def to_dataframe(self, normalize_columns=False):
         """Converts CSV to a Polars dataframe.

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -124,23 +124,23 @@ class TestEngines:
             expected_type = QUERY_RESULT_TYPES[engine]
             assert isinstance(result, expected_type)
 
-    def test_reader_get_sample_all_engines(self, sample_csv, capsys):
-        """Test get_sample method for all reader engines."""
+    def test_reader_get_sample_all_engines(self, sample_csv):
+        """Test get_sample method returns a sample DataFrame for all engines."""
         for engine in ALL_ENGINES:
             factory = CSVEngineFactory(sample_csv, engine)
             reader = factory.create_reader()
 
             # Test get_sample without normalization
-            reader.get_sample()
-            captured = capsys.readouterr()
-            # Different engines output different formats, just verify something was printed
-            assert len(captured.out) > 0
-            assert "John" in captured.out or "Jane" in captured.out  # Should contain sample data
+            sample = reader.get_sample()
+            assert isinstance(sample, pl.DataFrame)
+            assert len(sample) > 0
+            names = sample["name"].to_list()
+            assert "John" in names or "Jane" in names  # Should contain sample data
 
             # Test get_sample with normalization
-            reader.get_sample(normalize_columns=True)
-            captured = capsys.readouterr()
-            assert len(captured.out) > 0
+            normalized_sample = reader.get_sample(normalize_columns=True)
+            assert isinstance(normalized_sample, pl.DataFrame)
+            assert len(normalized_sample) > 0
 
     def test_writer_basic_operations_all_engines(self, tmp_path, sample_csv):
         """Test basic write operations for all writer engines."""

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -85,15 +85,86 @@ class TestCSVReader:
             df = reader.to_dataframe(normalize_columns=True)
             assert list(df.columns) == expected_columns
 
-    def test_get_sample(self, sample_csv, capsys):
-        """Test get_sample method."""
+    def test_get_sample(self, sample_csv):
+        """Test get_sample method returns a sample DataFrame."""
         for engine in ALL_ENGINES:
             reader = CSVReader(sample_csv, engine=engine)
-            reader.get_sample()
-            captured = capsys.readouterr()
-            assert captured.out  # Verify that something was printed
-            assert "John" in captured.out
-            assert "Jane" in captured.out
+            sample = reader.get_sample()
+            assert isinstance(sample, pl.DataFrame)
+            assert len(sample) == 2
+            names = sample["name"].to_list()
+            assert "John" in names
+            assert "Jane" in names
+
+    def test_same_stem_files_do_not_collide(self, tmp_path):
+        """Two files sharing a name stem must not overwrite each other's data.
+
+        Regression test for the DuckDB table-name collision bug: previously
+        both files mapped to a single global table named after the stem, so
+        constructing the second reader silently corrupted the first.
+        """
+        dir_a = tmp_path / "dirA"
+        dir_b = tmp_path / "dirB"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        (dir_a / "data.csv").write_text("col1,col2\n1,A\n2,B\n")
+        (dir_b / "data.csv").write_text("col1,col2\n99,Z\n100,Y\n")
+
+        for engine in ALL_ENGINES:
+            reader_a = CSVReader(str(dir_a / "data.csv"), engine=engine)
+            reader_b = CSVReader(str(dir_b / "data.csv"), engine=engine)
+
+            # Distinct, deterministic table names per file path
+            assert reader_a.db_table != reader_b.db_table
+
+            # Each reader must still return its own data after the other exists
+            a_vals = sorted(reader_a.to_dataframe()["col1"].to_list())
+            b_vals = sorted(reader_b.to_dataframe()["col1"].to_list())
+            assert a_vals == ["1", "2"]
+            assert b_vals == ["100", "99"]
+
+            # And SQL queries via DuckDB must hit the correct per-file table
+            res_a = reader_a.query_data(f"SELECT col1 FROM {reader_a.db_table} ORDER BY col1")
+            df_a = res_a.pl() if hasattr(res_a, "pl") else res_a
+            assert df_a["col1"].to_list() == ["1", "2"]
+
+    def test_duckdb_lazy_result_not_corrupted_by_later_same_stem_reader(self, tmp_path):
+        """A deferred DuckDB result must keep its own file's data even after a
+        second file sharing its name stem is loaded.
+
+        This is the test shape that actually exposes the original bug. The
+        eager paths (``to_dataframe``, or a ``query_data`` result materialized
+        immediately) re-import and read in a single step, so they always see
+        the right table and hide the collision. The bug only surfaces when a
+        *lazy* ``DuckDBPyRelation`` from the first file is materialized *after*
+        a second same-stem file is imported: on the old shared global
+        connection with a stem-only table name, the second ``CREATE OR REPLACE
+        TABLE`` overwrote the first file's table, so the deferred read returned
+        the wrong file's rows.
+
+        Lazy evaluation is DuckDB-specific here; the Polars and PyArrow engines
+        read eagerly into memory and never share a mutable table.
+        """
+        dir_a = tmp_path / "dirA"
+        dir_b = tmp_path / "dirB"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        (dir_a / "data.csv").write_text("col1,col2\n1,A\n2,B\n")
+        (dir_b / "data.csv").write_text("col1,col2\n99,Z\n100,Y\n")
+
+        reader_a = CSVReader(str(dir_a / "data.csv"), engine="duckdb")
+
+        # Build a lazy relation over file A's table but DO NOT materialize it.
+        lazy_a = reader_a.query_data(f"SELECT col1 FROM {reader_a.db_table} ORDER BY col1")
+
+        # Now import a different file that shares the "data" stem. On the buggy
+        # implementation this CREATE OR REPLACE TABLE clobbered the single
+        # shared table that ``lazy_a`` still points at.
+        reader_b = CSVReader(str(dir_b / "data.csv"), engine="duckdb")
+        reader_b.to_dataframe()
+
+        # Materialize A's deferred result only now. It must still be A's rows.
+        assert lazy_a.pl()["col1"].to_list() == ["1", "2"]
 
     def test_to_dataframe_empty_and_blank_files(self, tmp_path):
         """Test to_dataframe method specifically for empty and blank files."""


### PR DESCRIPTION
## Summary

Fixes two issues found while validating a code review of the DuckDB-backed CSV path:

- **Table/connection collision (critical).** `DuckDBQueries` used the global `duckdb.sql(...)` connection and a table name derived only from the file stem. Two files sharing a stem (e.g. `dirA/data.csv` and `dirB/data.csv`) both mapped to a single shared `data` table, so loading the second silently overwrote the first. Now each `DuckDBQueries` owns a private in-memory connection (`duckdb.connect(":memory:")`) and a deterministic, path-unique table name (`{stem}_{sha1(abspath)[:8]}`). All reader/writer queries run on `self.connection`.
- **`get_sample` returned nothing (major).** `CSVReader.get_sample` was missing its `return`, and the engines printed / `.show()`-ed instead of returning data. It now returns a Polars DataFrame (up to 20 rows) across all three engines.

## Regression test

Added `test_duckdb_lazy_result_not_corrupted_by_later_same_stem_reader`. The naive "two readers, compare data" approach does **not** catch this bug — eager reads re-import their own file immediately before reading, masking the collision. The test instead holds a **lazy `DuckDBPyRelation`** from file A, loads same-stem file B, then materializes A.

Proven by reverting the source to the pre-fix commit and running it:

| Code | Result |
|------|--------|
| Pre-fix | ❌ `AssertionError: ['100', '99'] == ['1', '2']` — A's deferred read returned B's rows |
| This PR | ✅ passes |

## Tests

`102 passed` across `tests/csv_api_tests` and `tests/core_tests/csv_io_tests`. (Patch-level fix — no version tag in the title.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)