### PR TITLE
refactor: address code review findings 5-7 (resource disposal, typos, test gap)

### DIFF
--- a/src/datagrunt/__init__.py
+++ b/src/datagrunt/__init__.py
@@ -8,7 +8,7 @@ writing CSV files.
 Example:
     A simple example of how to use the main functionality of your package:
 
-    from datagrunt.csvfile import CSVReader
+    from datagrunt import CSVReader
 
     csv_file = 'electric_vehicle_population_data.csv'
     engine = 'duckdb'

--- a/src/datagrunt/core/__init__.py
+++ b/src/datagrunt/core/__init__.py
@@ -27,7 +27,7 @@ from datagrunt.core.csv_io import (
     CSVWriterPolarsEngine,
     CSVWriterPyArrowEngine,
 )
-from datagrunt.core.databases import DuckDBDatabase, DuckDBQueries
+from datagrunt.core.databases import DuckDBQueries
 from datagrunt.core.file_io import FileProperties
 from datagrunt.core.pdf_io import (
     PDFComponents,
@@ -71,7 +71,6 @@ __all__ = [
     "CSVRows",
     "CSVStringSample",
     # Databases
-    "DuckDBDatabase",
     "DuckDBQueries",
     # File IO
     "FileProperties",

--- a/src/datagrunt/core/databases/__init__.py
+++ b/src/datagrunt/core/databases/__init__.py
@@ -1,5 +1,5 @@
 """Initializes the databases module of the datagrunt package."""
 
-from datagrunt.core.databases.databases import DuckDBDatabase, DuckDBQueries
+from datagrunt.core.databases.databases import DuckDBQueries
 
-__all__ = ["DuckDBDatabase", "DuckDBQueries"]
+__all__ = ["DuckDBQueries"]

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -12,57 +12,6 @@ import duckdb
 from datagrunt.core.csv_io import CSVColumnNameNormalizer, CSVDelimiter
 
 
-class DuckDBDatabase:
-    """Class to configure local database for file processing.
-    Utilizes duckdb as the processing engine.
-    """
-
-    DEFAULT_ENCODING = "utf-8"
-    DEFAULT_THREAD_COUNT = 16
-
-    def __init__(self, filepath):
-        """
-        Initialize the FileDatabase class.
-
-        Args:
-            filepath (str or Path): Path to the file.
-        """
-        self.filepath = Path(filepath)
-        self.database_filename = self._set_database_filename()
-        self.database_table_name = self._set_database_table_name()
-        self.database_connection = self._set_database_connection()
-
-    def __del__(self):
-        """
-        Close the database connection and delete .db files after use.
-        """
-        self.database_connection.close()
-        if Path(self.database_filename).exists():
-            Path(self.database_filename).unlink()
-
-    def _format_filename_string(self):
-        """Remove all non alphanumeric characters from filename."""
-        return re.sub(r"[^a-zA-Z0-9]", "", self.filepath.stem)
-
-    def _set_database_filename(self):
-        """Return name of duckdb file created at runtime."""
-        return f"{self._format_filename_string()}.db"
-
-    def _set_database_table_name(self):
-        """
-        Return name of duckdb import table created during file import.
-        """
-        return f"{self._format_filename_string()}"
-
-    def _set_database_connection(self, threads=DEFAULT_THREAD_COUNT):
-        """Establish a connection with duckdb.
-
-        Args:
-            threads (int): Number of threads to use for duckdb.
-        """
-        return duckdb.connect(self.database_filename, config={"threads": threads})
-
-
 class DuckDBQueries:
     """Class to store DuckDB database queries and query strings."""
 
@@ -83,6 +32,21 @@ class DuckDBQueries:
         self.delimiter = CSVDelimiter(filepath).delimiter
         self.database_table_name = self._set_database_table_name()
         self.connection = duckdb.connect(":memory:")
+
+    def close(self):
+        """Close this instance's DuckDB connection.
+
+        Provides deterministic disposal of the per-instance in-memory
+        connection. Safe to call multiple times. There is intentionally no
+        ``__del__``: relying on the garbage collector to close connections is
+        unreliable - timing is non-deterministic and module globals may already
+        be torn down at interpreter shutdown.
+
+        Note: any lazy ``DuckDBPyRelation`` still referencing this connection
+        becomes invalid once it is closed, so only call ``close()`` once you are
+        done with results derived from this instance.
+        """
+        self.connection.close()
 
     def _format_filename_string(self):
         """Remove all non alphanumeric characters from the file stem."""

--- a/src/datagrunt/core/file_io/fileproperties.py
+++ b/src/datagrunt/core/file_io/fileproperties.py
@@ -258,5 +258,5 @@ class FileProperties:
 
     @cached_property
     def is_tsv(self):
-        """Check if the file is tabular."""
+        """Check if the file is a TSV file."""
         return self.extension_string.lower() in self._ext.tsv_extensions

--- a/tests/core_tests/databases_tests/test_databases.py
+++ b/tests/core_tests/databases_tests/test_databases.py
@@ -1,0 +1,39 @@
+"""Tests for the DuckDBQueries connection lifecycle."""
+
+import duckdb
+import pytest
+
+from datagrunt.core.databases import DuckDBQueries
+
+
+class TestDuckDBQueriesClose:
+    """Explicit, deterministic disposal of the per-instance connection."""
+
+    def test_close_releases_connection(self, tmp_path):
+        """close() must close the per-instance in-memory connection.
+
+        DuckDBQueries owns a private connection; close() gives callers a
+        deterministic disposal path so they need not rely on garbage
+        collection or a __del__ (intentionally not implemented).
+        """
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1,col2\n1,A\n2,B\n")
+        queries = DuckDBQueries(str(csv))
+
+        # Usable before close.
+        assert queries.connection.sql("SELECT 1").fetchone() == (1,)
+
+        queries.close()
+
+        # Unusable after close: the underlying connection is gone.
+        with pytest.raises(duckdb.Error):
+            queries.connection.sql("SELECT 1")
+
+    def test_close_is_idempotent(self, tmp_path):
+        """Calling close() more than once must not raise."""
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1,col2\n1,A\n2,B\n")
+        queries = DuckDBQueries(str(csv))
+
+        queries.close()
+        queries.close()  # second call must be a safe no-op

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -85,6 +85,27 @@ class TestCSVReader:
             df = reader.to_dataframe(normalize_columns=True)
             assert list(df.columns) == expected_columns
 
+    def test_query_data_normalize_columns_polars_and_pyarrow(self, tmp_path):
+        """query_data(normalize_columns=True) normalizes result columns on the
+        Polars and PyArrow engines.
+
+        Coverage test for review finding 7: only these two engines route
+        query_data through DuckDBQueries.sql_query_to_dataframe and its
+        _normalize_dataframe_columns helper. The DuckDB engine uses a different
+        projection path, so those lines previously had no test coverage.
+        """
+        csv_file = tmp_path / "people.csv"
+        csv_file.write_text("First Name,Last Name,Age Group\nJohn,Doe,30-40\nJane,Smith,20-30")
+        expected_columns = ["first_name", "last_name", "age_group"]
+
+        for engine in ("polars", "pyarrow"):
+            reader = CSVReader(str(csv_file), engine=engine)
+            result = reader.query_data(
+                f"SELECT * FROM {reader.db_table}", normalize_columns=True
+            )
+            assert isinstance(result, pl.DataFrame)
+            assert list(result.columns) == expected_columns
+
     def test_get_sample(self, sample_csv):
         """Test get_sample method returns a sample DataFrame."""
         for engine in ALL_ENGINES:


### PR DESCRIPTION
## Summary

Addresses code review findings 5–7 (all confirmed in the validation pass):

- **Finding 5 — resource disposal (MEDIUM):** Remove the unused `DuckDBDatabase` class. Its `__del__` was the only destructor in `src/` and the sole `.db`-file / GC-timing risk, and it became dead code once `DuckDBQueries` moved to a per-instance in-memory connection (findings 1–2). Add an explicit `DuckDBQueries.close()` for deterministic disposal — **no `__del__`** is reintroduced.
- **Finding 6 — typos (LOW):** Fix the package docstring import example (`datagrunt.csvfile` → `datagrunt`) and the `FileProperties.is_tsv` docstring ("tabular" → "TSV file").
- **Finding 7 — test gap (LOW):** Add a `query_data(normalize_columns=True)` test for the **Polars and PyArrow** engines, covering `DuckDBQueries.sql_query_to_dataframe` / `_normalize_dataframe_columns` (the DuckDB engine takes a different projection path, so those lines were uncovered).

## ⚠️ Breaking change

`DuckDBDatabase` is no longer exported from `datagrunt.core` (it was unused internally). Decide `[major]` vs. patch in the merge commit subject.

## Test plan

- [x] Full suite green: **214 passed**, ruff clean
- [x] `DuckDBQueries.close()` added test-first (RED → GREEN); idempotency covered
- [x] Confirmed the finding-7 test covers the previously-uncovered normalize helper/branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)