### PR TITLE
Add PDFWriter.write_markdown feature

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -35,6 +35,7 @@ class PDFEngineProperties:
     default_workers: int = 4
     json_export_filename: str = "output.json"
     json_newline_export_filename: str = "output.jsonl"
+    markdown_export_filename: str = "output.md"
     images_export_dir: str = "output_images"
     valid_engines: tuple = ("pymupdf", "pdfium")
     value_error_message: str = "Engine '{engine}' is not supported. Valid engines: {valid}."
@@ -239,6 +240,13 @@ class PDFBaseWriterEngine(ABC):
         pass
 
     @abstractmethod
+    def write_markdown(
+        self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False
+    ):
+        """Write the document Markdown representation to disk."""
+        pass
+
+    @abstractmethod
     def extract_images(self, output_dir=None, dedupe=True):
         """Write embedded images to disk; return their paths."""
         pass
@@ -283,6 +291,27 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
         with open(filename, "w") as f:
             for record in records:
                 f.write(json.dumps(record) + "\n")
+        return filename
+
+    def write_markdown(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
+        """Parse the PDF and write the document Markdown.
+
+        Args:
+            export_filename (optional, str): Output path; defaults to output.md.
+            image_output_dir (optional, str): If provided, embedded images are
+                written there and referenced in the Markdown.
+            dedupe_images (bool, default True): When images are written, collapse
+                byte-identical duplicates to a single file and repoint references.
+            drop_layout_tables (bool, default False): Drop 1xN / Nx1 "tables"
+                that are layout boxes rather than real tabular data.
+        """
+        filename = set_export_filename(self.properties.markdown_export_filename, export_filename)
+        document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
+        if image_output_dir and dedupe_images:
+            pdfcomponents.ParsedDocument(document).dedupe_images()
+        markdown_text = pdfcomponents.ParsedDocument(document).to_markdown()
+        with open(filename, "w") as f:
+            f.write(markdown_text)
         return filename
 
     def extract_images(self, output_dir=None, dedupe=True):
@@ -350,6 +379,20 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
         with open(filename, "w") as f:
             for record in records:
                 f.write(json.dumps(record) + "\n")
+        return filename
+
+    def write_markdown(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
+        """Parse the PDF and write the document Markdown (native or structured schema)."""
+        filename = set_export_filename(self.properties.markdown_export_filename, export_filename)
+        document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
+        if image_output_dir and dedupe_images:
+            self._dedupe(document)
+        if self.structured:
+            markdown_text = pdfcomponents.ParsedDocument(document).to_markdown()
+        else:
+            markdown_text = PdfiumNativeReader.to_markdown(document)
+        with open(filename, "w") as f:
+            f.write(markdown_text)
         return filename
 
     def extract_images(self, output_dir=None, dedupe=True):

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -175,3 +175,17 @@ class PdfiumNativeReader:
             lambda img: img.get("file"),
             lambda img, p: img.__setitem__("file", p),
         )
+
+    @staticmethod
+    def to_markdown(document: dict) -> str:
+        """Render native schema document into Markdown paragraphs."""
+        blocks = []
+        for page in document.get("document", {}).get("pages", []):
+            text = (page.get("text") or "").strip()
+            if not text:
+                continue
+            for para in text.split("\n\n"):
+                para = para.strip()
+                if para:
+                    blocks.append(para)
+        return "\n\n".join(blocks) + "\n"

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -208,6 +208,51 @@ class ParsedDocument:
             page["elements"] = kept
         return removed
 
+    def to_markdown(self) -> str:
+        """Render the unified structured elements of the document into Markdown."""
+        blocks = []
+        heading_map = {"header": "# ", "subheader": "## "}
+        for page in self.document.get("document", {}).get("pages", []):
+            elements = sorted(
+                page.get("elements", []),
+                key=lambda el: (el.get("position", {}).get("y", 0.0), el.get("position", {}).get("x", 0.0)),
+            )
+            for el in elements:
+                etype = el.get("type")
+                content = el.get("content")
+                meta = el.get("metadata") or {}
+                if etype in heading_map:
+                    blocks.append(f"{heading_map[etype]}{content}")
+                elif etype == "caption":
+                    blocks.append(f"*{content}*")
+                elif etype == "table":
+                    blocks.append(self._render_table(content, meta.get("has_header_row", False)))
+                elif etype == "image":
+                    path = meta.get("file_path") or ""
+                    blocks.append(f"![{Path(path).name or 'image'}]({path})")
+                elif isinstance(content, str) and content.strip():
+                    blocks.append(content)
+        return "\n\n".join(blocks) + "\n"
+
+    @staticmethod
+    def _render_table(content: list, has_header: bool) -> str:
+        if not content:
+            return ""
+        def cell_str(val):
+            text = "" if val is None else str(val)
+            return text.replace("\n", " ").replace("|", "\\|").strip()
+            
+        rows = [[cell_str(c) for c in row] for row in content]
+        width = max(len(r) for r in rows)
+        rows = [r + [""] * (width - len(r)) for r in rows]
+        if has_header:
+            header, body = rows[0], rows[1:]
+        else:
+            header, body = [""] * width, rows
+        lines = ["| " + " | ".join(header) + " |", "| " + " | ".join(["---"] * width) + " |"]
+        lines += ["| " + " | ".join(r) + " |" for r in body]
+        return "\n".join(lines)
+
 
 class PDFComponents(FileProperties):
     """A class that combines PDF components into a single interface."""

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -74,6 +74,27 @@ class PDFWriter(PDFComponents):
             export_filename, image_output_dir, dedupe_images, drop_layout_tables
         )
 
+    def write_markdown(
+        self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False
+    ):
+        """Parse the PDF and write a formatted Markdown file to disk.
+
+        Args:
+            export_filename (optional, str): Output path; defaults to output.md.
+            image_output_dir (optional, str): If provided, embedded images are
+                written there and referenced in the Markdown.
+            dedupe_images (bool, default True): When images are written, collapse
+                byte-identical duplicates to a single file and repoint references.
+            drop_layout_tables (bool, default False): Drop 1xN / Nx1 "tables"
+                that are layout boxes rather than real tabular data.
+
+        Returns:
+            str: The path of the written Markdown file.
+        """
+        return self._create_writer().write_markdown(
+            export_filename, image_output_dir, dedupe_images, drop_layout_tables
+        )
+
     def extract_images(self, output_dir=None, dedupe=True):
         """Parse the PDF and write embedded image files to disk.
 

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -112,3 +112,34 @@ class TestPDFWriter:
         )
         PDFWriter(sample_pdf).write_json(drop_layout_tables=True)
         assert calls == [True]
+
+    def test_write_markdown_default(self, sample_pdf, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        writer = PDFWriter(sample_pdf)
+        path = writer.write_markdown()
+        assert os.path.basename(path) == "output.md"
+        with open(path) as f:
+            content = f.read()
+        assert len(content) > 0
+
+    def test_write_markdown_custom_name_and_images(self, sample_pdf, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        img_dir = tmp_path / "imgs"
+        writer = PDFWriter(sample_pdf)
+        path = writer.write_markdown(
+            export_filename="report.md", image_output_dir=str(img_dir)
+        )
+        assert os.path.basename(path) == "report.md"
+        with open(path) as f:
+            content = f.read()
+        assert len(content) > 0
+        assert "report_page" in content
+
+    def test_write_markdown_pdfium_native(self, sample_pdf, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        writer = PDFWriter(sample_pdf, engine="pdfium", native=True)
+        path = writer.write_markdown()
+        assert os.path.basename(path) == "output.md"
+        with open(path) as f:
+            content = f.read()
+        assert len(content) > 0


### PR DESCRIPTION
Implement and expose write_markdown method in PDFWriter class to export PDFs directly to structured Markdown.