### PR TITLE
optimize: support direct json and dict inputs in PDFWriter and PDFReader

### DIFF
--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -286,12 +286,71 @@ class PDFComponents(FileProperties):
         """Initialize the PDFComponents object.
 
         Args:
-            filepath (str or Path): Path to the PDF file.
+            filepath (str, Path, or dict): Path to the PDF/JSON file, or parsed document dict.
         """
-        super().__init__(filepath)  # Parent class handles Path conversion
+        self._parsed_dict = None
+        if isinstance(filepath, dict):
+            self._parsed_dict = filepath
+            # Setup dummy FileProperties attributes
+            self.filepath = Path("in_memory.json")
+            self.filename = "in_memory.json"
+            self.extension = ".json"
+            self.extension_string = "json"
+            self.size_in_bytes = 0
+            self.size_in_kb = 0.0
+            self.size_in_mb = 0.0
+            self.size_in_gb = 0.0
+            self.size_in_tb = 0.0
+            self.is_structured = True
+            self.is_semi_structured = True
+            self.is_unstructured = False
+            self.is_standard = True
+            self.is_proprietary = False
+            self.is_csv = False
+            self.is_pdf = False
+            self.is_excel = False
+            self.is_apache = False
+            self.is_empty = False
+            self.is_blank = False
+            self.is_large = False
+            self.is_tabular = False
+            self.is_tsv = False
+        else:
+            filepath_path = Path(filepath)
+            if filepath_path.suffix.lower() == ".json":
+                with open(filepath_path, "r", encoding="utf-8") as f:
+                    self._parsed_dict = json.load(f)
+                self.filepath = filepath_path
+                self.filename = filepath_path.name
+                self.extension = filepath_path.suffix
+                self.extension_string = self.extension.replace(".", "")
+                self.size_in_bytes = filepath_path.stat().st_size
+                self.size_in_kb = round(self.size_in_bytes / 1000.0, 5)
+                self.size_in_mb = round(self.size_in_kb / 1000.0, 5)
+                self.size_in_gb = round(self.size_in_mb / 1000.0, 5)
+                self.size_in_tb = round(self.size_in_gb / 1000.0, 5)
+                self.is_structured = True
+                self.is_semi_structured = True
+                self.is_unstructured = False
+                self.is_standard = True
+                self.is_proprietary = False
+                self.is_csv = False
+                self.is_pdf = False
+                self.is_excel = False
+                self.is_apache = False
+                self.is_empty = self.size_in_bytes == 0
+                self.is_blank = self.size_in_bytes <= 100
+                self.is_large = False
+                self.is_tabular = False
+                self.is_tsv = False
+            else:
+                super().__init__(filepath_path)
 
     @cached_property
     def total_pages(self):
-        """Return the total number of pages in the PDF."""
+        """Return the total number of pages in the PDF/JSON."""
+        if self._parsed_dict is not None:
+            pages = self._parsed_dict.get("document", {}).get("pages", [])
+            return len(pages)
         with PdfiumDocument(self.filepath) as d:
             return len(d)

--- a/src/datagrunt/pdf_api/pdfreader.py
+++ b/src/datagrunt/pdf_api/pdfreader.py
@@ -9,6 +9,8 @@ import pyarrow as pa
 
 # local libraries
 from datagrunt.core import PDFComponents, PDFEngineFactory
+from datagrunt.core.pdf_io import pdfcomponents
+from datagrunt.core.pdf_io.extraction import PdfiumNativeReader
 
 
 class PDFReader(PDFComponents):
@@ -18,7 +20,7 @@ class PDFReader(PDFComponents):
         """Initialize the PDF Reader class.
 
         Args:
-            filepath (str or Path): Path to the PDF file to read.
+            filepath (str, Path, or dict): Path to the PDF/JSON file to read, or parsed document dict.
             engine (str, default 'pdfium'): Parsing engine to instantiate.
                 One of 'pdfium' (default -- permissive license; emits the unified
                 element schema by default, or the lean native schema when
@@ -30,7 +32,8 @@ class PDFReader(PDFComponents):
                 detection) instead of the default unified element schema. Ignored
                 by the pymupdf engine.
         """
-        filepath = Path(filepath)
+        if not isinstance(filepath, dict):
+            filepath = Path(filepath)
         super().__init__(filepath)
         self.engine = engine.lower().replace(" ", "")
         self.workers = workers
@@ -46,6 +49,9 @@ class PDFReader(PDFComponents):
 
     def get_sample(self):
         """Parse and return the first page of the PDF."""
+        if self._parsed_dict is not None:
+            pages = self._parsed_dict.get("document", {}).get("pages", [])
+            return pages[0] if pages else {}
         if self.is_empty:
             return self._return_empty_file_object({})
         return self._create_reader().get_sample()
@@ -63,6 +69,8 @@ class PDFReader(PDFComponents):
         Returns:
             dict: ``{"document": {... "pages": [...]}}``.
         """
+        if self._parsed_dict is not None:
+            return self._parsed_dict
         if self.is_empty:
             return self._return_empty_file_object({})
         return self._create_reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
@@ -77,6 +85,15 @@ class PDFReader(PDFComponents):
         Returns:
             A Polars DataFrame with one row per extracted element.
         """
+        if self._parsed_dict is not None:
+            is_structured = any("elements" in pg for pg in self._parsed_dict.get("document", {}).get("pages", []))
+            if is_structured:
+                records = pdfcomponents.ParsedDocument(self._parsed_dict).flatten()
+            else:
+                records = PdfiumNativeReader.flatten(self._parsed_dict)
+            if not records:
+                return pl.DataFrame()
+            return pl.DataFrame(records)
         if self.is_empty:
             return self._return_empty_file_object(pl.DataFrame())
         return self._create_reader().to_dataframe(drop_layout_tables=drop_layout_tables)
@@ -91,6 +108,15 @@ class PDFReader(PDFComponents):
         Returns:
             A PyArrow table with one row per extracted element.
         """
+        if self._parsed_dict is not None:
+            is_structured = any("elements" in pg for pg in self._parsed_dict.get("document", {}).get("pages", []))
+            if is_structured:
+                records = pdfcomponents.ParsedDocument(self._parsed_dict).flatten()
+            else:
+                records = PdfiumNativeReader.flatten(self._parsed_dict)
+            if not records:
+                return pa.Table.from_pydict({})
+            return pa.Table.from_pylist(records)
         if self.is_empty:
             return self._return_empty_file_object(pa.Table.from_pydict({}))
         return self._create_reader().to_arrow_table(drop_layout_tables=drop_layout_tables)

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -1,10 +1,13 @@
 """Module for writing parsed PDF output (JSON + image files)."""
 
 # standard library
+import json
 from pathlib import Path
 
 # local libraries
 from datagrunt.core import PDFComponents, PDFEngineFactory
+from datagrunt.core.pdf_io import pdfcomponents
+from datagrunt.core.pdf_io.extraction import PdfiumNativeReader
 
 
 class PDFWriter(PDFComponents):
@@ -14,7 +17,7 @@ class PDFWriter(PDFComponents):
         """Initialize the PDF Writer class.
 
         Args:
-            filepath (str or Path): Path to the PDF file to parse.
+            filepath (str, Path, or dict): Path to the PDF/JSON file to parse, or parsed document dict.
             engine (str, default 'pdfium'): Parsing engine to instantiate.
                 One of 'pdfium' (default -- permissive license; emits the unified
                 element schema by default, or the lean native schema when
@@ -26,7 +29,8 @@ class PDFWriter(PDFComponents):
                 detection) instead of the default unified element schema. Ignored
                 by the pymupdf engine.
         """
-        filepath = Path(filepath)
+        if not isinstance(filepath, dict):
+            filepath = Path(filepath)
         super().__init__(filepath)
         self.engine = engine.lower().replace(" ", "")
         self.workers = workers
@@ -51,6 +55,18 @@ class PDFWriter(PDFComponents):
         Returns:
             str: The path of the written JSON file.
         """
+        if self._parsed_dict is not None:
+            filename = export_filename if export_filename else "output.json"
+            document = self._parsed_dict
+            if image_output_dir and dedupe_images:
+                is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
+                if is_structured:
+                    pdfcomponents.ParsedDocument(document).dedupe_images()
+                else:
+                    PdfiumNativeReader.dedupe_images(document)
+            with open(filename, "w") as f:
+                json.dump(document, f, indent=2)
+            return filename
         return self._create_writer().write_json(export_filename, image_output_dir, dedupe_images, drop_layout_tables)
 
     def write_json_newline_delimited(
@@ -70,6 +86,25 @@ class PDFWriter(PDFComponents):
         Returns:
             str: The path of the written JSONL file.
         """
+        if self._parsed_dict is not None:
+            filename = export_filename if export_filename else "output.jsonl"
+            document = self._parsed_dict
+            if image_output_dir and dedupe_images:
+                is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
+                if is_structured:
+                    pdfcomponents.ParsedDocument(document).dedupe_images()
+                else:
+                    PdfiumNativeReader.dedupe_images(document)
+            
+            is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
+            if is_structured:
+                records = pdfcomponents.ParsedDocument(document).flatten()
+            else:
+                records = PdfiumNativeReader.flatten(document)
+            with open(filename, "w") as f:
+                for record in records:
+                    f.write(json.dumps(record) + "\n")
+            return filename
         return self._create_writer().write_json_newline_delimited(
             export_filename, image_output_dir, dedupe_images, drop_layout_tables
         )
@@ -91,6 +126,24 @@ class PDFWriter(PDFComponents):
         Returns:
             str: The path of the written Markdown file.
         """
+        if self._parsed_dict is not None:
+            filename = export_filename if export_filename else "output.md"
+            document = self._parsed_dict
+            if image_output_dir and dedupe_images:
+                is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
+                if is_structured:
+                    pdfcomponents.ParsedDocument(document).dedupe_images()
+                else:
+                    PdfiumNativeReader.dedupe_images(document)
+            
+            is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
+            if is_structured:
+                markdown_text = pdfcomponents.ParsedDocument(document).to_markdown(export_filename=filename)
+            else:
+                markdown_text = PdfiumNativeReader.to_markdown(document)
+            with open(filename, "w") as f:
+                f.write(markdown_text)
+            return filename
         return self._create_writer().write_markdown(
             export_filename, image_output_dir, dedupe_images, drop_layout_tables
         )
@@ -107,4 +160,28 @@ class PDFWriter(PDFComponents):
         Returns:
             list: Paths of the written image files.
         """
+        if self._parsed_dict is not None:
+            document = self._parsed_dict
+            is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
+            if dedupe:
+                if is_structured:
+                    pdfcomponents.ParsedDocument(document).dedupe_images()
+                else:
+                    PdfiumNativeReader.dedupe_images(document)
+            paths = []
+            seen = set()
+            for page in document.get("document", {}).get("pages", []):
+                if is_structured:
+                    candidates = [
+                        (el.get("metadata") or {}).get("file_path")
+                        for el in page.get("elements", [])
+                        if el.get("type") == "image"
+                    ]
+                else:
+                    candidates = [img.get("file") for img in page.get("images", [])]
+                for fp in candidates:
+                    if fp and fp not in seen:
+                        seen.add(fp)
+                        paths.append(fp)
+            return paths
         return self._create_writer().extract_images(output_dir, dedupe)

--- a/tests/pdf_api_tests/test_pdfreader.py
+++ b/tests/pdf_api_tests/test_pdfreader.py
@@ -223,3 +223,68 @@ class TestPDFReaderMultiprocessing:
         assert doc["document"]["total_pages"] == 3
         assert len(calls) > 0
 
+
+class TestPDFReaderJsonAndDictInputs:
+    """Tests for initializing PDFReader with JSON files or dictionaries."""
+
+    @pytest.fixture
+    def dummy_structured_dict(self):
+        return {
+            "document": {
+                "source": "dummy.pdf",
+                "total_pages": 1,
+                "pages": [
+                    {
+                        "page_number": 1,
+                        "width": 100.0,
+                        "height": 100.0,
+                        "elements": [
+                            {"id": "el1", "type": "header", "content": "Header Text", "position": {"x": 10, "y": 10, "w": 80, "h": 10}},
+                            {"id": "el2", "type": "body_text", "content": "Hello body", "position": {"x": 10, "y": 30, "w": 80, "h": 10}},
+                        ]
+                    }
+                ]
+            }
+        }
+
+    def test_reader_with_dict(self, dummy_structured_dict):
+        reader = PDFReader(dummy_structured_dict)
+        assert reader._parsed_dict == dummy_structured_dict
+        assert reader.total_pages == 1
+        
+        # Test to_dicts
+        assert reader.to_dicts() == dummy_structured_dict
+        
+        # Test get_sample
+        sample = reader.get_sample()
+        assert sample["page_number"] == 1
+        assert "elements" in sample
+
+        # Test to_dataframe
+        df = reader.to_dataframe()
+        assert isinstance(df, pl.DataFrame)
+        assert df.height == 2
+        assert list(df["content"]) == ["Header Text", "Hello body"]
+
+        # Test to_arrow_table
+        table = reader.to_arrow_table()
+        assert isinstance(table, pa.Table)
+        assert table.num_rows == 2
+
+    def test_reader_with_json_file(self, tmp_path, dummy_structured_dict):
+        import json
+        json_file = tmp_path / "doc.json"
+        with open(json_file, "w") as f:
+            json.dump(dummy_structured_dict, f)
+
+        reader = PDFReader(str(json_file))
+        assert reader._parsed_dict == dummy_structured_dict
+        assert reader.total_pages == 1
+        assert reader.to_dicts() == dummy_structured_dict
+
+        # Test to_dataframe
+        df = reader.to_dataframe()
+        assert df.height == 2
+        assert list(df["content"]) == ["Header Text", "Hello body"]
+
+

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import pytest
 
 from datagrunt.pdf_api.pdfwriter import PDFWriter
 
@@ -143,3 +144,81 @@ class TestPDFWriter:
         with open(path) as f:
             content = f.read()
         assert len(content) > 0
+
+
+class TestPDFWriterJsonAndDictInputs:
+    """Tests for initializing PDFWriter with JSON files or dictionaries."""
+
+    @pytest.fixture
+    def dummy_structured_dict(self):
+        return {
+            "document": {
+                "source": "dummy.pdf",
+                "total_pages": 1,
+                "pages": [
+                    {
+                        "page_number": 1,
+                        "width": 100.0,
+                        "height": 100.0,
+                        "elements": [
+                            {"id": "el1", "type": "header", "content": "Header Text", "position": {"x": 10, "y": 10, "w": 80, "h": 10}},
+                            {"id": "el2", "type": "body_text", "content": "Hello body", "position": {"x": 10, "y": 30, "w": 80, "h": 10}},
+                            {"id": "el3", "type": "image", "content": None, "position": {"x": 10, "y": 50, "w": 80, "h": 10}, "metadata": {"file_path": "/dummy/img.png"}},
+                        ]
+                    }
+                ]
+            }
+        }
+
+    def test_writer_with_dict(self, dummy_structured_dict, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        writer = PDFWriter(dummy_structured_dict)
+        assert writer._parsed_dict == dummy_structured_dict
+        assert writer.total_pages == 1
+
+        # Test write_json
+        jpath = writer.write_json("test_out.json")
+        assert os.path.exists(jpath)
+        with open(jpath) as f:
+            data = json.load(f)
+        assert data["document"]["source"] == "dummy.pdf"
+
+        # Test write_json_newline_delimited
+        jlpath = writer.write_json_newline_delimited("test_out.jsonl")
+        assert os.path.exists(jlpath)
+        with open(jlpath) as f:
+            lines = f.readlines()
+        assert len(lines) == 3
+
+        # Test write_markdown
+        mdpath = writer.write_markdown("test_out.md")
+        assert os.path.exists(mdpath)
+        with open(mdpath) as f:
+            content = f.read()
+        assert "# Header Text" in content
+        assert "Hello body" in content
+        assert "![img.png]" in content
+        assert "dummy/img.png" in content
+
+        # Test extract_images
+        img_paths = writer.extract_images()
+        assert img_paths == ["/dummy/img.png"]
+
+    def test_writer_with_json_file(self, tmp_path, dummy_structured_dict, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        json_file = tmp_path / "doc.json"
+        with open(json_file, "w") as f:
+            json.dump(dummy_structured_dict, f)
+
+        writer = PDFWriter(str(json_file))
+        assert writer._parsed_dict == dummy_structured_dict
+        assert writer.total_pages == 1
+
+        # Test write_markdown
+        mdpath = writer.write_markdown("test_out_json.md")
+        assert os.path.exists(mdpath)
+        with open(mdpath) as f:
+            content = f.read()
+        assert "# Header Text" in content
+        assert "Hello body" in content
+


### PR DESCRIPTION
Allows PDFWriter and PDFReader to accept pre-parsed JSON dicts or .json file paths directly in their constructor. This avoids double-parsing the PDF when exporting both JSON and Markdown/DataFrame representations.