### PR TITLE
fix: quote detection in DuckDBQueries

### DIFF
--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -13,6 +13,7 @@ import duckdb
 from datagrunt.core.csv_io import (
     CSVColumnNameNormalizer,
     CSVDelimiter,
+    CSVDialect,
     _check_csv_ragged_and_warn,
     _count_leading_comments,
 )
@@ -45,6 +46,14 @@ class DuckDBQueries:
     def delimiter(self):
         """Get the delimiter."""
         return CSVDelimiter(self.filepath).delimiter
+
+    @cached_property
+    def quotechar(self):
+        """Get the quote character."""
+        try:
+            return CSVDialect(self.filepath).quotechar
+        except Exception:
+            return '"'
 
     def close(self):
         """Close this instance's DuckDB connection.
@@ -113,6 +122,7 @@ class DuckDBQueries:
                                 delim='{self.delimiter}',
                                 header=true,
                                 columns={cols_param},
+                                quote='{self.quotechar.replace("'", "''")}',
                                 null_padding=true,
                                 all_varchar=True,
                                 auto_detect=false,
@@ -127,6 +137,7 @@ class DuckDBQueries:
                                 auto_detect=true,
                                 delim='{self.delimiter}',
                                 header=true,
+                                quote='{self.quotechar.replace("'", "''")}',
                                 null_padding=true,
                                 all_varchar=True,
                                 strict_mode=true,
@@ -153,6 +164,7 @@ class DuckDBQueries:
                                 delim='{self.delimiter}',
                                 header=true,
                                 columns={cols_param},
+                                quote='{self.quotechar.replace("'", "''")}',
                                 null_padding=true,
                                 all_varchar=True,
                                 auto_detect=false,
@@ -168,6 +180,7 @@ class DuckDBQueries:
                                 auto_detect=true,
                                 delim='{self.delimiter}',
                                 header=true,
+                                quote='{self.quotechar.replace("'", "''")}',
                                 null_padding=true,
                                 all_varchar=True,
                                 strict_mode=true,

--- a/tests/core_tests/databases_tests/test_databases.py
+++ b/tests/core_tests/databases_tests/test_databases.py
@@ -37,3 +37,27 @@ class TestDuckDBQueriesClose:
 
         queries.close()
         queries.close()  # second call must be a safe no-op
+
+
+def test_csv_quotes_after_sniffer_sample(tmp_path):
+    csv_file = tmp_path / "delayed_quotes.csv"
+    # 5 rows without quotes, 6th row has a quoted field with a comma
+    content = (
+        "col1,col2,col3\n"
+        "1,2,3\n"
+        "4,5,6\n"
+        "7,8,9\n"
+        "10,11,12\n"
+        '13,"hello, world",15\n'
+    )
+    csv_file.write_text(content)
+
+    # This should parse successfully without raising column count/parsing errors
+    queries = DuckDBQueries(str(csv_file))
+    queries.connection.execute(queries.import_csv_query())
+    res = queries.connection.execute(queries.select_from_duckdb_table()).fetchall()
+    assert len(res) == 5
+    # The 5th row's second column should be "hello, world"
+    assert res[4][1] == "hello, world"
+    queries.close()
+


### PR DESCRIPTION
Explicitly pass CSV quote character to DuckDB read_csv queries to prevent auto-detect failures on large CSV files.