### PR TITLE
feat(pdf): default to sequential execution (workers=1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,12 @@ Datagrunt is not an extension of or a replacement for DuckDB, Polars, or PyArrow
 
 ## Installation
 
-We recommend using [UV](https://docs.astral.sh/uv/). However, you may get started with Datagrunt in seconds using UV or pip.
+We recommend using [uv](https://docs.astral.sh/uv/) as the default package manager.
 
-Get started with UV:
+To install Datagrunt using `uv`:
 
 ```bash
 uv pip install datagrunt
-```
-
-Get started with pip:
-
-```bash
-pip install datagrunt
 ```
 
 > **PDF parsing** is an optional extra — install it with `uv pip install "datagrunt[pdf]"`. See [PDF parsing](#pdf-parsing) below for details and OCR setup.
@@ -153,8 +147,6 @@ PDF support is an optional extra:
 
 ```bash
 uv pip install "datagrunt[pdf]"
-# or
-pip install "datagrunt[pdf]"
 ```
 
 OCR of scanned pages additionally requires the **Tesseract** system binary
@@ -209,12 +201,20 @@ on either engine.
   both engines (requires the Tesseract binary; see above).
 
 ### Parallel Processing & Concurrency
-`PDFReader` supports parallel processing on multi-core systems via the `workers` parameter (default: `4`):
+By default, `PDFReader` and `PDFWriter` run sequentially (`workers=1`). You can enable parallel processing on multi-core systems by passing a `workers` count greater than `1`:
 ```python
-# Run with 8 processes to parse pages concurrently
-reader = PDFReader("report.pdf", workers=8)
+if __name__ == '__main__':
+    # Run with 8 processes to parse pages concurrently
+    reader = PDFReader("report.pdf", workers=8)
+    document = reader.to_dicts()
 ```
-Because PDFium is not thread-safe within a single process, `datagrunt` uses a process pool (`ProcessPoolExecutor`) to bypass the Global Interpreter Lock (GIL) and run page-parsing concurrently for multi-page documents, running **~3x faster** than PyMuPDF's thread pool. For single-page documents, it automatically bypasses the process pool and executes sequentially to avoid process spawning overhead.
+
+#### Why `if __name__ == '__main__':` is required
+Because PDFium is not thread-safe within a single process, `datagrunt` uses a process pool (`ProcessPoolExecutor` with the `spawn` start context on macOS and Windows) to parse pages concurrently.
+
+Under Python's `spawn` start context, child processes import the main module to initialize. If you call `PDFReader` or `PDFWriter` with `workers > 1` outside of a `if __name__ == '__main__':` block, the child processes will recursively spawn their own process pools, leading to a crash or infinite recursion loop.
+
+For single-page documents, `datagrunt` automatically bypasses the process pool and executes sequentially to avoid process spawning overhead.
 
 #### Distributed Runtimes Fallback
 When running inside managed distributed environments (e.g. **Apache Spark**, **Apache Beam**, **Apache Flink**, or **Celery**), nested process spawning is restricted or causes container sandbox permission errors. `datagrunt` automatically detects these environments (by checking variables like `SPARK_ENV_LOADED`, `BEAM_WORKER_ID`, etc.) and falls back to sequential, parent-process execution to ensure robust, conflict-free operation.

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -72,7 +72,7 @@ class PDFEngineProperties:
     """Base properties for PDF operations."""
 
     filepath: Path
-    default_workers: int = 4
+    default_workers: int = 1
     json_export_filename: str = "output.json"
     json_newline_export_filename: str = "output.jsonl"
     markdown_export_filename: str = "output.md"
@@ -84,7 +84,7 @@ class PDFEngineProperties:
 class PDFBaseReaderEngine(ABC):
     """Abstract base class defining the interface for PDF reader engines."""
 
-    def __init__(self, filepath, workers: int = 4):
+    def __init__(self, filepath, workers: int = 1):
         """Initialize the PDF reader engine.
 
         Args:
@@ -179,7 +179,7 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
     process.
     """
 
-    def __init__(self, filepath, workers: int = 4, structured: bool = False):
+    def __init__(self, filepath, workers: int = 1, structured: bool = False):
         super().__init__(filepath, workers=workers)
         self.structured = structured
 
@@ -304,7 +304,7 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
 class PDFBaseWriterEngine(ABC):
     """Abstract base class defining the interface for PDF writer engines."""
 
-    def __init__(self, filepath, workers: int = 4):
+    def __init__(self, filepath, workers: int = 1):
         """Initialize the PDF writer engine.
 
         Args:
@@ -431,7 +431,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
 class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
     """Write parsed PDFium output. Native schema by default; unified when structured."""
 
-    def __init__(self, filepath, workers: int = 4, structured: bool = False):
+    def __init__(self, filepath, workers: int = 1, structured: bool = False):
         super().__init__(filepath, workers=workers)
         self.structured = structured
 

--- a/src/datagrunt/core/pdf_io/factories.py
+++ b/src/datagrunt/core/pdf_io/factories.py
@@ -26,7 +26,7 @@ class PDFEngineFactory:
         "pdfium": PDFWriterPdfiumEngine,
     }
 
-    def __init__(self, filepath, engine, workers: int = 4, structured: bool = False):
+    def __init__(self, filepath, engine, workers: int = 1, structured: bool = False):
         """Initialize the PDF Engine Factory class.
 
         Args:

--- a/src/datagrunt/pdf_api/pdfreader.py
+++ b/src/datagrunt/pdf_api/pdfreader.py
@@ -16,7 +16,7 @@ from datagrunt.core.pdf_io.extraction import PdfiumNativeReader
 class PDFReader(PDFComponents):
     """Class to unify the interface for reading and parsing PDF files."""
 
-    def __init__(self, filepath, engine="pdfium", workers=4, native=False):
+    def __init__(self, filepath, engine="pdfium", workers=1, native=False):
         """Initialize the PDF Reader class.
 
         Args:
@@ -26,7 +26,7 @@ class PDFReader(PDFComponents):
                 element schema by default, or the lean native schema when
                 ``native=True``) or 'pymupdf' (unified element schema, tables +
                 OCR).
-            workers (int, default 4): Number of concurrent per-page workers.
+            workers (int, default 1): Number of concurrent per-page workers.
             native (bool, default False): pdfium only -- when True, emit the lean
                 native schema (text, positioned text objects, images; no table
                 detection) instead of the default unified element schema. Ignored

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -13,7 +13,7 @@ from datagrunt.core.pdf_io.extraction import PdfiumNativeReader
 class PDFWriter(PDFComponents):
     """Class to unify the interface for writing parsed PDF output."""
 
-    def __init__(self, filepath, engine="pdfium", workers=4, native=False):
+    def __init__(self, filepath, engine="pdfium", workers=1, native=False):
         """Initialize the PDF Writer class.
 
         Args:
@@ -23,7 +23,7 @@ class PDFWriter(PDFComponents):
                 element schema by default, or the lean native schema when
                 ``native=True``) or 'pymupdf' (unified element schema, tables +
                 OCR).
-            workers (int, default 4): Number of concurrent per-page workers.
+            workers (int, default 1): Number of concurrent per-page workers.
             native (bool, default False): pdfium only -- when True, emit the lean
                 native schema (text, positioned text objects, images; no table
                 detection) instead of the default unified element schema. Ignored


### PR DESCRIPTION
This pull request defaults the worker count for PDF readers and writers to 1 to run sequentially by default. This allows guard-free simple scripts without requiring multiprocessing if __name__ == '__main__' entry guards, while keeping multiprocessing opt-in.