### PR TITLE
fix(pdf): order native-schema text bbox top-down to match image bbox

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -74,7 +74,7 @@ class PdfiumNativeReader:
 
     def _text_object(self, item) -> dict:
         """Convert a TextItem to the native text-object dict."""
-        bbox = [item.x0, round(item.y_bot, 2), item.x1, round(item.y_top, 2)]
+        bbox = [item.x0, round(item.y_top, 2), item.x1, round(item.y_bot, 2)]
         return {
             "text": item.text,
             "bbox": bbox,

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
@@ -30,6 +30,26 @@ class TestPdfiumNativeReader:
             "page", "type", "text", "font_size", "x", "y", "w", "h", "bbox", "file", "px_width", "px_height", "ocr"
         }
 
+    def test_text_bbox_top_down_and_consistent_with_image(self, sample_pdf, tmp_path):
+        """Native text bbox is top-down (y0 <= y1), matching image bbox and position."""
+        page = PdfiumNativeReader(sample_pdf).parse_page(0, image_output_dir=str(tmp_path))
+
+        for obj in page["text_objects"]:
+            x0, y0, x1, y1 = obj["bbox"]
+            pos = obj["position"]
+            # Top-down ascending convention: y0 (top) <= y1 (bottom).
+            assert y0 <= y1, f"text bbox y order descending: {obj['bbox']}"
+            # bbox top must equal the position's y (top edge).
+            assert y0 == pos["y"]
+            # position height is positive (top-down) and matches bbox span.
+            assert pos["h"] > 0
+            assert round(y1 - y0, 2) == round(pos["h"], 2)
+
+        # Same page's image bbox follows the same ascending convention.
+        for img in page["images"]:
+            ix0, iy0, ix1, iy1 = img["bbox"]
+            assert iy0 <= iy1, f"image bbox y order descending: {img['bbox']}"
+
     def test_dedupe_images(self, tmp_path):
         a, b = tmp_path / "a.png", tmp_path / "b.png"
         a.write_bytes(b"X")


### PR DESCRIPTION
Closes #94. 

- fix(pdf): order native-schema text bbox top-down to match image bbox

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)