### PR TITLE
fix(pdf): normalize CRLF before paragraph splitting in native markdown

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -184,6 +184,9 @@ class PdfiumNativeReader:
             text = (page.get("text") or "").strip()
             if not text:
                 continue
+            # pdfium emits \r\n line endings; normalize before splitting so
+            # paragraph breaks match and no raw \r leaks into the Markdown.
+            text = text.replace("\r\n", "\n").replace("\r", "\n")
             for para in text.split("\n\n"):
                 para = para.strip()
                 if para:

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
@@ -30,6 +30,20 @@ class TestPdfiumNativeReader:
             "page", "type", "text", "font_size", "x", "y", "w", "h", "bbox", "file", "px_width", "px_height", "ocr"
         }
 
+    def test_to_markdown_normalizes_crlf(self):
+        # pdfium emits \r\n line endings; markdown must not leak \r and must
+        # split paragraphs on blank lines (\r\n\r\n).
+        doc = {
+            "document": {
+                "pages": [
+                    {"text": "Page 1 line one\r\nstill para one\r\n\r\nPage 1 paragraph two"}
+                ]
+            }
+        }
+        markdown = PdfiumNativeReader.to_markdown(doc)
+        assert "\r" not in markdown
+        assert markdown == "Page 1 line one\nstill para one\n\nPage 1 paragraph two\n"
+
     def test_dedupe_images(self, tmp_path):
         a, b = tmp_path / "a.png", tmp_path / "b.png"
         a.write_bytes(b"X")


### PR DESCRIPTION
Closes #100. 

- fix(pdf): normalize CRLF before paragraph splitting in native markdown

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)