### PR TITLE
fix(pdf): classify pure-text pages as text_only, not mixed

### DIFF
--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -86,7 +86,7 @@ class DocumentAssembler:
             classification = "mixed"
             if analysis.is_scanned:
                 classification = "scanned"
-            elif analysis.has_text_layer and len(elements) == 0:
+            elif analysis.has_text_layer and analysis.image_count == 0 and not tables:
                 classification = "text_only"
 
             return {

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -1,7 +1,67 @@
 """Tests for PDF component assembly."""
 
+import pytest
 
 from datagrunt.core.pdf_io import pdfcomponents
+
+
+@pytest.fixture
+def text_only_pdf(tmp_path):
+    """Create a one-page PDF with native text and no images or tables."""
+    import pymupdf
+
+    doc = pymupdf.open()
+    page = doc.new_page(width=612, height=792)  # US Letter
+    page.insert_text((72, 72), "Quarterly Report", fontsize=24)  # header (large)
+    page.insert_text((72, 120), "This is body text for testing.", fontsize=11)
+    page.insert_text((72, 140), "Body line two for the report.", fontsize=11)
+    page.insert_text((72, 160), "Body line three with details.", fontsize=11)
+    page.insert_text((72, 180), "Body line four wraps up the text.", fontsize=11)
+    pdf_path = tmp_path / "text_only.pdf"
+    doc.save(str(pdf_path))
+    doc.close()
+    return str(pdf_path)
+
+
+def _pdfium_backend(filepath):
+    from datagrunt.core.pdf_io.extraction import PdfiumBackend
+
+    return PdfiumBackend(filepath)
+
+
+def _pymupdf_backend(filepath):
+    from datagrunt.core.pdf_io.extraction import PyMuPDFBackend
+
+    return PyMuPDFBackend(filepath)
+
+
+class TestPageClassification:
+    """Page ``classification`` reflects the element makeup of the page (issue #97)."""
+
+    @pytest.mark.parametrize("make_backend", [_pymupdf_backend, _pdfium_backend])
+    def test_text_only_page_classified_text_only(self, text_only_pdf, make_backend):
+        from datagrunt.core.pdf_io.pdfcomponents import DocumentAssembler
+
+        page = DocumentAssembler(
+            text_only_pdf, backend=make_backend(text_only_pdf)
+        ).parse_page(0)
+
+        types = {el["type"] for el in page["elements"]}
+        assert "image" not in types
+        assert "table" not in types
+        assert page["classification"] == "text_only"
+
+    @pytest.mark.parametrize("make_backend", [_pymupdf_backend, _pdfium_backend])
+    def test_page_with_image_classified_mixed(self, sample_pdf, make_backend):
+        from datagrunt.core.pdf_io.pdfcomponents import DocumentAssembler
+
+        page = DocumentAssembler(
+            sample_pdf, backend=make_backend(sample_pdf)
+        ).parse_page(0)
+
+        types = {el["type"] for el in page["elements"]}
+        assert "image" in types
+        assert page["classification"] == "mixed"
 
 
 class TestParsePage:


### PR DESCRIPTION
Closes #97. 

- fix(pdf): classify pure-text pages as text_only, not mixed

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)