### PR TITLE
fix(csv): guard get_sample against empty and blank files

### DIFF
--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -50,6 +50,8 @@ class CSVReader(CSVComponents):
         Returns:
             A Polars DataFrame containing the sample rows.
         """
+        if self.is_empty or self.is_blank:
+            return self._return_empty_file_object(pl.DataFrame())
         return self._create_reader().get_sample(normalize_columns)
 
     def to_dataframe(self, normalize_columns=False):

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -225,6 +225,33 @@ class TestCSVReader:
         df2 = reader_empty.to_dataframe()
         assert df1 is not df2
 
+    def test_get_sample_empty_and_blank_files(self, tmp_path):
+        """get_sample must return an empty DataFrame for empty and blank files.
+
+        Regression test for issue #86: get_sample lacked the empty/blank guard
+        the other read methods have, so it crashed or fabricated phantom
+        columns divergently per engine on empty or whitespace-only files.
+        """
+        # Test empty file (0 bytes)
+        empty_file = tmp_path / "empty.csv"
+        empty_file.write_text("")
+
+        for engine in ALL_ENGINES:
+            reader_empty = CSVReader(str(empty_file), engine=engine)
+            sample_empty = reader_empty.get_sample()
+            assert isinstance(sample_empty, pl.DataFrame)
+            assert sample_empty.shape == (0, 0)
+
+        # Test blank file (only whitespace and newlines)
+        blank_file = tmp_path / "blank.csv"
+        blank_file.write_text("\n   \n  \n")
+
+        for engine in ALL_ENGINES:
+            reader_blank = CSVReader(str(blank_file), engine=engine)
+            sample_blank = reader_blank.get_sample()
+            assert isinstance(sample_blank, pl.DataFrame)
+            assert sample_blank.shape == (0, 0)
+
     def test_query_data_empty_and_blank_files(self, tmp_path):
         """Test query_data method for empty and blank files."""
         # Test empty file (0 bytes)


### PR DESCRIPTION
Closes #86. 

- fix(csv): guard get_sample against empty and blank files

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)