### PR TITLE
fix(pdf): count pages with the pymupdf backend, not pdfium

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -17,7 +17,7 @@ import pyarrow as pa
 
 # local libraries
 from datagrunt.core.pdf_io import pdfcomponents
-from datagrunt.core.pdf_io.extraction import PdfiumBackend, PdfiumNativeReader
+from datagrunt.core.pdf_io.extraction import PdfiumBackend, PdfiumNativeReader, PyMuPDFBackend
 from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
 
 logger = logging.getLogger(__name__)
@@ -121,8 +121,10 @@ class PDFReaderPyMuPDFEngine(PDFBaseReaderEngine):
     """Read and parse PDF files using PyMuPDF / pdfplumber / Tesseract."""
 
     def _total_pages(self) -> int:
-        with PdfiumDocument(self.filepath) as doc:
-            return len(doc)
+        # Count pages with the engine's own backend so the pymupdf path has no
+        # pdfium dependency; pdfium cannot load zero-page PDFs that pymupdf
+        # handles fine (see issue #95).
+        return PyMuPDFBackend(self.filepath).page_count()
 
     def to_dicts(self, image_output_dir: Optional[str] = None, drop_layout_tables: bool = False) -> dict:
         """Parse all pages concurrently into the unified document dict."""

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -145,8 +145,12 @@ class PDFReaderPyMuPDFEngine(PDFBaseReaderEngine):
                 self.workers,
             )
         assembler = pdfcomponents.DocumentAssembler(self.filepath)
-        total_pages = self._total_pages()
-        document = assembler.parse_document(total_pages, image_output_dir)
+        # Count pages inside the held-open backend context so the count reuses
+        # the same pymupdf document handle as the parse — one open per parse
+        # (issue #102) with no pdfium dependency for the count (issue #95).
+        with assembler.backend:
+            total_pages = assembler.backend.page_count()
+            document = assembler.parse_document(total_pages, image_output_dir)
         if drop_layout_tables:
             pdfcomponents.ParsedDocument(document).drop_layout_tables()
         return document

--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -45,6 +45,15 @@ class PyMuPDFBackend(ExtractionBackend):
         pymupdf = _import_pymupdf()
         return pymupdf.open(self.filepath), True
 
+    def page_count(self) -> int:
+        """Return the document's page count using pymupdf (no pdfium dependency)."""
+        doc, should_close = self._get_doc()
+        try:
+            return doc.page_count
+        finally:
+            if should_close:
+                doc.close()
+
     def analyze_page(self, page_number: int) -> PageAnalysis:
         """Return page metadata; raises ValueError on failure/out-of-range."""
         doc, should_close = self._get_doc()

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -11,7 +11,6 @@ from datagrunt.core.file_io import FileProperties
 from datagrunt.core.pdf_io.extraction import PdfPlumberTableExtractor
 from datagrunt.core.pdf_io.extraction.image_dedupe import dedupe_image_files
 from datagrunt.core.pdf_io.extraction.ocr import dpi_for_page
-from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
 from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
 from datagrunt.core.pdf_io.extraction.layout_sorter import PageLayoutSorter, ElementAdapter
 
@@ -352,5 +351,8 @@ class PDFComponents(FileProperties):
         if self._parsed_dict is not None:
             pages = self._parsed_dict.get("document", {}).get("pages", [])
             return len(pages)
-        with PdfiumDocument(self.filepath) as d:
-            return len(d)
+        # Count pages with the pymupdf backend rather than pdfium: pdfium cannot
+        # load zero-page PDFs that pymupdf handles fine, and pymupdf reports the
+        # same count for valid PDFs, so the pdfium engine path stays correct
+        # while page counting no longer depends on pdfium (see issue #95).
+        return PyMuPDFBackend(self.filepath).page_count()

--- a/tests/core_tests/pdf_io_tests/test_engines.py
+++ b/tests/core_tests/pdf_io_tests/test_engines.py
@@ -67,6 +67,32 @@ class TestPDFReaderEngine:
         assert isinstance(table, pa.Table)
         assert table.num_rows >= 2
 
+    @staticmethod
+    def _zero_page_pdf(tmp_path):
+        """Write a valid zero-page PDF that pymupdf opens but pdfium cannot."""
+        import io
+
+        import pypdfium2 as pdfium
+
+        doc = pdfium.PdfDocument.new()
+        buf = io.BytesIO()
+        doc.save(buf)
+        path = tmp_path / "zero_page.pdf"
+        path.write_bytes(buf.getvalue())
+        return path
+
+    def test_zero_page_pdf_parses_cleanly(self, tmp_path):
+        """A zero-page PDF must parse on the pymupdf engine, not raise PdfiumError.
+
+        pymupdf opens zero-page PDFs (page_count == 0), but pdfium refuses to
+        load them at all. Counting pages with the engine's own backend keeps the
+        pymupdf path off pdfium so it returns an empty document instead of
+        inheriting pdfium's stricter failure surface (see issue #95).
+        """
+        pdf = self._zero_page_pdf(tmp_path)
+        doc = PDFReaderPyMuPDFEngine(pdf).to_dicts()
+        assert doc["document"]["total_pages"] == 0
+        assert doc["document"]["pages"] == []
 
 
 class TestPDFWriterEngine:

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -57,6 +57,25 @@ class TestPDFComponents:
         assert comp.is_pdf
         assert comp.total_pages == 1
 
+    def test_total_pages_zero_page_pdf(self, tmp_path):
+        """total_pages must report 0 for a zero-page PDF, not raise PdfiumError.
+
+        Counting via the pymupdf backend keeps page counting off pdfium, which
+        cannot load zero-page PDFs at all (see issue #95).
+        """
+        import io
+
+        import pypdfium2 as pdfium
+
+        doc = pdfium.PdfDocument.new()
+        buf = io.BytesIO()
+        doc.save(buf)
+        path = tmp_path / "zero_page.pdf"
+        path.write_bytes(buf.getvalue())
+
+        comp = pdfcomponents.PDFComponents(path)
+        assert comp.total_pages == 0
+
 
 class TestDedupeImages:
     """Test suite for ParsedDocument.dedupe_images."""


### PR DESCRIPTION
Closes #95. 

- fix(pdf): count pages with the pymupdf backend, not pdfium

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)