### PR TITLE
fix(pdf): guard PDFWriter methods against empty (0-byte) PDFs

### DIFF
--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -40,6 +40,18 @@ class PDFWriter(PDFComponents):
         """Create a writer engine instance."""
         return PDFEngineFactory(self.filepath, self.engine, self.workers, structured=not self.native).create_writer()
 
+    @staticmethod
+    def _write_empty_file(filename, content=""):
+        """Write ``content`` (default empty) to ``filename`` and return the path.
+
+        Used to mirror the reader's empty-document handling: a 0-byte PDF yields
+        an empty/minimal output file instead of leaking a raw PdfiumError from
+        the engine.
+        """
+        with open(filename, "w") as f:
+            f.write(content)
+        return filename
+
     def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
         """Parse the PDF and write the unified document JSON to disk.
 
@@ -67,6 +79,10 @@ class PDFWriter(PDFComponents):
             with open(filename, "w") as f:
                 json.dump(document, f, indent=2)
             return filename
+        # Mirror PDFReader's is_empty handling: a 0-byte PDF produces an empty
+        # document ({}) rather than a raw PdfiumError from loading the file.
+        if self.is_empty:
+            return self._write_empty_file(export_filename or "output.json", json.dumps({}))
         return self._create_writer().write_json(export_filename, image_output_dir, dedupe_images, drop_layout_tables)
 
     def write_json_newline_delimited(
@@ -105,6 +121,10 @@ class PDFWriter(PDFComponents):
                 for record in records:
                     f.write(json.dumps(record) + "\n")
             return filename
+        # Mirror PDFReader's is_empty handling: a 0-byte PDF has no elements, so
+        # the JSONL output is an empty file rather than a raw PdfiumError.
+        if self.is_empty:
+            return self._write_empty_file(export_filename or "output.jsonl")
         return self._create_writer().write_json_newline_delimited(
             export_filename, image_output_dir, dedupe_images, drop_layout_tables
         )
@@ -144,6 +164,10 @@ class PDFWriter(PDFComponents):
             with open(filename, "w") as f:
                 f.write(markdown_text)
             return filename
+        # Mirror PDFReader's is_empty handling: a 0-byte PDF has no content, so
+        # the Markdown output is an empty file rather than a raw PdfiumError.
+        if self.is_empty:
+            return self._write_empty_file(export_filename or "output.md")
         return self._create_writer().write_markdown(
             export_filename, image_output_dir, dedupe_images, drop_layout_tables
         )
@@ -184,4 +208,7 @@ class PDFWriter(PDFComponents):
                         seen.add(fp)
                         paths.append(fp)
             return paths
+        # Mirror PDFReader's is_empty handling: a 0-byte PDF has no images.
+        if self.is_empty:
+            return []
         return self._create_writer().extract_images(output_dir, dedupe)

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -146,6 +146,56 @@ class TestPDFWriter:
         assert len(content) > 0
 
 
+class TestPDFWriterEmptyPdf:
+    """Empty (0-byte) PDFs must not surface a raw PdfiumError.
+
+    The reader (PDFReader) guards 0-byte files with ``is_empty`` and returns
+    empty objects rather than raising; the writer must behave consistently so
+    callers get an empty output file (or a clear ValueError), never a confusing
+    ``pypdfium2.PdfiumError`` leaking from deep inside the engine.
+    """
+
+    def _assert_not_pdfium_error(self, callable_):
+        """Run ``callable_``; fail if it raises a raw PdfiumError."""
+        try:
+            return callable_()
+        except Exception as exc:  # noqa: BLE001 - we are asserting the *kind* of error
+            module = type(exc).__module__
+            assert "pdfium" not in module.lower() and "PdfiumError" not in type(exc).__name__, (
+                f"empty PDF leaked a raw PdfiumError: {type(exc).__module__}.{type(exc).__name__}: {exc}"
+            )
+            raise
+
+    def test_write_json_empty_pdf(self, empty_pdf, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        writer = PDFWriter(empty_pdf)
+        path = self._assert_not_pdfium_error(lambda: writer.write_json("out.json"))
+        assert os.path.isfile(path)
+        with open(path) as f:
+            assert json.load(f) == {}
+
+    def test_write_json_newline_delimited_empty_pdf(self, empty_pdf, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        writer = PDFWriter(empty_pdf)
+        path = self._assert_not_pdfium_error(lambda: writer.write_json_newline_delimited("out.jsonl"))
+        assert os.path.isfile(path)
+        with open(path) as f:
+            assert [line for line in f if line.strip()] == []
+
+    def test_write_markdown_empty_pdf(self, empty_pdf, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        writer = PDFWriter(empty_pdf)
+        path = self._assert_not_pdfium_error(lambda: writer.write_markdown("out.md"))
+        assert os.path.isfile(path)
+
+    def test_extract_images_empty_pdf(self, empty_pdf, tmp_path):
+        writer = PDFWriter(empty_pdf)
+        paths = self._assert_not_pdfium_error(
+            lambda: writer.extract_images(output_dir=str(tmp_path / "imgs"))
+        )
+        assert paths == []
+
+
 class TestPDFWriterJsonAndDictInputs:
     """Tests for initializing PDFWriter with JSON files or dictionaries."""
 


### PR DESCRIPTION
Closes #80. 

- fix(pdf): guard PDFWriter methods against empty (0-byte) PDFs

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)