### PR TITLE
fix(csv): guard CSVWriter against empty and blank source files

### DIFF
--- a/src/datagrunt/csv_api/csvwriter.py
+++ b/src/datagrunt/csv_api/csvwriter.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 # third party libraries
 # local libraries
-from datagrunt.core import CSVComponents, CSVEngineFactory, DuckDBQueries
+from datagrunt.core import (
+    CSVComponents,
+    CSVEngineFactory,
+    CSVEngineProperties,
+    DuckDBQueries,
+)
 
 
 class CSVWriter(CSVComponents):
@@ -27,12 +32,24 @@ class CSVWriter(CSVComponents):
         filepath = Path(filepath)
         self.lenient = lenient
         super().__init__(filepath)
-        self.db_table = DuckDBQueries(self.filepath, lenient=self.lenient).database_table_name
+        self.queries = DuckDBQueries(self.filepath, lenient=self.lenient)
+        self.db_table = self.queries.database_table_name
         self.engine = engine.lower().replace(" ", "")
 
     def _create_writer(self):
         """Create a reader object."""
         return CSVEngineFactory(self.filepath, self.engine, lenient=self.lenient).create_writer()
+
+    def _write_empty_output(self, default_filename, out_filename=None):
+        """Write a truly empty output file for an empty/blank source.
+
+        Mirrors CSVReader's empty/blank guard: rather than fabricating a
+        ``column0`` header (duckdb) or raising an engine-specific error
+        (polars ``NoDataError`` / pyarrow ``ArrowInvalid``), every engine
+        produces an identical 0-byte file.
+        """
+        filename = self.queries.set_export_filename(default_filename, out_filename)
+        Path(filename).write_bytes(b"")
 
     def write_csv(self, out_filename=None, normalize_columns=False):
         """
@@ -43,6 +60,8 @@ class CSVWriter(CSVComponents):
                 normalize_columns optional, bool: Whether to normalize column
                 names.
         """
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(CSVEngineProperties.csv_export_filename, out_filename)
         return self._create_writer().write_csv(out_filename, normalize_columns)
 
     def write_excel(self, out_filename=None, normalize_columns=False):
@@ -54,6 +73,8 @@ class CSVWriter(CSVComponents):
             normalize_columns optional, bool: Whether to normalize column
             names.
         """
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(CSVEngineProperties.excel_export_filename, out_filename)
         return self._create_writer().write_excel(out_filename, normalize_columns)  # noqa: E501
 
     def write_json(self, out_filename=None, normalize_columns=False):
@@ -65,6 +86,8 @@ class CSVWriter(CSVComponents):
             normalize_columns optional, bool: Whether to normalize column
             names.
         """
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(CSVEngineProperties.json_export_filename, out_filename)
         return self._create_writer().write_json(out_filename, normalize_columns)  # noqa: E501
 
     def write_json_newline_delimited(self, out_filename=None, normalize_columns=False):
@@ -76,6 +99,10 @@ class CSVWriter(CSVComponents):
             normalize_columns optional, bool: Whether to normalize column
             names.
         """
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(
+                CSVEngineProperties.json_newline_export_filename, out_filename
+            )
         return self._create_writer().write_json_newline_delimited(out_filename, normalize_columns)
 
     def write_parquet(self, out_filename=None, normalize_columns=False):
@@ -87,4 +114,6 @@ class CSVWriter(CSVComponents):
             normalize_columns optional, bool: Whether to normalize column
             names.
         """
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(CSVEngineProperties.parquet_export_filename, out_filename)
         return self._create_writer().write_parquet(out_filename, normalize_columns)  # noqa: E501

--- a/tests/csv_api_tests/test_csvwriter.py
+++ b/tests/csv_api_tests/test_csvwriter.py
@@ -98,16 +98,50 @@ class TestCSVWriter:
             expected_columns = ["first_name", "last_name", "age_group"]
             assert list(df.columns) == expected_columns
 
-    def test_write_completely_empty_file(self, completely_empty_csv, tmp_path):
-        """Test writing completely empty files (no headers, no content)."""
-        writer = CSVWriter(completely_empty_csv)
+    def test_write_empty_source_produces_empty_output(self, empty_csv, tmp_path):
+        """Writing a zero-byte source yields a truly empty output on every engine.
 
-        out_csv = str(tmp_path / "completely_empty_output.csv")
-        writer.write_csv(out_csv)
-        assert Path(out_csv).exists()
-        with open(out_csv, "r") as f:
-            content = f.read()
-        assert content.strip() == "" or "column0"  # Verify file is completely empty (ignoring whitespace)
+        Mirrors CSVReader's empty/blank guard: no fabricated ``column0`` header
+        (duckdb) and no engine-specific crash (polars NoDataError / pyarrow
+        ArrowInvalid). The output file must exist and be empty (0 bytes).
+        """
+        for engine in ALL_ENGINES:
+            writer = CSVWriter(empty_csv, engine=engine)
+            out_file = Path(tmp_path / f"empty_source_{engine}.csv")
+            writer.write_csv(str(out_file))
+
+            assert out_file.exists()
+            content = out_file.read_text()
+            assert content == "", f"{engine} fabricated output: {content!r}"
+            assert out_file.stat().st_size == 0
+
+    def test_write_blank_source_produces_empty_output(self, blank_csv, tmp_path):
+        """Writing a whitespace-only source yields empty output on every engine."""
+        for engine in ALL_ENGINES:
+            writer = CSVWriter(blank_csv, engine=engine)
+            out_file = Path(tmp_path / f"blank_source_{engine}.csv")
+            writer.write_csv(str(out_file))
+
+            assert out_file.exists()
+            assert out_file.read_text() == ""
+            assert out_file.stat().st_size == 0
+
+    def test_write_empty_source_all_formats(self, empty_csv, tmp_path):
+        """All write_* methods produce empty output for an empty source."""
+        methods_and_exts = [
+            ("write_csv", "csv"),
+            ("write_json", "json"),
+            ("write_json_newline_delimited", "jsonl"),
+            ("write_parquet", "parquet"),
+            ("write_excel", "xlsx"),
+        ]
+        for engine in ALL_ENGINES:
+            writer = CSVWriter(empty_csv, engine=engine)
+            for method_name, ext in methods_and_exts:
+                out_file = Path(tmp_path / f"empty_{engine}.{ext}")
+                getattr(writer, method_name)(str(out_file))
+                assert out_file.exists()
+                assert out_file.stat().st_size == 0
 
     def test_default_filenames(self, sample_csv):
         """Test writing with default filenames."""


### PR DESCRIPTION
Closes #91. 

- fix(csv): guard CSVWriter against empty and blank source files

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)