### PR TITLE
fix(csv): count CSV records, not physical lines, in row counts

### DIFF
--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -322,18 +322,29 @@ class CSVRows:
 
     @cached_property
     def row_count_with_header(self):
-        """Return the number of lines in the CSV file including the header."""
+        """Return the number of CSV records in the file including the header.
+
+        Counts parsed CSV records rather than physical lines so that quoted
+        fields containing embedded newlines are counted as a single record,
+        matching what the parsing engines report. Comment and blank records
+        are still excluded, mirroring ``_check_csv_ragged_and_warn``.
+        """
+        is_legacy_mac = _is_legacy_mac_newlines(self.filepath)
+        newline_param = None if is_legacy_mac else ""
+        encoding = FileProperties(self.filepath).DEFAULT_ENCODING
+        delimiter = CSVDelimiter(self.filepath).delimiter
         count = 0
-        with open(self.filepath, "r", encoding=FileProperties(self.filepath).DEFAULT_ENCODING) as csv_file:
-            for line in csv_file:
-                stripped = line.strip()
-                if stripped and not stripped.startswith("#"):
-                    count += 1
+        with open(self.filepath, "r", encoding=encoding, newline=newline_param) as csv_file:
+            reader = csv.reader(csv_file, delimiter=delimiter)
+            for row in reader:
+                if not row or row[0].startswith("#"):
+                    continue
+                count += 1
         return count
 
     @property
     def row_count_without_header(self):
-        """Return the number of lines in the CSV file excluding the header."""
+        """Return the number of CSV records in the file excluding the header."""
         return self.row_count_with_header - 1
 
 

--- a/tests/core_tests/csv_io_tests/test_csvcomponents.py
+++ b/tests/core_tests/csv_io_tests/test_csvcomponents.py
@@ -173,6 +173,26 @@ class TestCSVRows:
         rows = CSVRows(str(csv_file))
         assert rows.first_row == "Name,Age,City"
 
+    def test_row_count_with_quoted_embedded_newlines(self, tmp_path):
+        # A quoted field containing an embedded newline is one CSV record,
+        # not two physical lines. Row counts must match what the engines parse.
+        csv_file = tmp_path / "embedded_newlines.csv"
+        csv_file.write_text('name,notes\nalice,"line1\nline2"\nbob,"hello"\n')
+
+        rows = CSVRows(str(csv_file))
+        # header + 2 data records, despite 4 physical lines
+        assert rows.row_count_with_header == 3
+        assert rows.row_count_without_header == 2
+
+    def test_row_count_excludes_comment_and_blank_records(self, tmp_path):
+        csv_file = tmp_path / "comments_blanks.csv"
+        csv_file.write_text("# leading comment\n\nname,notes\nalice,1\n\nbob,2\n")
+
+        rows = CSVRows(str(csv_file))
+        # header + 2 data records; comment and blank lines excluded
+        assert rows.row_count_with_header == 3
+        assert rows.row_count_without_header == 2
+
 
 class TestCSVDialect:
     """Test suite for CSVDialect class."""


### PR DESCRIPTION
Closes #87. 

- fix(csv): count CSV records, not physical lines, in row counts

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)