### PR TITLE
fix(csv): polars engines skip only the LEADING comment block

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -333,12 +333,15 @@ class CSVReaderPolarsEngine(CSVBaseReaderEngine):
         if self.lenient:
             _check_csv_ragged_and_warn(self.filepath, self.delimiter)
         try:
+            # Skip only the LEADING comment block. Using comment_prefix here
+            # would also drop any data row whose first field begins with "#"
+            # (e.g. a hex color like "#FF0000"), silently losing rows.
             df = pl.read_csv(
                 self.filepath,
                 separator=self.delimiter,
                 truncate_ragged_lines=self.lenient,
                 infer_schema=False,
-                comment_prefix="#",
+                skip_rows=_count_leading_comments(self.filepath),
             )
             if normalize_columns:
                 df = df.rename(CSVColumnNameNormalizer(self.filepath, columns=df.columns).columns_to_normalized_mapping)
@@ -365,13 +368,15 @@ class CSVReaderPolarsEngine(CSVBaseReaderEngine):
         if self.lenient:
             _check_csv_ragged_and_warn(self.filepath, self.delimiter)
         try:
+            # Skip only the LEADING comment block so data rows whose first
+            # field starts with "#" are not mistaken for comments.
             df = pl.read_csv(
                 self.filepath,
                 separator=self.delimiter,
                 truncate_ragged_lines=self.lenient,
                 infer_schema=False,
                 n_rows=CSVEngineProperties.dataframe_sample_rows,
-                comment_prefix="#",
+                skip_rows=_count_leading_comments(self.filepath),
             )
             if normalize_columns:
                 df = df.rename(CSVColumnNameNormalizer(self.filepath, columns=df.columns).columns_to_normalized_mapping)
@@ -632,13 +637,14 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
             )
         if self.lenient:
             _check_csv_ragged_and_warn(self.filepath, self.delimiter)
-            # Fallback to Polars to parse the ragged CSV, then convert to Arrow Table
+            # Fallback to Polars to parse the ragged CSV, then convert to Arrow Table.
+            # Skip only the LEADING comment block so "#"-prefixed data rows survive.
             df = pl.read_csv(
                 self.filepath,
                 separator=self.delimiter,
                 truncate_ragged_lines=True,
                 infer_schema=False,
-                comment_prefix="#",
+                skip_rows=_count_leading_comments(self.filepath),
             )
             table = df.to_arrow()
             string_schema = pa.schema([(name, pa.string()) for name in table.column_names])
@@ -694,14 +700,15 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
             )
         if self.lenient:
             _check_csv_ragged_and_warn(self.filepath, self.delimiter)
-            # Fallback to Polars to parse the ragged CSV, then convert to Arrow Table
+            # Fallback to Polars to parse the ragged CSV, then convert to Arrow Table.
+            # Skip only the LEADING comment block so "#"-prefixed data rows survive.
             df = pl.read_csv(
                 self.filepath,
                 separator=self.delimiter,
                 truncate_ragged_lines=True,
                 infer_schema=False,
                 n_rows=CSVEngineProperties.dataframe_sample_rows,
-                comment_prefix="#",
+                skip_rows=_count_leading_comments(self.filepath),
             )
             table = df.to_arrow()
             string_schema = pa.schema([(name, pa.string()) for name in table.column_names])
@@ -845,13 +852,14 @@ class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
             )
         if self.lenient:
             _check_csv_ragged_and_warn(self.filepath, self.queries.delimiter)
-            # Fallback to Polars to parse the ragged CSV, then convert to Arrow Table
+            # Fallback to Polars to parse the ragged CSV, then convert to Arrow Table.
+            # Skip only the LEADING comment block so "#"-prefixed data rows survive.
             df = pl.read_csv(
                 self.filepath,
                 separator=self.queries.delimiter,
                 truncate_ragged_lines=True,
                 infer_schema=False,
-                comment_prefix="#",
+                skip_rows=_count_leading_comments(self.filepath),
             )
             table = df.to_arrow()
             string_schema = pa.schema([(name, pa.string()) for name in table.column_names])

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -416,3 +416,34 @@ class TestEngines:
         assert "last_name" in df.columns
         assert "e_mail" in df.columns
         assert "phone" in df.columns
+
+
+class TestLeadingCommentHandling:
+    """Tests that engines treat only LEADING ``#`` lines as comments.
+
+    A ``#`` at the start of a DATA field (e.g. a hex color) must not cause the
+    row to be dropped, and all engines must agree on the resulting row count.
+    """
+
+    def test_hash_prefixed_data_rows_preserved_all_engines(self, tmp_path):
+        """A data field starting with ``#`` must not be treated as a comment."""
+        hex_csv = tmp_path / "hex.csv"
+        hex_csv.write_text("color,name\n#FF0000,red\n#00FF00,green\n00ABCD,teal\n")
+
+        row_counts = {}
+        for engine in ALL_ENGINES:
+            reader = CSVEngineFactory(str(hex_csv), engine).create_reader()
+            row_counts[engine] = len(reader.to_dataframe())
+
+        assert row_counts == {"duckdb": 3, "polars": 3, "pyarrow": 3}
+
+    def test_leading_comment_block_skipped_all_engines(self, tmp_path):
+        """A genuine leading comment block must still be skipped on all engines."""
+        commented_csv = tmp_path / "commented.csv"
+        commented_csv.write_text("# generated\n# v2\na,b\n1,2\n")
+
+        for engine in ALL_ENGINES:
+            reader = CSVEngineFactory(str(commented_csv), engine).create_reader()
+            df = reader.to_dataframe()
+            assert df.columns == ["a", "b"]
+            assert len(df) == 1


### PR DESCRIPTION
Closes #73. 

- fix(csv): polars engines skip only the LEADING comment block

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

**Merge-order note:** Overlaps with the branch for #85 (fix/csv-leading-blank-lines) in the leading-comment counting helpers; whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)