### PR TITLE
fix(pdf): harden PageLayoutSorter against off-page and corrupt coordinates

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
+++ b/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
@@ -149,6 +149,12 @@ class PageLayoutSorter:
         bin_limit = bin_count
         for it in text_items:
             x0, _, x1, _ = self.adapter.get_bounds(it)
+            # The partition-level finiteness guard only sees the aggregate
+            # min/max (NaN loses every min()/max() comparison against a finite
+            # first operand), so a non-finite coordinate on a later item can
+            # still reach int() here. Skip such items individually.
+            if not (math.isfinite(x0) and math.isfinite(x1)):
+                continue
             if (x1 - x0) > page_width * 0.7:
                 continue
             start = max(0, int(x0))

--- a/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
+++ b/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+import math
+
+# Upper bound on the density-histogram size. A corrupt PDF can carry a single
+# absurd x-coordinate (e.g. 1e9); without a cap, ``[0] * int(max_x)`` would try
+# to allocate gigabytes and effectively hang or OOM the process. 100k bins is
+# far more than any real page width in PDF points, so clamping here never
+# affects legitimate layouts.
+MAX_HISTOGRAM_BINS = 100_000
+
 
 class LayoutAdapter:
     """Interface to abstract coordinate and weight access for different item types."""
@@ -72,6 +81,13 @@ class PageLayoutSorter:
         page_width = max_x - min_x
         page_height = max_y - min_y
 
+        # Corrupt PDFs can yield non-finite coordinates (NaN/inf). A NaN slips
+        # past the ``page_width < 100`` guard below (every comparison with NaN is
+        # False) and an inf overflows ``int()`` in the histogram, so screen them
+        # out here and skip column partitioning rather than crash downstream.
+        if not (math.isfinite(min_x) and math.isfinite(max_x)):
+            return [items]
+
         if page_width < 100 or len(items) < 3:
             return [items]
 
@@ -125,13 +141,18 @@ class PageLayoutSorter:
 
     def _build_density_histogram(self, text_items: list, page_width: float, max_x: float) -> list[int]:
         """Build a horizontal density histogram from text items."""
-        bins = [0] * int(max_x + 2)
+        # Cap the allocation so a single absurd x-coordinate cannot OOM/hang the
+        # process. ``bin_limit`` is the exclusive upper index, so every write
+        # below stays within ``[0, len(bins))``.
+        bin_count = min(int(max_x) + 2, MAX_HISTOGRAM_BINS)
+        bins = [0] * bin_count
+        bin_limit = bin_count
         for it in text_items:
             x0, _, x1, _ = self.adapter.get_bounds(it)
             if (x1 - x0) > page_width * 0.7:
                 continue
             start = max(0, int(x0))
-            end = min(int(max_x), int(x1))
+            end = min(int(max_x), int(x1), bin_limit)
             weight = self.adapter.get_weight(it)
             for x in range(start, end):
                 bins[x] += weight
@@ -139,8 +160,14 @@ class PageLayoutSorter:
 
     def _find_widest_gutter(self, bins: list[int], min_x: float, page_width: float) -> float | None:
         """Search for the widest vertical gutter in the middle region (25% - 75%)."""
-        search_start = int(min_x + page_width * 0.25)
-        search_end = int(min_x + page_width * 0.75)
+        # Clamp the search window to valid bin indices. Off-page/cropped content
+        # (negative min_x) or a capped histogram can push these bounds outside
+        # ``[0, len(bins))``; an unclamped negative index would wrap around via
+        # Python negative indexing (silently picking the wrong gutter) and an
+        # out-of-range index would raise IndexError. ``range`` over an empty
+        # window simply finds no gutter and returns None.
+        search_start = max(0, min(len(bins), int(min_x + page_width * 0.25)))
+        search_end = max(search_start, min(len(bins), int(min_x + page_width * 0.75)))
         best_gutter_start = None
         best_gutter_width = 0
         current_start = None

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_layout_sorter.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_layout_sorter.py
@@ -78,6 +78,43 @@ class TestPartitionPathologicalCoordinates:
 
         assert len(_flatten(segments)) == len(items)
 
+    def test_nan_coordinate_on_non_first_item_does_not_raise(self):
+        """A NaN on a NON-first item evades the aggregate finiteness guard.
+
+        ``min(0, nan)`` returns 0 (NaN comparisons are False), so min_x/max_x
+        stay finite and partition proceeds to the histogram, where ``int(nan)``
+        raised ValueError. Non-finite items must be skipped per item.
+        """
+        nan = float("nan")
+        items = [
+            _text_item(0, 10, 10),
+            _text_item(nan, nan, 30),
+            _text_item(150, 160, 50),
+            _text_item(155, 165, 70),
+        ]
+
+        segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+
+        assert len(_flatten(segments)) == len(items)
+
+    def test_infinite_coordinate_on_non_first_item_does_not_raise(self):
+        """An inf x0 with a finite x1 evades the aggregate guard.
+
+        min_x aggregates x0 (``min(0, inf)`` is 0) and max_x aggregates x1, so
+        both stay finite; ``int(inf)`` in the histogram raised OverflowError.
+        """
+        inf = float("inf")
+        items = [
+            _text_item(0, 10, 10),
+            _text_item(inf, 20, 30),
+            _text_item(150, 160, 50),
+            _text_item(155, 165, 70),
+        ]
+
+        segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+
+        assert len(_flatten(segments)) == len(items)
+
     def test_infinite_coordinate_does_not_raise(self):
         """An infinite x-coordinate overflowed int() (OverflowError) before.
 

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_layout_sorter.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_layout_sorter.py
@@ -1,0 +1,155 @@
+"""Tests for layout-aware partitioning (PageLayoutSorter).
+
+These focus on hardening ``partition`` against pathological coordinates that a
+corrupt or cropped PDF can produce: off-page (negative) positions, non-finite
+values (NaN/inf), and absurdly large finite coordinates. Each must degrade
+gracefully (return the items as segments) instead of crashing, hanging, or
+allocating gigabytes -- while still partitioning a normal multi-column page
+correctly.
+"""
+
+import time
+
+from datagrunt.core.pdf_io.extraction.layout_sorter import (
+    MAX_HISTOGRAM_BINS,
+    PageLayoutSorter,
+    TextItemAdapter,
+)
+from datagrunt.core.pdf_io.extraction.shapes import TextItem
+
+
+def _text_item(x0: float, x1: float, y: float, text: str = "word") -> TextItem:
+    """Build a TextItem at the given horizontal span and y position."""
+    return TextItem(
+        text=text,
+        x0=x0,
+        x1=x1,
+        y_top=y,
+        y_bot=y + 8,
+        size=10,
+        font="F",
+        is_bold=False,
+        is_italic=False,
+    )
+
+
+def _flatten(segments: list[list]) -> list:
+    """Collapse partition segments into a flat list of items."""
+    return [item for segment in segments for item in segment]
+
+
+class TestPartitionPathologicalCoordinates:
+    """partition() must not crash/hang on off-page or corrupt coordinates."""
+
+    def test_off_page_negative_coordinates_do_not_raise(self):
+        """Negative (off-page) x-coordinates previously caused IndexError.
+
+        min_x=-90 with page_width=140 drove the gutter search index negative,
+        which either wrapped via Python negative indexing or raised IndexError.
+        After clamping, partition returns all items intact.
+        """
+        items = [
+            _text_item(-90, -80, 10),
+            _text_item(-90, -80, 30),
+            _text_item(40, 50, 50),
+            _text_item(45, 50, 70),
+        ]
+
+        segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+
+        assert _flatten(segments) and len(_flatten(segments)) == len(items)
+        assert {id(i) for i in _flatten(segments)} == {id(i) for i in items}
+
+    def test_nan_coordinate_does_not_raise(self):
+        """A NaN x-coordinate slipped past the page_width guard and crashed.
+
+        ``NaN < 100`` is False, so the old code proceeded to int(NaN) and raised
+        ValueError. The finiteness guard now skips partitioning instead.
+        """
+        nan = float("nan")
+        items = [
+            _text_item(nan, 10, 10),
+            _text_item(0, 10, 30),
+            _text_item(40, 50, 50),
+            _text_item(45, 50, 70),
+        ]
+
+        segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+
+        assert len(_flatten(segments)) == len(items)
+
+    def test_infinite_coordinate_does_not_raise(self):
+        """An infinite x-coordinate overflowed int() (OverflowError) before.
+
+        The finiteness guard now returns the items as a single segment.
+        """
+        inf = float("inf")
+        items = [
+            _text_item(0, inf, 10),
+            _text_item(0, 10, 30),
+            _text_item(40, 50, 50),
+            _text_item(45, 50, 70),
+        ]
+
+        segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+
+        assert len(_flatten(segments)) == len(items)
+
+    def test_huge_finite_coordinate_is_fast_and_bounded(self):
+        """A single absurd x-coordinate must not allocate a giant histogram.
+
+        Pre-fix, ``[0] * int(1e9)`` allocated ~8 GB and took seconds for this
+        tiny input. The histogram cap keeps it instant; we assert it both
+        completes quickly and preserves every item.
+        """
+        items = [
+            _text_item(0, 10, 10),
+            _text_item(0, 10, 30),
+            _text_item(0, 1e9, 50),
+            _text_item(45, 50, 70),
+        ]
+
+        start = time.perf_counter()
+        segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+        elapsed = time.perf_counter() - start
+
+        assert len(_flatten(segments)) == len(items)
+        # Generous bound: the real fix runs in milliseconds, while the unbounded
+        # allocation took several seconds. This fails loudly if the cap regresses.
+        assert elapsed < 2.0
+
+    def test_histogram_cap_is_a_sane_bound(self):
+        """The bin cap must stay well above any real page width but bounded."""
+        assert 10_000 <= MAX_HISTOGRAM_BINS <= 1_000_000
+
+
+class TestPartitionNormalLayout:
+    """Regression guard: clamping must not change correct in-bounds behavior."""
+
+    def test_two_column_page_partitions_left_before_right(self):
+        """A clean two-column page yields all left items before all right items.
+
+        Left column spans x 50-240, right column x 360-550, with a ~120pt gutter
+        between them on a 500pt-wide page. partition recurses per column, so the
+        invariant we pin is reading order: every left-column item precedes every
+        right-column item, and no item is dropped or duplicated.
+        """
+        left_column = [_text_item(50, 240, y) for y in (50, 70, 90, 110)]
+        right_column = [_text_item(360, 550, y) for y in (50, 70, 90, 110)]
+        items = left_column + right_column
+
+        segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+        flattened = _flatten(segments)
+
+        assert len(flattened) == len(items)
+        x0_order = [item.x0 for item in flattened]
+        # All left-column x0 (50) come before all right-column x0 (360).
+        assert x0_order == [50, 50, 50, 50, 360, 360, 360, 360]
+
+    def test_single_column_returns_items_unsplit(self):
+        """A narrow single block of text is returned without column splitting."""
+        items = [_text_item(50, 90, y) for y in (50, 70)]
+
+        segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+
+        assert segments == [items]


### PR DESCRIPTION
Closes #83. 

- fix(pdf): harden PageLayoutSorter against off-page and corrupt coordinates
- fix(pdf): skip non-finite coordinates per item in the density histogram

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)