### PR TITLE
fix(pdf): close pdfium page and textpage handles deterministically

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
@@ -39,23 +39,23 @@ class PdfiumBackend(ExtractionBackend):
         """Return page metadata (raises if the page/file is invalid)."""
         doc, should_close = self._get_doc()
         try:
-            page = doc.page(page_number)
-            width, height = page.size()
-            text = page.full_text().strip()
-            text_objs, image_objs = page.count_objects()
-            has_text = len(text) > 0
-            return PageAnalysis(
-                width=float(width),
-                height=float(height),
-                rotation=page.rotation(),
-                has_text_layer=has_text,
-                is_scanned=(not has_text and image_objs > 0),
-                text_block_count=text_objs,
-                image_count=image_objs,
-                image_block_count=image_objs,
-                has_line_drawings=page.has_paths(),
-                text_length=len(text),
-            )
+            with doc.page(page_number) as page:
+                width, height = page.size()
+                text = page.full_text().strip()
+                text_objs, image_objs = page.count_objects()
+                has_text = len(text) > 0
+                return PageAnalysis(
+                    width=float(width),
+                    height=float(height),
+                    rotation=page.rotation(),
+                    has_text_layer=has_text,
+                    is_scanned=(not has_text and image_objs > 0),
+                    text_block_count=text_objs,
+                    image_count=image_objs,
+                    image_block_count=image_objs,
+                    has_line_drawings=page.has_paths(),
+                    text_length=len(text),
+                )
         finally:
             if should_close:
                 doc.close()
@@ -64,7 +64,8 @@ class PdfiumBackend(ExtractionBackend):
         """Return classified text blocks built from pdfium text objects."""
         doc, should_close = self._get_doc()
         try:
-            items = list(doc.page(page_number).text_items())
+            with doc.page(page_number) as page:
+                items = list(page.text_items())
         finally:
             if should_close:
                 doc.close()
@@ -74,11 +75,12 @@ class PdfiumBackend(ExtractionBackend):
         """Return embedded images (>= MIN_IMAGE_DIMENSION); write when output_dir set."""
         doc, should_close = self._get_doc()
         try:
-            res = list(
-                doc.page(page_number).image_items(
-                    output_dir=output_dir, name_prefix=name_prefix, page_number=page_number
+            with doc.page(page_number) as page:
+                res = list(
+                    page.image_items(
+                        output_dir=output_dir, name_prefix=name_prefix, page_number=page_number
+                    )
                 )
-            )
         finally:
             if should_close:
                 doc.close()
@@ -88,7 +90,8 @@ class PdfiumBackend(ExtractionBackend):
         """Render the page via pdfium and OCR it with Tesseract."""
         doc, should_close = self._get_doc()
         try:
-            img = doc.page(page_number).render_pil(dpi=dpi)
+            with doc.page(page_number) as page:
+                img = page.render_pil(dpi=dpi)
         finally:
             if should_close:
                 doc.close()

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
@@ -40,6 +40,22 @@ class PdfiumPage:
         self._raw = raw_module
         self._textpage = page.get_textpage()
 
+    def __enter__(self) -> "PdfiumPage":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release the page and textpage handles (textpage first, then page).
+
+        pypdfium2 leaves these handles open until the cyclic GC runs; closing
+        them explicitly reclaims them deterministically. Safe to call more than
+        once: ``close()`` on an already-closed handle is a no-op in pypdfium2.
+        """
+        self._textpage.close()
+        self._page.close()
+
     def size(self) -> tuple:
         """Return ``(width, height)`` in points."""
         return self._page.get_size()

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -45,20 +45,20 @@ class PdfiumNativeReader:
         """Parse one page into the native schema dict."""
         doc, should_close = self._get_doc()
         try:
-            page = doc.page(page_index)
-            width, height = page.size()
-            full_text = page.full_text()
-            text_objects = [self._text_object(it) for it in page.text_items()]
-            images = [
-                self._image(img)
-                for img in page.image_items(
-                    output_dir=image_output_dir, name_prefix=Path(self.filepath).stem, page_number=page_index
-                )
-            ]
-            ocr_used = False
-            if not full_text.strip():
-                full_text, extra, ocr_used = self._ocr_fallback(doc, page_index, width, height)
-                text_objects.extend(extra)
+            with doc.page(page_index) as page:
+                width, height = page.size()
+                full_text = page.full_text()
+                text_objects = [self._text_object(it) for it in page.text_items()]
+                images = [
+                    self._image(img)
+                    for img in page.image_items(
+                        output_dir=image_output_dir, name_prefix=Path(self.filepath).stem, page_number=page_index
+                    )
+                ]
+                ocr_used = False
+                if not full_text.strip():
+                    full_text, extra, ocr_used = self._ocr_fallback(page, width, height)
+                    text_objects.extend(extra)
             return {
                 "page_number": page_index + 1,
                 "width": round(float(width), 2),
@@ -98,10 +98,13 @@ class PdfiumNativeReader:
             "extracted": img.file_path is not None,
         }
 
-    def _ocr_fallback(self, doc, page_index, width, height):
-        """Run OCR on an image-only page; return (text, extra_objects, used)."""
+    def _ocr_fallback(self, page, width, height):
+        """Run OCR on an image-only page; return (text, extra_objects, used).
+
+        Reuses the already-open ``page`` rather than opening a second handle.
+        """
         page_dpi = dpi_for_page(width, height)
-        img = doc.page(page_index).render_pil(dpi=page_dpi)
+        img = page.render_pil(dpi=page_dpi)
         blocks = ocr_data_to_blocks(img, page_dpi)
         if not blocks:
             return "", [], False

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_handle_leak.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_handle_leak.py
@@ -1,0 +1,101 @@
+"""Regression tests for issue #93: pdfium page/textpage handle leak.
+
+Page and textpage handles must be closed deterministically as each page is
+parsed, not left open until the document closes or the cyclic garbage collector
+runs. These tests run with ``gc.disable()`` so any reliance on GC for handle
+reclamation is exposed, and they inspect handles WHILE THE DOCUMENT IS STILL
+OPEN so that the document's own cascade-close on exit cannot mask a per-page
+leak.
+
+A pypdfium2 handle (``PdfPage`` / ``PdfTextPage``) is open while its
+``weakref.finalize`` is still armed: ``obj._finalizer is not None and
+obj._finalizer.alive``. Calling ``close()`` detaches the finalizer (sets it to
+``None``) and frees the underlying handle. On the buggy code, parsing N pages
+leaves N ``PdfPage`` + N ``PdfTextPage`` finalizers still alive.
+"""
+
+import gc
+
+import pytest
+
+# pypdfium2 is an optional extra; skip cleanly if it is unavailable.
+pdfium_page = pytest.importorskip("pypdfium2._helpers.page")
+pdfium_textpage = pytest.importorskip("pypdfium2._helpers.textpage")
+
+from datagrunt.core.pdf_io.extraction.pdfium_backend import PdfiumBackend
+from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
+from datagrunt.core.pdf_io.extraction.pdfium_native import PdfiumNativeReader
+
+PdfPage = pdfium_page.PdfPage
+PdfTextPage = pdfium_textpage.PdfTextPage
+
+
+def _is_open(handle) -> bool:
+    """Return True if a pypdfium2 handle is still open (finalizer armed)."""
+    finalizer = getattr(handle, "_finalizer", None)
+    return finalizer is not None and finalizer.alive
+
+
+def _open_handle_counts() -> tuple:
+    """Return (open_pages, open_textpages) currently alive in the process.
+
+    ``gc.get_objects()`` is queried WITHOUT a preceding ``gc.collect()`` so a
+    handle only counts as reclaimed if it was explicitly closed, never because
+    the cyclic collector happened to run.
+    """
+    open_pages = sum(
+        1 for obj in gc.get_objects() if isinstance(obj, PdfPage) and _is_open(obj)
+    )
+    open_textpages = sum(
+        1 for obj in gc.get_objects() if isinstance(obj, PdfTextPage) and _is_open(obj)
+    )
+    return open_pages, open_textpages
+
+
+@pytest.fixture
+def _gc_disabled():
+    """Disable the cyclic GC for the duration of a test, then restore it."""
+    was_enabled = gc.isenabled()
+    gc.collect()  # start from a clean slate
+    gc.disable()
+    try:
+        yield
+    finally:
+        if was_enabled:
+            gc.enable()
+        gc.collect()
+
+
+class TestPdfiumHandleLeak:
+    """No page/textpage handle may stay open after the page it belongs to is parsed."""
+
+    def test_native_reader_closes_page_handles(self, multipage_pdf, _gc_disabled):
+        with PdfiumNativeReader(multipage_pdf) as reader:
+            for index in range(3):
+                reader.parse_page(index)
+            # Inspect while the document is still open: a leak shows up here.
+            open_pages, open_textpages = _open_handle_counts()
+
+        assert open_pages == 0, f"{open_pages} PdfPage handle(s) left open after parse"
+        assert open_textpages == 0, f"{open_textpages} PdfTextPage handle(s) left open after parse"
+
+    def test_backend_closes_page_handles(self, multipage_pdf, _gc_disabled):
+        with PdfiumBackend(multipage_pdf) as backend:
+            for index in range(3):
+                backend.analyze_page(index)
+                backend.extract_text_blocks(index)
+                backend.extract_images(index)
+            open_pages, open_textpages = _open_handle_counts()
+
+        assert open_pages == 0, f"{open_pages} PdfPage handle(s) left open after parse"
+        assert open_textpages == 0, f"{open_textpages} PdfTextPage handle(s) left open after parse"
+
+    def test_document_page_is_context_manager(self, multipage_pdf, _gc_disabled):
+        with PdfiumDocument(multipage_pdf) as doc:
+            with doc.page(0) as page:
+                assert page.size()[0] > 0
+                raw_page, raw_textpage = page._page, page._textpage
+                assert _is_open(raw_page) and _is_open(raw_textpage)
+            # Leaving the `with doc.page(...)` block must close both handles.
+            assert not _is_open(raw_page), "page handle not closed on context exit"
+            assert not _is_open(raw_textpage), "textpage handle not closed on context exit"


### PR DESCRIPTION
Closes #93. 

- fix(pdf): close pdfium page and textpage handles deterministically

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)