### PR TITLE
fix(pdf): raise a clear error for encrypted PDFs instead of a raw PdfiumError

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
@@ -12,6 +12,14 @@ from datagrunt.core.pdf_io.extraction.shapes import BBox, ImageBlock, TextItem
 
 PDF_EXTRA_HINT = "PDF parsing requires extra dependencies. Install with: pip install datagrunt[pdf]"
 
+# Substring present in pdfium's load error when a PDF needs a password.
+_PDFIUM_PASSWORD_ERROR = "password"
+
+ENCRYPTED_PDF_MESSAGE = (
+    "The PDF is encrypted or password-protected and cannot be opened without "
+    "the correct password."
+)
+
 # Minimum image dimension (px) to keep; smaller images are layout artifacts.
 MIN_IMAGE_DIMENSION = 40
 
@@ -206,7 +214,15 @@ class PdfiumDocument:
         """
         pdfium, raw = _import_pdfium()
         self._raw = raw
-        self._pdf = pdfium.PdfDocument(str(filepath))
+        try:
+            self._pdf = pdfium.PdfDocument(str(filepath))
+        except pdfium.PdfiumError as exc:
+            # Translate pdfium's raw "Incorrect password error" into a clear,
+            # catchable datagrunt error. Re-raise any other load failure as-is
+            # so unrelated problems are not masked.
+            if _PDFIUM_PASSWORD_ERROR in str(exc).lower():
+                raise ValueError(ENCRYPTED_PDF_MESSAGE) from exc
+            raise
 
     def __enter__(self) -> "PdfiumDocument":
         return self

--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -2,6 +2,7 @@
 
 from datagrunt.core.pdf_io.extraction.base import ExtractionBackend
 from datagrunt.core.pdf_io.extraction.ocr import ocr_data_to_blocks
+from datagrunt.core.pdf_io.extraction.pdfium_document import ENCRYPTED_PDF_MESSAGE
 from datagrunt.core.pdf_io.extraction.shapes import BBox, ImageBlock, PageAnalysis, TextBlock
 from datagrunt.core.pdf_io.extraction.text_block_builder import classify_font_size
 
@@ -23,12 +24,25 @@ class PyMuPDFBackend(ExtractionBackend):
         import threading
         self._local = threading.local()
 
+    def _open_doc(self):
+        """Open the document, translating the encrypted case to a clear error.
+
+        pymupdf opens password-protected PDFs without raising (every page then
+        reads as empty/garbage), so encryption must be detected explicitly via
+        ``needs_pass`` to match the pdfium engines' behavior (issue #99).
+        """
+        pymupdf = _import_pymupdf()
+        doc = pymupdf.open(self.filepath)
+        if doc.needs_pass:
+            doc.close()
+            raise ValueError(ENCRYPTED_PDF_MESSAGE)
+        return doc
+
     def __enter__(self):
         if not hasattr(self._local, "depth"):
             self._local.depth = 0
         if self._local.depth == 0:
-            pymupdf = _import_pymupdf()
-            self._local.doc = pymupdf.open(self.filepath)
+            self._local.doc = self._open_doc()
         self._local.depth += 1
         return self
 
@@ -42,8 +56,7 @@ class PyMuPDFBackend(ExtractionBackend):
     def _get_doc(self):
         if hasattr(self._local, "doc") and self._local.doc:
             return self._local.doc, False
-        pymupdf = _import_pymupdf()
-        return pymupdf.open(self.filepath), True
+        return self._open_doc(), True
 
     def page_count(self) -> int:
         """Return the document's page count using pymupdf (no pdfium dependency)."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,26 @@ def sample_pdf(tmp_path):
 
 
 @pytest.fixture
+def encrypted_pdf(tmp_path):
+    """Create a one-page AES-256 encrypted (password-protected) PDF."""
+    import pymupdf
+
+    doc = pymupdf.open()
+    page = doc.new_page(width=612, height=792)
+    page.insert_text((72, 72), "Confidential", fontsize=12)
+
+    pdf_path = tmp_path / "encrypted.pdf"
+    doc.save(
+        str(pdf_path),
+        encryption=pymupdf.PDF_ENCRYPT_AES_256,
+        owner_pw="owner-secret",
+        user_pw="user-secret",
+    )
+    doc.close()
+    return str(pdf_path)
+
+
+@pytest.fixture
 def empty_pdf(tmp_path):
     """Create a 0-byte PDF file."""
     pdf_path = tmp_path / "empty.pdf"

--- a/tests/pdf_api_tests/test_encrypted_pdf.py
+++ b/tests/pdf_api_tests/test_encrypted_pdf.py
@@ -1,0 +1,32 @@
+"""Tests for clean error handling of encrypted / password-protected PDFs."""
+
+import pypdfium2 as pdfium
+import pytest
+
+from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
+from datagrunt.pdf_api.pdfreader import PDFReader
+
+
+class TestEncryptedPdf:
+    """Encrypted PDFs must surface a clear, catchable datagrunt-level error."""
+
+    def test_pdfium_document_raises_clear_error(self, encrypted_pdf):
+        with pytest.raises(ValueError) as excinfo:
+            PdfiumDocument(encrypted_pdf)
+        message = str(excinfo.value).lower()
+        assert "encrypted" in message or "password" in message
+        # Must not leak the raw backend exception type.
+        assert not isinstance(excinfo.value, pdfium.PdfiumError)
+
+    @pytest.mark.parametrize("engine,native", [
+        ("pdfium", True),
+        ("pdfium", False),
+        ("pymupdf", False),
+    ])
+    def test_reader_raises_clear_error(self, encrypted_pdf, engine, native):
+        reader = PDFReader(encrypted_pdf, engine=engine, native=native)
+        with pytest.raises(ValueError) as excinfo:
+            reader.to_dicts()
+        message = str(excinfo.value).lower()
+        assert "encrypted" in message or "password" in message
+        assert not isinstance(excinfo.value, pdfium.PdfiumError)


### PR DESCRIPTION
Closes #99. 

- fix(pdf): raise a clear error for encrypted PDFs instead of a raw PdfiumError

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)