### PR TITLE
fix(pdf): escape leading markdown metacharacters in extracted body text

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/markdown_escape.py
+++ b/src/datagrunt/core/pdf_io/extraction/markdown_escape.py
@@ -1,0 +1,29 @@
+"""Escaping helpers for rendering extracted text into Markdown safely."""
+
+import re
+
+# A leading markdown metacharacter ('#', '>', '*', '+', '-') or an ordered-list
+# marker ('1.') turns verbatim body text into markdown structure. Match the
+# leading whitespace plus either a block metacharacter or the dot of an
+# ordered-list marker so the structural character can be backslash-escaped.
+_LEADING_MARKDOWN_METACHAR = re.compile(r"^(\s*)(?:([#>*+-])|(\d+)(\.))")
+
+
+def escape_leading_markdown(text: str) -> str:
+    """Backslash-escape a leading markdown metacharacter in body/caption text.
+
+    Prevents extracted text such as ``# rm -rf is not a heading`` from being
+    reinterpreted as markdown structure (an H1, list item, or blockquote).
+    Only the leading structural character is escaped; the rest of the text is
+    left untouched. Non-string input is returned unchanged.
+    """
+    if not isinstance(text, str):
+        return text
+
+    def _escape(match: re.Match) -> str:
+        indent, block_char, digits, dot = match.groups()
+        if block_char is not None:
+            return f"{indent}\\{block_char}"
+        return f"{indent}{digits}\\{dot}"
+
+    return _LEADING_MARKDOWN_METACHAR.sub(_escape, text, count=1)

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from datagrunt.core.pdf_io.extraction.image_dedupe import dedupe_image_files
+from datagrunt.core.pdf_io.extraction.markdown_escape import escape_leading_markdown
 from datagrunt.core.pdf_io.extraction.ocr import dpi_for_page, ocr_data_to_blocks
 from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
 
@@ -187,5 +188,7 @@ class PdfiumNativeReader:
             for para in text.split("\n\n"):
                 para = para.strip()
                 if para:
-                    blocks.append(para)
+                    # Native paragraphs are all body text; escape any leading
+                    # markdown metacharacter so it is not rendered as structure.
+                    blocks.append(escape_leading_markdown(para))
         return "\n\n".join(blocks) + "\n"

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from datagrunt.core.file_io import FileProperties
 from datagrunt.core.pdf_io.extraction import PdfPlumberTableExtractor
 from datagrunt.core.pdf_io.extraction.image_dedupe import dedupe_image_files
+from datagrunt.core.pdf_io.extraction.markdown_escape import escape_leading_markdown
 from datagrunt.core.pdf_io.extraction.ocr import dpi_for_page
 from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
 from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
@@ -240,9 +241,11 @@ class ParsedDocument:
                 content = el.get("content")
                 meta = el.get("metadata") or {}
                 if etype in heading_map:
-                    blocks.append(f"{heading_map[etype]}{content}")
+                    # Keep the intentional heading marker, but escape the
+                    # element's own content so it cannot inject a second one.
+                    blocks.append(f"{heading_map[etype]}{escape_leading_markdown(content)}")
                 elif etype == "caption":
-                    blocks.append(f"*{content}*")
+                    blocks.append(f"*{escape_leading_markdown(content)}*")
                 elif etype == "table":
                     blocks.append(self._render_table(content, meta.get("has_header_row", False)))
                 elif etype == "image":
@@ -256,7 +259,7 @@ class ParsedDocument:
                             pass
                     blocks.append(f"![{Path(path).name or 'image'}]({path})")
                 elif isinstance(content, str) and content.strip():
-                    blocks.append(content)
+                    blocks.append(escape_leading_markdown(content))
         return "\n\n".join(blocks) + "\n"
 
     @staticmethod

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
@@ -37,3 +37,12 @@ class TestPdfiumNativeReader:
         doc = {"document": {"pages": [{"images": [{"file": str(a)}, {"file": str(b)}]}]}}
         removed = PdfiumNativeReader.dedupe_images(doc)
         assert removed == 1 and not b.exists()
+
+    def test_to_markdown_escapes_leading_metacharacters(self):
+        # Native paragraph text is all body text; a paragraph that happens to
+        # start with a markdown metacharacter must not become structure.
+        doc = {"document": {"pages": [{"text": "# rm -rf is not a heading\n\n- not a list"}]}}
+        md = PdfiumNativeReader.to_markdown(doc)
+        assert "\\# rm -rf is not a heading" in md
+        assert "\\- not a list" in md
+        assert not md.lstrip().startswith("# ")

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -283,3 +283,56 @@ class TestParsedDocument:
         assert pd.drop_layout_tables() == 1
         kept = document["document"]["pages"][0]["elements"]
         assert [e["type"] for e in kept] == ["table", "body_text"]
+
+
+class TestMarkdownMetacharacterEscaping:
+    """Body/caption text starting with markdown metacharacters must be escaped."""
+
+    @staticmethod
+    def _element(etype, content):
+        return {"type": etype, "content": content, "metadata": {}}
+
+    @staticmethod
+    def _markdown(elements):
+        from datagrunt.core.pdf_io.pdfcomponents import ParsedDocument
+
+        document = {"document": {"pages": [{"page_number": 1, "elements": elements}]}}
+        return ParsedDocument(document).to_markdown()
+
+    def test_body_text_leading_hash_is_escaped(self):
+        md = self._markdown([self._element("body_text", "# rm -rf is not a heading")])
+        assert "\\# rm -rf is not a heading" in md
+        # The line must not begin with a bare H1 marker.
+        assert not md.lstrip().startswith("# ")
+
+    def test_body_text_leading_dash_is_escaped(self):
+        md = self._markdown([self._element("body_text", "- not a list item")])
+        assert "\\- not a list item" in md
+
+    def test_body_text_leading_blockquote_is_escaped(self):
+        md = self._markdown([self._element("body_text", "> not a quote")])
+        assert "\\> not a quote" in md
+
+    def test_body_text_leading_ordered_list_is_escaped(self):
+        md = self._markdown([self._element("body_text", "1. not a list")])
+        assert "1\\. not a list" in md
+
+    def test_caption_leading_metacharacter_is_escaped(self):
+        md = self._markdown([self._element("caption", "# caption text")])
+        assert "*\\# caption text*" in md
+
+    def test_intentional_heading_element_still_renders(self):
+        md = self._markdown([self._element("header", "Quarterly Report")])
+        assert md.lstrip().startswith("# Quarterly Report")
+
+    def test_heading_content_with_metacharacter_does_not_inject_structure(self):
+        # A genuine heading element keeps its '# ' marker, but its own content
+        # must not introduce a second heading level.
+        md = self._markdown([self._element("header", "# extra hash")])
+        assert "# \\# extra hash" in md
+
+    def test_table_cell_escaping_unchanged(self):
+        from datagrunt.core.pdf_io.pdfcomponents import ParsedDocument
+
+        rendered = ParsedDocument._render_table([["a|b", "c"]], has_header=False)
+        assert "a\\|b" in rendered


### PR DESCRIPTION
Closes #98. 

- fix(pdf): escape leading markdown metacharacters in extracted body text

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)