### PR TITLE
fix(pdf): parse PyMuPDF pages sequentially (MuPDF is not thread-safe)

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -6,7 +6,6 @@ import logging
 import os
 import time
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -125,23 +124,30 @@ class PDFReaderPyMuPDFEngine(PDFBaseReaderEngine):
             return len(doc)
 
     def to_dicts(self, image_output_dir: Optional[str] = None, drop_layout_tables: bool = False) -> dict:
-        """Parse all pages concurrently into the unified document dict."""
+        """Parse all pages sequentially into the unified document dict.
+
+        Pages are parsed one at a time on purpose: PyMuPDF/MuPDF shares a global
+        context and is not thread-safe, so dispatching pages across threads risks
+        garbled output or an interpreter crash. The ``workers`` argument is kept
+        for API compatibility but does not enable threading here; callers needing
+        parallel parsing should use the process-based pdfium engine.
+        """
+        if self.workers > 1:
+            logger.warning(
+                "PyMuPDF parses pages sequentially because MuPDF is not thread-safe; "
+                "the 'workers=%d' setting is ignored. Use the pdfium engine for parallel parsing.",
+                self.workers,
+            )
         assembler = pdfcomponents.DocumentAssembler(self.filepath)
         total_pages = self._total_pages()
         page_results = {}
         errors = []
-        with ThreadPoolExecutor(max_workers=self.workers) as executor:
-            futures = {
-                executor.submit(assembler.parse_page, idx, image_output_dir): idx
-                for idx in range(total_pages)
-            }
-            for future in as_completed(futures):
-                idx = futures[future]
-                try:
-                    page = future.result()
-                    page_results[page["page_number"]] = page
-                except Exception as e:  # noqa: BLE001 - per-page isolation
-                    errors.append(f"Page {idx + 1}: {e}")
+        for idx in range(total_pages):
+            try:
+                page = assembler.parse_page(idx, image_output_dir)
+                page_results[page["page_number"]] = page
+            except Exception as e:  # noqa: BLE001 - per-page isolation
+                errors.append(f"Page {idx + 1}: {e}")
         ordered = [page_results[p] for p in sorted(page_results.keys())]
         document = assembler.combine(total_pages, ordered, errors)
         if drop_layout_tables:

--- a/tests/core_tests/pdf_io_tests/test_engines.py
+++ b/tests/core_tests/pdf_io_tests/test_engines.py
@@ -200,6 +200,82 @@ class TestDropLayoutTablesThreading:
         assert calls == [True]
 
 
+class TestPDFReaderPyMuPDFSequential:
+    """PyMuPDF engine must parse pages sequentially (MuPDF is not thread-safe).
+
+    These are correctness/regression guards rather than red-green tests: a
+    thread-safety race is non-deterministic, so we cannot reliably reproduce a
+    crash. Instead we pin the contract -- no ThreadPoolExecutor is used, multi
+    page output is complete and correctly ordered, and a warning fires when a
+    caller requests workers > 1 (which is now ignored).
+    """
+
+    @staticmethod
+    def _four_page_pdf(tmp_path):
+        """Build a 4-page PDF with a distinct marker on each page."""
+        import pymupdf
+
+        doc = pymupdf.open()
+        for n in range(1, 5):
+            page = doc.new_page(width=612, height=792)
+            page.insert_text((72, 72), f"Sequential Marker {n}", fontsize=18)
+            page.insert_text((72, 110), f"Body content for page {n}.", fontsize=11)
+        path = tmp_path / "seq.pdf"
+        doc.save(str(path))
+        doc.close()
+        return str(path)
+
+    def test_multipage_parses_all_pages_in_order(self, tmp_path):
+        pdf = self._four_page_pdf(tmp_path)
+        doc = PDFReaderPyMuPDFEngine(pdf, workers=4).to_dicts()
+
+        pages = doc["document"]["pages"]
+        assert doc["document"]["total_pages"] == 4
+        assert [p["page_number"] for p in pages] == [1, 2, 3, 4]
+        for n, page in enumerate(pages, start=1):
+            text = " ".join(
+                e.get("content", "") for e in page["elements"] if e.get("type") in ("header", "body_text")
+            )
+            assert f"Sequential Marker {n}" in text
+
+    def test_does_not_use_thread_pool_executor(self, tmp_path, monkeypatch):
+        """The engine must never dispatch pages onto a ThreadPoolExecutor."""
+        import concurrent.futures
+
+        calls = []
+        original_init = concurrent.futures.ThreadPoolExecutor.__init__
+
+        def spy_init(self, *args, **kwargs):
+            calls.append(True)
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(concurrent.futures.ThreadPoolExecutor, "__init__", spy_init)
+
+        pdf = self._four_page_pdf(tmp_path)
+        PDFReaderPyMuPDFEngine(pdf, workers=4).to_dicts()
+        assert calls == []
+
+    def test_warns_once_when_workers_gt_one(self, tmp_path, caplog):
+        import logging
+
+        pdf = self._four_page_pdf(tmp_path)
+        with caplog.at_level(logging.WARNING, logger="datagrunt.core.pdf_io.engines"):
+            PDFReaderPyMuPDFEngine(pdf, workers=4).to_dicts()
+
+        warnings = [r for r in caplog.records if "not thread-safe" in r.getMessage()]
+        assert len(warnings) == 1
+
+    def test_no_warning_when_workers_is_one(self, tmp_path, caplog):
+        import logging
+
+        pdf = self._four_page_pdf(tmp_path)
+        with caplog.at_level(logging.WARNING, logger="datagrunt.core.pdf_io.engines"):
+            PDFReaderPyMuPDFEngine(pdf, workers=1).to_dicts()
+
+        warnings = [r for r in caplog.records if "not thread-safe" in r.getMessage()]
+        assert warnings == []
+
+
 class TestPDFReaderPdfiumEngine:
     """Test suite for the PDFium reader engine."""
 

--- a/tests/pdf_api_tests/test_pdfreader.py
+++ b/tests/pdf_api_tests/test_pdfreader.py
@@ -224,6 +224,44 @@ class TestPDFReaderMultiprocessing:
         assert len(calls) > 0
 
 
+class TestPDFReaderPyMuPDFSequential:
+    """PyMuPDF parses sequentially because MuPDF is not thread-safe.
+
+    Regression guard (not red-green): a thread-safety race is non-deterministic,
+    so we cannot reliably reproduce a crash. We instead pin that parsing a
+    multi-page PDF with the public API and workers > 1 still returns every page
+    in the correct order with the expected content -- the ``workers`` setting is
+    accepted (API compatibility) but does not enable threading.
+    """
+
+    @staticmethod
+    def _four_page_pdf(tmp_path):
+        import pymupdf
+
+        doc = pymupdf.open()
+        for n in range(1, 5):
+            page = doc.new_page(width=612, height=792)
+            page.insert_text((72, 72), f"Sequential Marker {n}", fontsize=18)
+            page.insert_text((72, 110), f"Body content for page {n}.", fontsize=11)
+        path = tmp_path / "seq.pdf"
+        doc.save(str(path))
+        doc.close()
+        return str(path)
+
+    def test_to_dicts_all_pages_present_and_ordered(self, tmp_path):
+        pdf = self._four_page_pdf(tmp_path)
+        doc = PDFReader(pdf, engine="pymupdf", workers=4).to_dicts()
+
+        pages = doc["document"]["pages"]
+        assert doc["document"]["total_pages"] == 4
+        assert [p["page_number"] for p in pages] == [1, 2, 3, 4]
+        for n, page in enumerate(pages, start=1):
+            text = " ".join(
+                e.get("content", "") for e in page["elements"] if e.get("type") in ("header", "body_text")
+            )
+            assert f"Sequential Marker {n}" in text
+
+
 class TestPDFReaderJsonAndDictInputs:
     """Tests for initializing PDFReader with JSON files or dictionaries."""
 


### PR DESCRIPTION
Closes #77. 

- fix(pdf): parse PyMuPDF pages sequentially (MuPDF is not thread-safe)

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

**Merge-order note:** Overlaps with the branch for #102 (perf/pdf-pymupdf-reopen): both rewrite PDFReaderPyMuPDFEngine.to_dicts. If both are approved, the combined resolution keeps this branch's workers>1 warning plus #102's parse_document delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)