### PR TITLE
fix(pdf): keep page content when OCR fails instead of dropping the page

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -56,10 +56,17 @@ class PdfiumNativeReader:
                 )
             ]
             ocr_used = False
+            warnings = []
             if not full_text.strip():
-                full_text, extra, ocr_used = self._ocr_fallback(doc, page_index, width, height)
-                text_objects.extend(extra)
-            return {
+                try:
+                    full_text, extra, ocr_used = self._ocr_fallback(doc, page_index, width, height)
+                    text_objects.extend(extra)
+                except Exception as exc:  # noqa: BLE001 - soft per-category failure
+                    # OCR failed (e.g. missing tesseract). Keep the page with its
+                    # already-extracted images/text rather than dropping it, and
+                    # record a page-level warning. See base.py soft-failure contract.
+                    warnings.append(f"OCR failed: {exc}")
+            page_dict = {
                 "page_number": page_index + 1,
                 "width": round(float(width), 2),
                 "height": round(float(height), 2),
@@ -68,6 +75,9 @@ class PdfiumNativeReader:
                 "images": images,
                 "ocr": ocr_used,
             }
+            if warnings:
+                page_dict["warnings"] = warnings
+            return page_dict
         finally:
             if should_close:
                 doc.close()

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -65,12 +65,23 @@ class DocumentAssembler:
                         return True
                 return False
 
+            warnings = []
             if analysis.has_text_layer:
                 for block in self.backend.extract_text_blocks(page_index):
                     if not is_inside_table(block.bbox):
                         elements.append(self._text_element(block, gen_elem_id(), page_index))
             elif analysis.is_scanned:
-                for block in self.backend.ocr_page(page_index, dpi=dpi_for_page(analysis.width, analysis.height)):
+                try:
+                    ocr_blocks = self.backend.ocr_page(
+                        page_index, dpi=dpi_for_page(analysis.width, analysis.height)
+                    )
+                except Exception as exc:  # noqa: BLE001 - soft per-category failure
+                    # OCR failed (e.g. missing tesseract). Keep the page with its
+                    # already-extracted images/tables rather than dropping it, and
+                    # record a page-level warning. See base.py soft-failure contract.
+                    ocr_blocks = []
+                    warnings.append(f"OCR failed: {exc}")
+                for block in ocr_blocks:
                     if not is_inside_table(block.bbox):
                         elements.append(self._ocr_element(block, gen_elem_id(), page_index))
 
@@ -89,13 +100,16 @@ class DocumentAssembler:
             elif analysis.has_text_layer and len(elements) == 0:
                 classification = "text_only"
 
-            return {
+            page_dict = {
                 "page_number": page_index + 1,
                 "width": float(analysis.width),
                 "height": float(analysis.height),
                 "classification": classification,
                 "elements": PageLayoutSorter(ElementAdapter()).sort(elements),
             }
+            if warnings:
+                page_dict["warnings"] = warnings
+            return page_dict
 
     def parse_document(self, total_pages, image_output_dir=None) -> dict:
         """Parse all pages sequentially and combine into the document envelope."""

--- a/tests/core_tests/pdf_io_tests/test_ocr_partial_failure.py
+++ b/tests/core_tests/pdf_io_tests/test_ocr_partial_failure.py
@@ -1,0 +1,75 @@
+"""OCR failure must not discard an image-only page (issue #96).
+
+When OCR fails (e.g. the tesseract binary is missing) on an image-only page,
+the page must still appear in the parsed output with its already-extracted
+image/text content and a page-level warning marker, rather than the whole page
+being dropped. This exercises both the native pdfium schema and the structured
+(unified element) schema, plus ``get_sample``.
+"""
+
+from datagrunt.core.pdf_io import pdfcomponents
+from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine, PDFReaderPyMuPDFEngine
+from datagrunt.core.pdf_io.extraction import pdfium_native
+from datagrunt.core.pdf_io.extraction.pdfium_native import PdfiumNativeReader
+from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
+
+
+def _tesseract_not_found(*args, **kwargs):
+    """Raise the real pytesseract error that a missing binary would raise."""
+    import pytesseract
+
+    raise pytesseract.TesseractNotFoundError()
+
+
+class TestNativeSchemaOcrFailure:
+    """Native pdfium schema keeps the page when OCR fails."""
+
+    def test_parse_page_keeps_image_and_marks_ocr_false(self, scanned_pdf, tmp_path, monkeypatch):
+        monkeypatch.setattr(pdfium_native, "ocr_data_to_blocks", _tesseract_not_found)
+        page = PdfiumNativeReader(scanned_pdf).parse_page(0, image_output_dir=str(tmp_path))
+
+        assert page["page_number"] == 1
+        assert page["ocr"] is False
+        assert len(page["images"]) >= 1  # already-extracted image survives
+        assert page.get("warnings"), "expected a page-level OCR warning"
+        assert any("ocr" in w.lower() for w in page["warnings"])
+
+    def test_to_dicts_native_keeps_page(self, scanned_pdf, tmp_path, monkeypatch):
+        monkeypatch.setattr(pdfium_native, "ocr_data_to_blocks", _tesseract_not_found)
+        document = PDFReaderPdfiumEngine(scanned_pdf, structured=False).to_dicts(
+            image_output_dir=str(tmp_path)
+        )
+        pages = document["document"]["pages"]
+        assert len(pages) == 1  # page not dropped
+        assert pages[0]["ocr"] is False
+        assert len(pages[0]["images"]) >= 1
+
+    def test_get_sample_native_does_not_raise(self, scanned_pdf, monkeypatch):
+        monkeypatch.setattr(pdfium_native, "ocr_data_to_blocks", _tesseract_not_found)
+        page = PDFReaderPdfiumEngine(scanned_pdf, structured=False).get_sample()
+        assert page["page_number"] == 1
+        assert page["ocr"] is False
+
+
+class TestStructuredSchemaOcrFailure:
+    """Structured (unified) schema keeps the page when OCR fails."""
+
+    def _force_ocr_failure(self, monkeypatch, assembler):
+        monkeypatch.setattr(assembler.backend, "ocr_page", _tesseract_not_found)
+
+    def test_parse_page_keeps_image_and_marks_warning(self, scanned_pdf, tmp_path, monkeypatch):
+        assembler = pdfcomponents.DocumentAssembler(scanned_pdf)
+        self._force_ocr_failure(monkeypatch, assembler)
+        page = assembler.parse_page(0, image_output_dir=str(tmp_path))
+
+        assert page["page_number"] == 1
+        # The already-extracted image element survives even though OCR failed.
+        assert any(e["type"] == "image" for e in page["elements"])
+        assert page.get("warnings"), "expected a page-level OCR warning"
+        assert any("ocr" in w.lower() for w in page["warnings"])
+
+    def test_get_sample_structured_does_not_raise(self, scanned_pdf, monkeypatch):
+        monkeypatch.setattr(PyMuPDFBackend, "ocr_page", _tesseract_not_found)
+        page = PDFReaderPyMuPDFEngine(scanned_pdf).get_sample()
+        assert page["page_number"] == 1
+        assert any(e["type"] == "image" for e in page["elements"])


### PR DESCRIPTION
Closes #96. 

- fix(pdf): keep page content when OCR fails instead of dropping the page

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)