### PR TITLE
fix(pdf): pair PyMuPDF image bboxes by xref, not list index

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -143,10 +143,18 @@ class PyMuPDFBackend(ExtractionBackend):
                 os.makedirs(output_dir, exist_ok=True)
             page = doc[page_number]
             image_list = page.get_images()
-            image_blocks = [b for b in page.get_text("dict")["blocks"] if b.get("type") == 1]
             results = []
+            # ``get_images()`` lists images in resource (xref) order, which can
+            # differ from the content/display order. Resolve each image's bbox by
+            # its xref so positions never get swapped; track per-xref occurrences
+            # so an image drawn multiple times maps to the correct rect each time.
+            xref_occurrence = {}
             for idx, img_info in enumerate(image_list):
-                block = self._image_block(doc, img_info, idx, image_blocks, output_dir, name_prefix, page_number)
+                xref = img_info[0]
+                occurrence = xref_occurrence.get(xref, 0)
+                xref_occurrence[xref] = occurrence + 1
+                bbox = self._resolve_image_bbox(page, xref, occurrence)
+                block = self._image_block(doc, img_info, idx, bbox, output_dir, name_prefix, page_number)
                 if block is not None:
                     results.append(block)
             return results
@@ -154,8 +162,36 @@ class PyMuPDFBackend(ExtractionBackend):
             if should_close:
                 doc.close()
 
-    def _image_block(self, doc, img_info, idx, image_blocks, output_dir, name_prefix, page_number):
-        """Extract one image to an ImageBlock (or None to skip), <40px filtered."""
+    @staticmethod
+    def _resolve_image_bbox(page, xref, occurrence) -> BBox:
+        """Return the BBox for the ``occurrence``-th placement of image ``xref``.
+
+        Uses ``page.get_image_rects(xref)`` so the bbox always corresponds to the
+        specific image being emitted rather than a position paired by list index.
+        Falls back to a zero box when the image has no resolvable rect (e.g. it is
+        referenced but never drawn).
+        """
+        try:
+            rects = page.get_image_rects(xref)
+        except Exception:  # noqa: BLE001 - rect lookup is best-effort
+            rects = []
+        if not rects:
+            return BBox(0, 0, 0, 0)
+        # ``get_image_rects`` returns one rect per placement, in placement order,
+        # so the k-th occurrence in ``get_images()`` maps to the k-th rect.
+        rect = rects[occurrence] if occurrence < len(rects) else rects[0]
+        return BBox(
+            x=round(rect.x0, 2),
+            y=round(rect.y0, 2),
+            w=round(rect.x1 - rect.x0, 2),
+            h=round(rect.y1 - rect.y0, 2),
+        )
+
+    def _image_block(self, doc, img_info, idx, bbox, output_dir, name_prefix, page_number):
+        """Extract one image to an ImageBlock (or None to skip), <40px filtered.
+
+        ``bbox`` is the already-resolved (by xref) position for this image.
+        """
         try:
             base_image = doc.extract_image(img_info[0])
         except Exception:  # noqa: BLE001
@@ -185,10 +221,6 @@ class PyMuPDFBackend(ExtractionBackend):
             file_path = os.path.join(output_dir, f"{name_prefix}_page{page_number}_img{idx}.{ext}")
             with open(file_path, "wb") as f:
                 f.write(image_bytes)
-        bbox = BBox(0, 0, 0, 0)
-        if idx < len(image_blocks):
-            b = image_blocks[idx]["bbox"]
-            bbox = BBox(x=round(b[0], 2), y=round(b[1], 2), w=round(b[2] - b[0], 2), h=round(b[3] - b[1], 2))
         return ImageBlock(bbox=bbox, file_path=file_path, width_px=width, height_px=height, fmt=ext)
 
     def ocr_page(self, page_number: int, dpi: int = 300) -> list:

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pymupdf_backend.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pymupdf_backend.py
@@ -23,3 +23,70 @@ class TestPyMuPDFBackend:
     def test_missing_file_raises(self):
         with pytest.raises(FileNotFoundError):
             PyMuPDFBackend("nope.pdf")
+
+    @staticmethod
+    def _two_image_swapped_draw_order_pdf(tmp_path):
+        """Build a 2-image page whose draw order differs from resource order.
+
+        Inserts a distinctively-sized blue image top-left (80px, lower xref,
+        ``fzImg0``) and a green image bottom-right (60px, higher xref,
+        ``fzImg1``), then rewrites the content stream so the green image is
+        *drawn first*. After this, ``page.get_images()`` still lists images in
+        resource/xref order ``[blue@top-left, green@bottom-right]`` while
+        ``get_text("dict")`` reports them in draw order
+        ``[green@bottom-right, blue@top-left]`` -- the exact mismatch that breaks
+        index-based bbox pairing. The two images differ in pixel size so each
+        emitted block can be identified by ``width_px`` regardless of order.
+
+        Returns ``(pdf_path, blue_corner, green_corner)`` -- the ``(x, y)``
+        top-left corner each image was actually placed at, in datagrunt's
+        top-left-origin convention.
+        """
+        import pymupdf
+
+        doc = pymupdf.open()
+        page = doc.new_page(width=400, height=400)
+        blue = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 80, 80))
+        blue.set_rect(blue.irect, (0, 0, 255))
+        green = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 60, 60))
+        green.set_rect(green.irect, (0, 255, 0))
+        page.insert_image(pymupdf.Rect(20, 20, 100, 100), stream=blue.tobytes("png"))
+        page.insert_image(pymupdf.Rect(280, 300, 340, 360), stream=green.tobytes("png"))
+        page.clean_contents()  # normalize so we can reliably find the two draw blocks
+
+        content_xref = page.get_contents()[0]
+        stream = doc.xref_stream(content_xref).decode("latin-1")
+        blue_block = "q 80 0 0 80 20 300 cm /fzImg0 Do Q"
+        green_block = "q 60 0 0 60 280 40 cm /fzImg1 Do Q"
+        # Swap the two draw blocks so green (higher xref) is drawn before blue.
+        swapped = (
+            stream.replace(blue_block, "__BLUE__")
+            .replace(green_block, blue_block)
+            .replace("__BLUE__", green_block)
+        )
+        assert swapped != stream, "content-stream swap did not match expected draw blocks"
+        doc.update_stream(content_xref, swapped.encode("latin-1"))
+
+        path = tmp_path / "swapped.pdf"
+        doc.save(str(path))
+        doc.close()
+        return str(path), (20.0, 20.0), (280.0, 300.0)
+
+    def test_image_bbox_paired_by_xref_not_index(self, tmp_path):
+        """Each image must get ITS OWN bbox even when draw order != resource order.
+
+        Regression for the index-based pairing bug: with draw order swapped, the
+        old code paired ``get_images()[idx]`` with ``image_blocks[idx]`` and gave
+        each image the *other* image's position. Resolving by xref fixes it.
+        """
+        pdf, blue_corner, green_corner = self._two_image_swapped_draw_order_pdf(tmp_path)
+        images = PyMuPDFBackend(pdf).extract_images(0)
+        assert len(images) == 2
+        # Identify each image by its distinctive pixel size, then assert it landed
+        # at the position where THAT image was actually placed.
+        by_size = {im.width_px: im for im in images}
+        assert set(by_size) == {80, 60}
+        blue, green = by_size[80], by_size[60]
+        assert (round(blue.bbox.x, 1), round(blue.bbox.y, 1)) == blue_corner
+        assert (round(green.bbox.x, 1), round(green.bbox.y, 1)) == green_corner
+        assert all(im.bbox.w > 0 and im.bbox.h > 0 for im in images)


### PR DESCRIPTION
Closes #79. 

- fix(pdf): pair PyMuPDF image bboxes by xref, not list index

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)