### PR TITLE
fix(csv): atomic normalize rebuild + collision-proof, empty-safe normalizer

### DIFF
--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -410,6 +410,9 @@ class CSVColumnNameNormalizer:
 
     SPECIAL_CHARS_PATTERN = re.compile(r"[^a-z0-9]+")
     MULTI_UNDERSCORE_PATTERN = re.compile(r"_+")
+    # Used when a header normalizes to the empty string so it can still be
+    # uniquified into a valid, non-empty identifier.
+    EMPTY_NAME_PLACEHOLDER = "column"
 
     def __init__(self, filepath, columns=None):
         """Initialize the CSVColumnNameNormalizer with a filepath.
@@ -454,11 +457,25 @@ class CSVColumnNameNormalizer:
         name = self.SPECIAL_CHARS_PATTERN.sub("_", name)
         name = name.strip("_")
         name = self.MULTI_UNDERSCORE_PATTERN.sub("_", name)
-        return f"_{name}" if name and name[0].isdigit() else name
+        # A header of only special characters (e.g. "%" or "()") normalizes to
+        # the empty string, which is an invalid zero-length SQL identifier and
+        # is silently dropped by some engines. Fall back to a placeholder so it
+        # can be uniquified into a valid column name.
+        if not name:
+            return self.EMPTY_NAME_PLACEHOLDER
+        return f"_{name}" if name[0].isdigit() else name
 
     def _make_unique_column_names(self, columns_list):
         """
         Make unique column names by appending a number to duplicate names.
+
+        A naive ``name_N`` suffix can itself collide with a real column (e.g.
+        ``col_a, col_a, col_a_1`` would emit two ``col_a_1``). To guarantee a
+        unique result, this tracks every name already emitted and keeps
+        incrementing the suffix until the candidate is unused across the whole
+        list. Downstream SQL projections and Arrow renames rely on this: a
+        duplicate name breaks DuckDB's ``AS`` projection and silently drops a
+        column in PyArrow.
 
         Args:
             columns_list (list): List of column names to make unique
@@ -466,16 +483,17 @@ class CSVColumnNameNormalizer:
         Returns:
             list: List of unique column names
         """
-        name_count = {}
+        emitted = set()
         unique_names = []
 
         for name in columns_list:
-            if name in name_count:
-                name_count[name] += 1
-                unique_names.append(f"{name}_{name_count[name]}")
-            else:
-                name_count[name] = 0
-                unique_names.append(name)
+            candidate = name
+            suffix = 0
+            while candidate in emitted:
+                suffix += 1
+                candidate = f"{name}_{suffix}"
+            emitted.add(candidate)
+            unique_names.append(candidate)
 
         return unique_names
 

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -277,13 +277,29 @@ class DuckDBQueries:
         of engines throughout the ecosystem may have different conventions,
         this method uses the CSVColumnNameNormalizer class to ensure
         consistent naming conventions across different processing engines.
+
+        The rename is done as a single atomic rebuild rather than a sequence of
+        ``ALTER TABLE ... RENAME COLUMN`` statements. Sequential renames can
+        collide mid-flight: if two distinct headers normalize to the same name
+        (e.g. ``Col A`` and ``col_a`` both -> ``col_a``), an intermediate rename
+        would target a name a not-yet-renamed column still holds, raising a
+        CatalogException. Projecting every column to its new name in one
+        ``CREATE OR REPLACE TABLE ... AS SELECT`` avoids any intermediate state.
         """
         self.connection.sql(self.import_csv_query())
         table_columns = self.connection.sql(f"SELECT * FROM {self.database_table_name} LIMIT 0").columns
         normalizer = CSVColumnNameNormalizer(self.filepath, columns=table_columns)
-        for old_name, new_name in zip(table_columns, normalizer.columns_normalized):
-            sql_string = f'ALTER TABLE {self.database_table_name} RENAME COLUMN "{old_name}" TO "{new_name}"'
-            self.connection.sql(sql_string)
+        # The normalizer guarantees the new names are unique among themselves,
+        # so the projection below cannot produce a duplicate output column.
+        projections = ", ".join(
+            f'"{old_name}" AS "{new_name}"'
+            for old_name, new_name in zip(table_columns, normalizer.columns_normalized)
+        )
+        rebuild_sql = (
+            f"CREATE OR REPLACE TABLE {self.database_table_name} AS "
+            f"SELECT {projections} FROM {self.database_table_name}"
+        )
+        self.connection.sql(rebuild_sql)
 
     def create_table(self, normalize_columns=False):
         """Create a DuckDB table from the CSV file.

--- a/tests/core_tests/csv_io_tests/test_csvcomponents.py
+++ b/tests/core_tests/csv_io_tests/test_csvcomponents.py
@@ -148,6 +148,47 @@ class TestCSVColumnNameNormalizer:
         assert mapping["First Name"] == "first_name"
         assert mapping["Last Name"] == "last_name"
 
+    def test_normalized_name_collides_with_existing_suffixed_name(self, tmp_path):
+        """The uniquifier must not emit a name that collides with a real column.
+
+        ``Col A`` and ``col a`` both normalize to ``col_a``; the third header
+        ``col_a_1`` already occupies the naive ``col_a_1`` suffix. The result
+        must be three DISTINCT names, so the suffix counter has to keep
+        incrementing past names already taken.
+        """
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("Col A,col a,col_a_1\n1,2,3")
+
+        normalizer = CSVColumnNameNormalizer(str(csv_file))
+        normalized = normalizer.columns_normalized
+        assert len(normalized) == 3
+        assert len(set(normalized)) == 3  # no collisions
+
+    def test_header_that_normalizes_to_empty_gets_placeholder(self, tmp_path):
+        """A header cell of only special chars must not normalize to ``""``.
+
+        An empty identifier (e.g. from a header of ``%``) is an invalid,
+        zero-length SQL identifier. The normalizer must return a non-empty
+        placeholder so it can be uniquified into a valid column name.
+        """
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("%,name\n1,2")
+
+        normalizer = CSVColumnNameNormalizer(str(csv_file))
+        normalized = normalizer.columns_normalized
+        assert all(name != "" for name in normalized)
+        assert len(set(normalized)) == len(normalized)
+
+    def test_multiple_empty_headers_get_unique_placeholders(self, tmp_path):
+        """Several empty-normalizing headers must yield distinct placeholders."""
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("%,(),name\n1,2,3")
+
+        normalizer = CSVColumnNameNormalizer(str(csv_file))
+        normalized = normalizer.columns_normalized
+        assert all(name != "" for name in normalized)
+        assert len(set(normalized)) == 3
+
 
 class TestCSVRows:
     """Test suite for CSVRows class."""

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -416,3 +416,56 @@ class TestEngines:
         assert "last_name" in df.columns
         assert "e_mail" in df.columns
         assert "phone" in df.columns
+
+
+class TestNormalizeCollidingColumnsAllEngines:
+    """``normalize_columns=True`` must behave identically across engines.
+
+    When two distinct headers normalize to the same name, every engine must
+    disambiguate them rather than crash or silently drop a column.
+    """
+
+    def test_colliding_normalized_names_all_engines(self, tmp_path):
+        """``Col A,col_a`` both normalize to ``col_a`` on every engine.
+
+        The DuckDB engine historically crashed here with a CatalogException
+        because it renamed columns sequentially; polars/pyarrow returned
+        ``['col_a', 'col_a_1']``. All three must now agree.
+        """
+        csv_file = tmp_path / "collide.csv"
+        csv_file.write_text("Col A,col_a\n1,2\n3,4\n")
+
+        results = {}
+        for engine in ALL_ENGINES:
+            reader = CSVEngineFactory(str(csv_file), engine).create_reader()
+            df = reader.to_dataframe(normalize_columns=True)
+            results[engine] = (df.columns, len(df))
+
+        for engine in ALL_ENGINES:
+            assert results[engine][0] == ["col_a", "col_a_1"], engine
+            assert results[engine][1] == 2, engine
+
+    def test_three_way_collision_yields_distinct_names_all_engines(self, tmp_path):
+        """``Col A,col a,col_a_1`` must produce 3 distinct names on every engine."""
+        csv_file = tmp_path / "collide3.csv"
+        csv_file.write_text("Col A,col a,col_a_1\n1,2,3\n")
+
+        for engine in ALL_ENGINES:
+            reader = CSVEngineFactory(str(csv_file), engine).create_reader()
+            df = reader.to_dataframe(normalize_columns=True)
+            assert len(df.columns) == 3, engine
+            assert len(set(df.columns)) == 3, engine
+
+    def test_empty_normalizing_header_is_valid_all_engines(self, tmp_path):
+        """A header that normalizes to empty must become a valid column name."""
+        # Three columns so the comma is unambiguously the inferred delimiter
+        # (a two-field "%,name" header ties %/comma and the sniffer would pick
+        # %). Both "%" and "()" normalize to empty and must get valid names.
+        csv_file = tmp_path / "empty_header.csv"
+        csv_file.write_text("%,(),name\n1,2,3\n")
+
+        for engine in ALL_ENGINES:
+            reader = CSVEngineFactory(str(csv_file), engine).create_reader()
+            df = reader.to_dataframe(normalize_columns=True)
+            assert len(df.columns) == 3, engine
+            assert all(col != "" for col in df.columns), engine


### PR DESCRIPTION
Closes #75. 

- fix(csv): atomic normalize rebuild + collision-proof, empty-safe normalizer

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

**Merge-order note:** Conflicts with the branch for #82 (fix/sec-duckdb-sql-escaping) in update_and_normalize_column_names. Combined resolution: keep this branch's atomic CREATE-OR-REPLACE projection and apply #82's _escape_identifier to the projected names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)