### PR TITLE
fix(databases): open DuckDB connection lazily and dispose deterministically

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -217,8 +217,13 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         Returns:
             A Polars DataFrame containing the sample rows.
         """
-        relation = self.queries.create_table(normalize_columns)
-        return relation.limit(CSVEngineProperties.dataframe_sample_rows).pl()
+        # Materialize fully (.pl()) before closing so the per-call connection is
+        # released deterministically rather than waiting on garbage collection.
+        try:
+            relation = self.queries.create_table(normalize_columns)
+            return relation.limit(CSVEngineProperties.dataframe_sample_rows).pl()
+        finally:
+            self.queries.close()
 
     def to_dataframe(self, normalize_columns=False):
         """
@@ -231,7 +236,11 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         Returns:
             A Polars dataframe.
         """
-        return self.queries.create_table(normalize_columns).pl()
+        # Materialize fully (.pl()) before closing the per-call connection.
+        try:
+            return self.queries.create_table(normalize_columns).pl()
+        finally:
+            self.queries.close()
 
     def to_arrow_table(self, normalize_columns=False):
         """
@@ -244,10 +253,14 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         Returns:
             A PyArrow table.
         """
-        result = self.queries.create_table(normalize_columns).arrow()
-        if isinstance(result, pa.Table):
-            return result
-        return result.read_all()
+        # Materialize into an in-memory pa.Table before closing the connection.
+        try:
+            result = self.queries.create_table(normalize_columns).arrow()
+            if isinstance(result, pa.Table):
+                return result
+            return result.read_all()
+        finally:
+            self.queries.close()
 
     def to_dicts(self, normalize_columns=False):
         """
@@ -260,6 +273,7 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         Returns:
             A list of dictionaries.
         """
+        # to_dataframe already materializes and closes; this is a thin wrapper.
         return self.to_dataframe(normalize_columns).to_dicts()
 
     def _normalize_relation_columns(self, relation):
@@ -472,8 +486,13 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
                 normalize_columns bool: Whether to normalize column names.
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.csv_export_filename, export_filename)
-        self.queries.create_table(normalize_columns)
-        self.queries.connection.sql(self.queries.export_csv_query(filename))
+        # COPY executes eagerly on .sql(), so the file is written before close()
+        # releases the per-call connection.
+        try:
+            self.queries.create_table(normalize_columns)
+            self.queries.connection.sql(self.queries.export_csv_query(filename))
+        finally:
+            self.queries.close()
 
     def write_excel(self, export_filename=None, normalize_columns=False):
         """
@@ -485,8 +504,11 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
             names.
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.excel_export_filename, export_filename)
-        self.queries.create_table(normalize_columns)
-        self.queries.connection.sql(self.queries.export_excel_query(filename))
+        try:
+            self.queries.create_table(normalize_columns)
+            self.queries.connection.sql(self.queries.export_excel_query(filename))
+        finally:
+            self.queries.close()
 
     def write_json(self, export_filename=None, normalize_columns=False):
         """
@@ -498,8 +520,11 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
             names.
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.json_export_filename, export_filename)
-        self.queries.create_table(normalize_columns)
-        self.queries.connection.sql(self.queries.export_json_query(filename))
+        try:
+            self.queries.create_table(normalize_columns)
+            self.queries.connection.sql(self.queries.export_json_query(filename))
+        finally:
+            self.queries.close()
 
     def write_json_newline_delimited(self, export_filename=None, normalize_columns=False):
         """
@@ -511,8 +536,11 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
             names.
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.json_newline_export_filename, export_filename)
-        self.queries.create_table(normalize_columns)
-        self.queries.connection.sql(self.queries.export_json_newline_delimited_query(filename))
+        try:
+            self.queries.create_table(normalize_columns)
+            self.queries.connection.sql(self.queries.export_json_newline_delimited_query(filename))
+        finally:
+            self.queries.close()
 
     def write_parquet(self, export_filename=None, normalize_columns=False):
         """
@@ -524,8 +552,11 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
             names.
         """
         filename = self.queries.set_export_filename(CSVEngineProperties.parquet_export_filename, export_filename)
-        self.queries.create_table(normalize_columns)
-        self.queries.connection.sql(self.queries.export_parquet_query(filename))
+        try:
+            self.queries.create_table(normalize_columns)
+            self.queries.connection.sql(self.queries.export_parquet_query(filename))
+        finally:
+            self.queries.close()
 
 
 class CSVWriterPolarsEngine(CSVBaseWriterEngine):

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -464,7 +464,13 @@ class CSVReaderPolarsEngine(CSVBaseReaderEngine):
             query = "SELECT col1, col2 FROM {dg.db_table}" # f string assumed
             dg.query_csv_data(query)
         """
-        return self.queries.sql_query_to_dataframe(sql_query, normalize_columns)
+        # The result is a fully-materialized polars DataFrame, so the
+        # connection can be disposed deterministically (unlike the duckdb
+        # engine, whose query_data returns a live relation).
+        try:
+            return self.queries.sql_query_to_dataframe(sql_query, normalize_columns)
+        finally:
+            self.queries.close()
 
 
 class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
@@ -849,7 +855,13 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
             query = "SELECT col1, col2 FROM {dg.db_table}" # f string assumed
             dg.query_csv_data(query)
         """
-        return self.queries.sql_query_to_dataframe(sql_query, normalize_columns)
+        # The result is a fully-materialized polars DataFrame, so the
+        # connection can be disposed deterministically (unlike the duckdb
+        # engine, whose query_data returns a live relation).
+        try:
+            return self.queries.sql_query_to_dataframe(sql_query, normalize_columns)
+        finally:
+            self.queries.close()
 
 
 class CSVWriterPyArrowEngine(CSVBaseWriterEngine):

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -39,8 +39,26 @@ class DuckDBQueries:
         self.filepath = Path(filepath)
         self.lenient = lenient
         self.database_table_name = self._set_database_table_name()
-        self.connection = duckdb.connect(":memory:")
+        # Opened lazily on first access via the ``connection`` property. Many
+        # construction paths (reading a table name, or any polars/pyarrow read)
+        # never touch DuckDB, so eagerly opening a connection here would waste
+        # one on every such instance.
+        self._connection = None
         self.skip_rows = _count_leading_comments(self.filepath)
+
+    @property
+    def connection(self):
+        """Return this instance's DuckDB connection, opening it on first use.
+
+        The connection is created lazily so that constructing a
+        ``DuckDBQueries`` (e.g. just to read ``database_table_name``) does not
+        open a connection. The public attribute name is unchanged, so existing
+        callers that do ``self.connection.sql(...)`` continue to work exactly
+        as they did with the previous eager attribute.
+        """
+        if self._connection is None:
+            self._connection = duckdb.connect(":memory:")
+        return self._connection
 
     @cached_property
     def delimiter(self):
@@ -68,7 +86,12 @@ class DuckDBQueries:
         becomes invalid once it is closed, so only call ``close()`` once you are
         done with results derived from this instance.
         """
-        self.connection.close()
+        # Only close if a connection was actually opened, and reset the backing
+        # attribute so a later access transparently reopens one (preserving the
+        # always-usable contract of the previous eager attribute).
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
 
     def _format_filename_string(self):
         """Remove all non alphanumeric characters from the file stem."""

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -124,6 +124,24 @@ class TestEngines:
             expected_type = QUERY_RESULT_TYPES[engine]
             assert isinstance(result, expected_type)
 
+    def test_query_data_disposes_connection_on_materializing_engines(self, sample_csv):
+        """polars/pyarrow query_data must close the DuckDB connection.
+
+        Those engines return a fully-materialized polars DataFrame from
+        ``sql_query_to_dataframe``, so nothing references the connection after
+        the call and it must be disposed deterministically. The duckdb engine
+        returns a live relation and must keep its connection open.
+        """
+        for engine in ("polars", "pyarrow"):
+            reader = CSVEngineFactory(sample_csv, engine).create_reader()
+            reader.query_data(f"SELECT * FROM {reader.db_table} LIMIT 1")
+            assert reader.queries._connection is None, engine
+
+        duckdb_reader = CSVEngineFactory(sample_csv, "duckdb").create_reader()
+        relation = duckdb_reader.query_data(f"SELECT * FROM {duckdb_reader.db_table} LIMIT 1")
+        assert duckdb_reader.queries._connection is not None
+        assert relation.fetchall()  # the live relation is still usable
+
     def test_reader_get_sample_all_engines(self, sample_csv):
         """Test get_sample method returns a sample DataFrame for all engines."""
         for engine in ALL_ENGINES:

--- a/tests/core_tests/databases_tests/test_databases.py
+++ b/tests/core_tests/databases_tests/test_databases.py
@@ -10,24 +10,31 @@ class TestDuckDBQueriesClose:
     """Explicit, deterministic disposal of the per-instance connection."""
 
     def test_close_releases_connection(self, tmp_path):
-        """close() must close the per-instance in-memory connection.
+        """close() must dispose the live per-instance in-memory connection.
 
         DuckDBQueries owns a private connection; close() gives callers a
         deterministic disposal path so they need not rely on garbage
         collection or a __del__ (intentionally not implemented).
+
+        The connection is now opened lazily, so close() resets the backing
+        handle to None. We therefore capture the live handle before closing and
+        assert THAT handle is dead afterwards; the property itself transparently
+        reopens on the next access (covered by TestDuckDBQueriesLazyConnection).
         """
         csv = tmp_path / "data.csv"
         csv.write_text("col1,col2\n1,A\n2,B\n")
         queries = DuckDBQueries(str(csv))
 
-        # Usable before close.
-        assert queries.connection.sql("SELECT 1").fetchone() == (1,)
+        # Usable before close; capture the live handle to verify disposal.
+        live_handle = queries.connection
+        assert live_handle.sql("SELECT 1").fetchone() == (1,)
 
         queries.close()
 
-        # Unusable after close: the underlying connection is gone.
+        # The disposed handle is unusable; the backing attribute is reset.
+        assert queries._connection is None
         with pytest.raises(duckdb.Error):
-            queries.connection.sql("SELECT 1")
+            live_handle.sql("SELECT 1")
 
     def test_close_is_idempotent(self, tmp_path):
         """Calling close() more than once must not raise."""
@@ -37,6 +44,47 @@ class TestDuckDBQueriesClose:
 
         queries.close()
         queries.close()  # second call must be a safe no-op
+
+
+class TestDuckDBQueriesLazyConnection:
+    """The per-instance DuckDB connection must open lazily, not eagerly."""
+
+    def test_connection_not_opened_until_first_access(self, tmp_path):
+        """Constructing DuckDBQueries must not open a connection.
+
+        Readers/writers build a DuckDBQueries just to read the table name; the
+        polars/pyarrow paths never touch DuckDB. Opening a connection eagerly
+        in __init__ wastes a connection on every such construction.
+        """
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1,col2\n1,A\n")
+        queries = DuckDBQueries(str(csv))
+
+        # No connection should exist before the property is first accessed.
+        assert queries._connection is None
+
+        # Accessing the public attribute opens it (backward-compatible usage).
+        assert queries.connection.sql("SELECT 1").fetchone() == (1,)
+        assert queries._connection is not None
+
+    def test_close_allows_reopen(self, tmp_path):
+        """After close(), a later access must transparently reopen.
+
+        close() resets the backing attribute to None so the connection can be
+        lazily reopened, matching the old eager attribute's always-usable
+        contract for any caller that touches it again.
+        """
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1,col2\n1,A\n")
+        queries = DuckDBQueries(str(csv))
+
+        assert queries.connection.sql("SELECT 1").fetchone() == (1,)
+        queries.close()
+        assert queries._connection is None
+
+        # A fresh access reopens a working connection.
+        assert queries.connection.sql("SELECT 2").fetchone() == (2,)
+        queries.close()
 
 
 def test_csv_quotes_after_sniffer_sample(tmp_path):


### PR DESCRIPTION
Closes #81. 

- fix(databases): open DuckDB connection lazily and dispose deterministically
- fix(databases): dispose the DuckDB connection after polars/pyarrow query_data

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

**Merge-order note:** Overlaps with the branch for #104 (perf/csv-query-data-reimport) on the databases.py connection-lifecycle seam; whichever merges second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)