### PR TITLE
fix(csv): skip only leading comment lines, not blank lines, when locating the header

### DIFF
--- a/src/datagrunt/core/csv_io/__init__.py
+++ b/src/datagrunt/core/csv_io/__init__.py
@@ -10,6 +10,7 @@ from datagrunt.core.csv_io.csvcomponents import (
     CSVStringSample,
     _check_csv_ragged_and_warn,
     _count_leading_comments,
+    _count_leading_physical_lines_before_header,
 )
 from datagrunt.core.csv_io.engines import (
     CSVEngineProperties,
@@ -39,5 +40,6 @@ __all__ = [
     "CSVWriterPyArrowEngine",
     "CSVEngineFactory",
     "_count_leading_comments",
+    "_count_leading_physical_lines_before_header",
     "_check_csv_ragged_and_warn",
 ]

--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -15,13 +15,42 @@ from datagrunt.core.file_io import FileProperties
 
 
 def _count_leading_comments(filepath):
+    """Count leading ``#``-prefixed comment lines before the header.
+
+    Blank lines are intentionally excluded: Polars and PyArrow already ignore
+    leading blank lines natively, so counting them here would double-skip and
+    push the header onto a data row (see issue #85). Blank lines interleaved
+    with comments are tolerated and do not stop the count.
+    """
     count = 0
     with open(filepath, "r", encoding=FileProperties(filepath).DEFAULT_ENCODING) as f:
         for line in f:
             stripped = line.strip()
-            if stripped.startswith("#") or not stripped:
+            if stripped.startswith("#"):
                 count += 1
+            elif not stripped:
+                # Blank line: skip over it without counting it as a row to skip.
+                continue
             else:
+                break
+    return count
+
+
+def _count_leading_physical_lines_before_header(filepath):
+    """Count every leading physical line up to and including the header line.
+
+    Unlike :func:`_count_leading_comments`, this counts blank lines too. It is
+    used for engines (PyArrow) whose ``skip_rows`` operates on physical lines
+    and does not natively ignore leading blank lines once explicit column names
+    are supplied.
+    """
+    count = 0
+    with open(filepath, "r", encoding=FileProperties(filepath).DEFAULT_ENCODING) as f:
+        for line in f:
+            stripped = line.strip()
+            count += 1
+            if stripped and not stripped.startswith("#"):
+                # This is the header line; include it in the skip count.
                 break
     return count
 

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -19,20 +19,9 @@ from datagrunt.core.csv_io.csvcomponents import (
     CSVColumnNameNormalizer,
     CSVColumns,
     _check_csv_ragged_and_warn,
+    _count_leading_physical_lines_before_header,
 )
 from datagrunt.core.databases import DuckDBQueries
-
-
-def _count_leading_comments(filepath):
-    count = 0
-    with open(filepath, "r", encoding="utf-8-sig") as f:
-        for line in f:
-            stripped = line.strip()
-            if stripped.startswith("#") or not stripped:
-                count += 1
-            else:
-                break
-    return count
 
 
 def _is_legacy_mac_newlines(filepath):
@@ -650,7 +639,7 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
                 table = table.rename_columns(new_names)
             return table
         try:
-            skip_count = _count_leading_comments(self.filepath) + 1
+            skip_count = _count_leading_physical_lines_before_header(self.filepath)
             table = pacsv.read_csv(
                 self.filepath,
                 read_options=pacsv.ReadOptions(column_names=columns, skip_rows=skip_count),
@@ -713,7 +702,7 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
                 table = table.rename_columns(new_names)
             return table
         try:
-            skip_count = _count_leading_comments(self.filepath) + 1
+            skip_count = _count_leading_physical_lines_before_header(self.filepath)
             table = pacsv.read_csv(
                 self.filepath,
                 read_options=pacsv.ReadOptions(column_names=columns, skip_rows=skip_count),
@@ -863,7 +852,7 @@ class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
                 table = table.rename_columns(new_names)
             return table
         try:
-            skip_count = _count_leading_comments(self.filepath) + 1
+            skip_count = _count_leading_physical_lines_before_header(self.filepath)
             table = pacsv.read_csv(
                 self.filepath,
                 read_options=pacsv.ReadOptions(column_names=columns, skip_rows=skip_count),

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -15,7 +15,7 @@ from datagrunt.core.csv_io import (
     CSVDelimiter,
     CSVDialect,
     _check_csv_ragged_and_warn,
-    _count_leading_comments,
+    _count_leading_physical_lines_before_header,
 )
 
 
@@ -40,7 +40,13 @@ class DuckDBQueries:
         self.lenient = lenient
         self.database_table_name = self._set_database_table_name()
         self.connection = duckdb.connect(":memory:")
-        self.skip_rows = _count_leading_comments(self.filepath)
+        # DuckDB's read_csv ``skip`` operates on physical lines and, unlike
+        # Polars/PyArrow, does not natively ignore leading blank lines. Skip
+        # every leading physical line up to (but not including) the header,
+        # which ``header=true`` then consumes. See issue #85. ``max(..., 0)``
+        # guards files with no header line (empty/blank), where the helper
+        # returns 0 and DuckDB rejects a negative ``skip``.
+        self.skip_rows = max(_count_leading_physical_lines_before_header(self.filepath) - 1, 0)
 
     @cached_property
     def delimiter(self):

--- a/tests/core_tests/csv_io_tests/test_leading_blank_lines.py
+++ b/tests/core_tests/csv_io_tests/test_leading_blank_lines.py
@@ -1,0 +1,64 @@
+"""Regression tests for issue #85.
+
+Leading blank lines before the header must not corrupt column metadata on
+any engine, and must not silently corrupt data on the pyarrow engine.
+"""
+
+import pytest
+
+from datagrunt import CSVReader
+from datagrunt.core import CSVColumns, CSVComponents
+
+ENGINES = ("polars", "duckdb", "pyarrow")
+
+# Two leading blank lines, then header, then two data rows.
+LEADING_BLANK_LINES_CONTENT = "\n\nname,age\nalice,30\nbob,25\n"
+
+
+@pytest.fixture
+def leading_blank_lines_csv(tmp_path):
+    """A CSV file whose header is preceded by leading blank lines."""
+    csv_file = tmp_path / "leading_blank_lines.csv"
+    csv_file.write_text(LEADING_BLANK_LINES_CONTENT)
+    return str(csv_file)
+
+
+class TestLeadingBlankLinesColumns:
+    """Column metadata must be correct regardless of leading blank lines."""
+
+    def test_csvcolumns_header_not_taken_from_data(self, leading_blank_lines_csv):
+        columns = CSVColumns(leading_blank_lines_csv)
+        assert columns.columns == ["name", "age"]
+        assert columns.columns_count == 2
+
+    def test_components_columns_metadata(self, leading_blank_lines_csv):
+        components = CSVComponents(leading_blank_lines_csv)
+        assert components.columns == ["name", "age"]
+        assert components.columns_normalized == ["name", "age"]
+        assert components.columns_count == 2
+
+    @pytest.mark.parametrize("engine", ENGINES)
+    def test_reader_columns_metadata(self, leading_blank_lines_csv, engine):
+        reader = CSVReader(leading_blank_lines_csv, engine=engine)
+        assert reader.columns == ["name", "age"]
+        assert reader.columns_normalized == ["name", "age"]
+        assert reader.columns_count == 2
+
+
+class TestLeadingBlankLinesData:
+    """Data must be parsed correctly regardless of leading blank lines."""
+
+    @pytest.mark.parametrize("engine", ENGINES)
+    def test_dataframe_header_and_data(self, leading_blank_lines_csv, engine):
+        reader = CSVReader(leading_blank_lines_csv, engine=engine)
+        df = reader.to_dataframe()
+
+        # Header must come from the real header row, not a data row.
+        assert list(df.columns) == ["name", "age"]
+
+        # All engines return a Polars dataframe from to_dataframe().
+        records = df.to_dicts()
+        names = [str(r["name"]) for r in records]
+        ages = [str(r["age"]) for r in records]
+        assert names == ["alice", "bob"]
+        assert ages == ["30", "25"]


### PR DESCRIPTION
Closes #85. 

- fix(csv): skip only leading comment lines, not blank lines, when locating the header

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

**Merge-order note:** Overlaps with the branch for #73 (fix/1-polars-comment-rows) in the leading-comment counting helpers; whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)