### PR TITLE
fix(pdf): contain image-dedupe deletion to the run's output directory

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -364,7 +364,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
         filename = set_export_filename(self.properties.json_export_filename, export_filename)
         document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
         if image_output_dir and dedupe_images:
-            pdfcomponents.ParsedDocument(document).dedupe_images()
+            pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
         with open(filename, "w") as f:
             json.dump(document, f, indent=2)
         return filename
@@ -376,7 +376,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
         filename = set_export_filename(self.properties.json_newline_export_filename, export_filename)
         document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
         if image_output_dir and dedupe_images:
-            pdfcomponents.ParsedDocument(document).dedupe_images()
+            pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
         records = pdfcomponents.ParsedDocument(document).flatten()
         with open(filename, "w") as f:
             for record in records:
@@ -398,7 +398,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
         filename = set_export_filename(self.properties.markdown_export_filename, export_filename)
         document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
         if image_output_dir and dedupe_images:
-            pdfcomponents.ParsedDocument(document).dedupe_images()
+            pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
         markdown_text = pdfcomponents.ParsedDocument(document).to_markdown(export_filename=filename)
         with open(filename, "w") as f:
             f.write(markdown_text)
@@ -415,7 +415,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
         directory = output_dir if output_dir else self.properties.images_export_dir
         document = self._reader().to_dicts(image_output_dir=directory)
         if dedupe:
-            pdfcomponents.ParsedDocument(document).dedupe_images()
+            pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=directory)
         paths = []
         seen = set()
         for page in document.get("document", {}).get("pages", []):
@@ -438,18 +438,18 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
     def _reader(self):
         return PDFReaderPdfiumEngine(self.filepath, workers=self.workers, structured=self.structured)
 
-    def _dedupe(self, document):
+    def _dedupe(self, document, image_output_dir):
         if self.structured:
-            pdfcomponents.ParsedDocument(document).dedupe_images()
+            pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
         else:
-            PdfiumNativeReader.dedupe_images(document)
+            PdfiumNativeReader.dedupe_images(document, image_output_dir=image_output_dir)
 
     def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
         """Parse the PDF and write the document JSON (native or unified schema)."""
         filename = set_export_filename(self.properties.json_export_filename, export_filename)
         document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
         if image_output_dir and dedupe_images:
-            self._dedupe(document)
+            self._dedupe(document, image_output_dir)
         with open(filename, "w") as f:
             json.dump(document, f, indent=2)
         return filename
@@ -461,7 +461,7 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
         filename = set_export_filename(self.properties.json_newline_export_filename, export_filename)
         document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
         if image_output_dir and dedupe_images:
-            self._dedupe(document)
+            self._dedupe(document, image_output_dir)
         if self.structured:
             records = pdfcomponents.ParsedDocument(document).flatten()
         else:
@@ -476,7 +476,7 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
         filename = set_export_filename(self.properties.markdown_export_filename, export_filename)
         document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
         if image_output_dir and dedupe_images:
-            self._dedupe(document)
+            self._dedupe(document, image_output_dir)
         if self.structured:
             markdown_text = pdfcomponents.ParsedDocument(document).to_markdown(export_filename=filename)
         else:
@@ -490,7 +490,7 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
         directory = output_dir if output_dir else self.properties.images_export_dir
         document = self._reader().to_dicts(image_output_dir=directory)
         if dedupe:
-            self._dedupe(document)
+            self._dedupe(document, directory)
         paths = []
         seen = set()
         for page in document.get("document", {}).get("pages", []):

--- a/src/datagrunt/core/pdf_io/extraction/image_dedupe.py
+++ b/src/datagrunt/core/pdf_io/extraction/image_dedupe.py
@@ -2,20 +2,63 @@
 
 import hashlib
 import os
+import stat
+from typing import Callable, Iterable, Optional
 
 
-def dedupe_image_files(images, get_path, set_path) -> int:
+def _is_deletion_safe(path: str, allowed_root: Optional[str]) -> bool:
+    """Return True only when ``path`` is a regular file this run may delete.
+
+    Deletion is a destructive primitive, and image ``file_path`` values come
+    from the (untrusted) parsed-document JSON, so a path is only safe when:
+
+    * it is not a symlink (we refuse to follow links into other directories),
+    * its resolved real path sits inside ``allowed_root`` (the caller-provided
+      image output directory), and
+    * an ``allowed_root`` was actually supplied (no root means delete nothing).
+
+    See issue #101: without these guards, attacker-controlled paths echoed from
+    the input document could be deleted (arbitrary file deletion).
+    """
+    if not allowed_root:
+        return False
+    try:
+        if stat.S_ISLNK(os.lstat(path).st_mode):
+            return False
+    except OSError:
+        return False
+    real_path = os.path.realpath(path)
+    real_root = os.path.realpath(allowed_root)
+    # ``commonpath`` raises on differing drives/relative-vs-absolute mixes; treat
+    # any such case as "not contained" rather than letting it escape.
+    try:
+        return os.path.commonpath([real_path, real_root]) == real_root
+    except ValueError:
+        return False
+
+
+def dedupe_image_files(
+    images: Iterable[dict],
+    get_path: Callable[[dict], Optional[str]],
+    set_path: Callable[[dict, str], None],
+    allowed_dir: Optional[str] = None,
+) -> int:
     """Collapse byte-identical files among image records; return count removed.
 
     Args:
         images: Iterable of mutable image records.
         get_path: Callable ``(record) -> path | None``.
         set_path: Callable ``(record, path) -> None`` repointing a record.
+        allowed_dir: The image output directory produced by this extraction run.
+            Only files resolving inside this directory are eligible for removal;
+            symlinks are never followed. When ``None`` (no run-owned directory),
+            no file is deleted, though records are still repointed at the first
+            occurrence so duplicate references collapse.
 
     Returns:
         The number of duplicate files removed from disk.
     """
-    seen = {}  # md5 digest -> first path that produced it
+    seen: dict = {}  # md5 digest -> first path that produced it
     removed = 0
     for record in images:
         path = get_path(record)
@@ -30,6 +73,8 @@ def dedupe_image_files(images, get_path, set_path) -> int:
         if first == path:
             continue
         set_path(record, first)
+        if not _is_deletion_safe(path, allowed_dir):
+            continue
         try:
             os.remove(path)
         except OSError:

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -163,8 +163,15 @@ class PdfiumNativeReader:
         }
 
     @staticmethod
-    def dedupe_images(document: dict) -> int:
-        """Collapse byte-identical extracted image files; return count removed."""
+    def dedupe_images(document: dict, image_output_dir: str | None = None) -> int:
+        """Collapse byte-identical extracted image files; return count removed.
+
+        Args:
+            document: Parsed native-schema document.
+            image_output_dir: Directory holding the images written by this run.
+                Only files resolving inside it are eligible for deletion (see
+                issue #101); when ``None`` no file is removed from disk.
+        """
         images = [
             img
             for page in document.get("document", {}).get("pages", [])
@@ -174,6 +181,7 @@ class PdfiumNativeReader:
             images,
             lambda img: img.get("file"),
             lambda img, p: img.__setitem__("file", p),
+            allowed_dir=image_output_dir,
         )
 
     @staticmethod

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -199,8 +199,14 @@ class ParsedDocument:
                 )
         return records
 
-    def dedupe_images(self) -> int:
-        """Collapse byte-identical extracted image files; return count removed."""
+    def dedupe_images(self, image_output_dir: str | None = None) -> int:
+        """Collapse byte-identical extracted image files; return count removed.
+
+        Args:
+            image_output_dir: Directory holding the images written by this run.
+                Only files resolving inside it are eligible for deletion (see
+                issue #101); when ``None`` no file is removed from disk.
+        """
         images = [
             el
             for page in self.document.get("document", {}).get("pages", [])
@@ -211,6 +217,7 @@ class ParsedDocument:
             images,
             lambda el: (el.get("metadata") or {}).get("file_path"),
             lambda el, p: el.setdefault("metadata", {}).__setitem__("file_path", p),
+            allowed_dir=image_output_dir,
         )
 
     def drop_layout_tables(self, min_rows: int = 2, min_cols: int = 2) -> int:

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -61,9 +61,9 @@ class PDFWriter(PDFComponents):
             if image_output_dir and dedupe_images:
                 is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
                 if is_structured:
-                    pdfcomponents.ParsedDocument(document).dedupe_images()
+                    pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
                 else:
-                    PdfiumNativeReader.dedupe_images(document)
+                    PdfiumNativeReader.dedupe_images(document, image_output_dir=image_output_dir)
             with open(filename, "w") as f:
                 json.dump(document, f, indent=2)
             return filename
@@ -92,9 +92,9 @@ class PDFWriter(PDFComponents):
             if image_output_dir and dedupe_images:
                 is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
                 if is_structured:
-                    pdfcomponents.ParsedDocument(document).dedupe_images()
+                    pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
                 else:
-                    PdfiumNativeReader.dedupe_images(document)
+                    PdfiumNativeReader.dedupe_images(document, image_output_dir=image_output_dir)
             
             is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
             if is_structured:
@@ -132,9 +132,9 @@ class PDFWriter(PDFComponents):
             if image_output_dir and dedupe_images:
                 is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
                 if is_structured:
-                    pdfcomponents.ParsedDocument(document).dedupe_images()
+                    pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
                 else:
-                    PdfiumNativeReader.dedupe_images(document)
+                    PdfiumNativeReader.dedupe_images(document, image_output_dir=image_output_dir)
             
             is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
             if is_structured:
@@ -162,12 +162,13 @@ class PDFWriter(PDFComponents):
         """
         if self._parsed_dict is not None:
             document = self._parsed_dict
+            image_dir = output_dir if output_dir else "output_images"
             is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
             if dedupe:
                 if is_structured:
-                    pdfcomponents.ParsedDocument(document).dedupe_images()
+                    pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_dir)
                 else:
-                    PdfiumNativeReader.dedupe_images(document)
+                    PdfiumNativeReader.dedupe_images(document, image_output_dir=image_dir)
             paths = []
             seen = set()
             for page in document.get("document", {}).get("pages", []):

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_image_dedupe.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_image_dedupe.py
@@ -1,0 +1,85 @@
+"""Tests for the shared byte-identical image-file de-duplication helper.
+
+Includes a security regression test for issue #101: image ``file_path`` values
+are attacker-controlled file *content* (parsed-document JSON is a documented
+input), so dedupe must never ``os.remove`` a path outside the caller-provided
+output directory, nor follow a symlink.
+"""
+
+import os
+
+from datagrunt.core.pdf_io.extraction.image_dedupe import dedupe_image_files
+
+
+def _records(*paths):
+    """Build mutable image records keyed on ``file_path``."""
+    return [{"file_path": p} for p in paths]
+
+
+def _get(record):
+    return record.get("file_path")
+
+
+def _set(record, path):
+    record["file_path"] = path
+
+
+def test_in_run_duplicates_inside_output_dir_are_collapsed(tmp_path):
+    output_dir = tmp_path / "images"
+    output_dir.mkdir()
+    first = output_dir / "img_0.png"
+    second = output_dir / "img_1.png"
+    payload = b"identical-bytes"
+    first.write_bytes(payload)
+    second.write_bytes(payload)
+
+    records = _records(str(first), str(second))
+    removed = dedupe_image_files(records, _get, _set, allowed_dir=str(output_dir))
+
+    assert removed == 1
+    assert second.exists() is False
+    assert first.exists() is True
+    # The duplicate record is repointed at the surviving file.
+    assert records[1]["file_path"] == str(first)
+
+
+def test_paths_outside_output_dir_are_not_deleted(tmp_path):
+    """Issue #101: attacker-named paths outside the run's dir must survive."""
+    output_dir = tmp_path / "images"
+    output_dir.mkdir()
+
+    outside_first = tmp_path / "victim_a"
+    outside_second = tmp_path / "victim_b"
+    # Two byte-identical (empty) files mimic the empty-file hash collision repro.
+    outside_first.write_bytes(b"")
+    outside_second.write_bytes(b"")
+
+    records = _records(str(outside_first), str(outside_second))
+    removed = dedupe_image_files(records, _get, _set, allowed_dir=str(output_dir))
+
+    assert removed == 0
+    assert outside_first.exists() is True
+    assert outside_second.exists() is True
+
+
+def test_symlink_inside_output_dir_is_not_followed(tmp_path):
+    """A symlink whose real target sits outside the dir must not be deleted."""
+    output_dir = tmp_path / "images"
+    output_dir.mkdir()
+
+    real_image = output_dir / "img_0.png"
+    real_image.write_bytes(b"")
+
+    victim = tmp_path / "important.lock"
+    victim.write_bytes(b"")
+
+    # Symlink lives inside the output dir but points at the outside victim.
+    link = output_dir / "img_1.png"
+    link.symlink_to(victim)
+
+    records = _records(str(real_image), str(link))
+    removed = dedupe_image_files(records, _get, _set, allowed_dir=str(output_dir))
+
+    assert removed == 0
+    assert victim.exists() is True
+    assert os.path.islink(link) is True

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
@@ -35,5 +35,5 @@ class TestPdfiumNativeReader:
         a.write_bytes(b"X")
         b.write_bytes(b"X")
         doc = {"document": {"pages": [{"images": [{"file": str(a)}, {"file": str(b)}]}]}}
-        removed = PdfiumNativeReader.dedupe_images(doc)
+        removed = PdfiumNativeReader.dedupe_images(doc, image_output_dir=str(tmp_path))
         assert removed == 1 and not b.exists()

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -100,7 +100,7 @@ class TestDedupeImages:
             }
         }
 
-        removed = pdfcomponents.ParsedDocument(document).dedupe_images()
+        removed = pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=str(tmp_path))
 
         assert removed == 1
         # The redundant duplicate file is deleted; the first + unique remain.
@@ -268,7 +268,7 @@ class TestParsedDocument:
             {"type": "image", "metadata": {"file_path": str(a)}},
             {"type": "image", "metadata": {"file_path": str(b)}},
         ]}]}}
-        removed = ParsedDocument(document).dedupe_images()
+        removed = ParsedDocument(document).dedupe_images(image_output_dir=str(tmp_path))
         assert removed == 1 and not b.exists()
 
     def test_drop_layout_tables(self):


### PR DESCRIPTION
Closes #101. 

- fix(pdf): contain image-dedupe deletion to the run's output directory

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)