### PR TITLE
fix(databases): escape DuckDB SQL literals and identifiers

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -275,7 +275,11 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         projections = []
         for col in current_columns:
             normalized_name = column_normalizer.columns_to_normalized_mapping.get(col, col)
-            projections.append(f'"{col}" AS "{normalized_name}"')
+            # Double-quote-escape both identifiers; a quote in a header-derived
+            # column name would otherwise break the projection SQL.
+            safe_col = col.replace('"', '""')
+            safe_normalized = normalized_name.replace('"', '""')
+            projections.append(f'"{safe_col}" AS "{safe_normalized}"')
         return relation.project(", ".join(projections))
 
     def query_data(self, sql_query, normalize_columns=False):

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -179,7 +179,7 @@ class DuckDBQueries:
                 CREATE OR REPLACE TABLE {self.database_table_name} AS
                 SELECT *
                 FROM read_csv('{self._escaped_filepath_literal}',
-                                delim='{self.delimiter}',
+                                delim='{self._escape_sql_literal(self.delimiter)}',
                                 header=true,
                                 columns={cols_param},
                                 quote='{self.quotechar.replace("'", "''")}',
@@ -195,7 +195,7 @@ class DuckDBQueries:
                 SELECT *
                 FROM read_csv('{self._escaped_filepath_literal}',
                                 auto_detect=true,
-                                delim='{self.delimiter}',
+                                delim='{self._escape_sql_literal(self.delimiter)}',
                                 header=true,
                                 quote='{self.quotechar.replace("'", "''")}',
                                 null_padding=true,
@@ -221,7 +221,7 @@ class DuckDBQueries:
                 CREATE OR REPLACE TABLE {self.database_table_name} AS
                 SELECT *
                 FROM read_csv('{self._escaped_filepath_literal}',
-                                delim='{self.delimiter}',
+                                delim='{self._escape_sql_literal(self.delimiter)}',
                                 header=true,
                                 columns={cols_param},
                                 quote='{self.quotechar.replace("'", "''")}',
@@ -238,7 +238,7 @@ class DuckDBQueries:
                 SELECT *
                 FROM read_csv('{self._escaped_filepath_literal}',
                                 auto_detect=true,
-                                delim='{self.delimiter}',
+                                delim='{self._escape_sql_literal(self.delimiter)}',
                                 header=true,
                                 quote='{self.quotechar.replace("'", "''")}',
                                 null_padding=true,

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -42,6 +42,17 @@ class DuckDBQueries:
         self.connection = duckdb.connect(":memory:")
         self.skip_rows = _count_leading_comments(self.filepath)
 
+    @property
+    def _escaped_filepath_literal(self):
+        """Return the file path as a single-quote-escaped SQL string literal.
+
+        DuckDB string literals are single-quoted, so a path containing an
+        apostrophe (e.g. ``o'hara.csv``) must double the quote to avoid
+        producing broken SQL. Built once and reused by every import/export
+        query that interpolates the path.
+        """
+        return Path(self.filepath).as_posix().replace("'", "''")
+
     @cached_property
     def delimiter(self):
         """Get the delimiter."""
@@ -54,6 +65,55 @@ class DuckDBQueries:
             return CSVDialect(self.filepath).quotechar
         except Exception:
             return '"'
+
+    @staticmethod
+    def _escape_sql_literal(value):
+        """Escape a value for use inside a single-quoted SQL string literal.
+
+        Doubling embedded apostrophes prevents an export path containing a
+        quote (e.g. ``my'data.csv``) from terminating the literal early and
+        producing broken ``COPY ... TO '...'`` SQL.
+
+        Args:
+            value (str): The raw string to place inside a literal.
+
+        Returns:
+            str: The escaped string (without the surrounding quotes).
+        """
+        return str(value).replace("'", "''")
+
+    @staticmethod
+    def _escape_identifier(name):
+        """Escape a column name for use inside a double-quoted SQL identifier.
+
+        DuckDB identifiers are double-quoted, so a quote in a column name (which
+        can come straight from a CSV header cell) must be doubled or it
+        terminates the identifier early and produces broken SQL.
+
+        Args:
+            name (str): The raw column name.
+
+        Returns:
+            str: The escaped name (without the surrounding double quotes).
+        """
+        return str(name).replace('"', '""')
+
+    @staticmethod
+    def _build_lenient_columns_param(columns):
+        """Build the ``columns={...}`` struct for a lenient ``read_csv`` call.
+
+        Each column name becomes a single-quoted SQL string literal, so any
+        apostrophe in a header cell must be doubled or it terminates the literal
+        early and produces broken SQL.
+
+        Args:
+            columns (list[str]): Header-derived column names.
+
+        Returns:
+            str: A DuckDB struct literal mapping each column to ``'VARCHAR'``.
+        """
+        entries = ", ".join(f"'{name.replace(chr(39), chr(39) * 2)}': 'VARCHAR'" for name in columns)
+        return "{" + entries + "}"
 
     def close(self):
         """Close this instance's DuckDB connection.
@@ -114,11 +174,11 @@ class DuckDBQueries:
             from datagrunt.core.csv_io import CSVColumns
 
             cols = CSVColumns(self.filepath, delimiter=self.delimiter).columns
-            cols_param = "{" + ", ".join(f"'{c}': 'VARCHAR'" for c in cols) + "}"
+            cols_param = self._build_lenient_columns_param(cols)
             return f"""
                 CREATE OR REPLACE TABLE {self.database_table_name} AS
                 SELECT *
-                FROM read_csv('{self.filepath}',
+                FROM read_csv('{self._escaped_filepath_literal}',
                                 delim='{self.delimiter}',
                                 header=true,
                                 columns={cols_param},
@@ -133,7 +193,7 @@ class DuckDBQueries:
             return f"""
                 CREATE OR REPLACE TABLE {self.database_table_name} AS
                 SELECT *
-                FROM read_csv('{self.filepath}',
+                FROM read_csv('{self._escaped_filepath_literal}',
                                 auto_detect=true,
                                 delim='{self.delimiter}',
                                 header=true,
@@ -156,11 +216,11 @@ class DuckDBQueries:
             from datagrunt.core.csv_io import CSVColumns
 
             cols = CSVColumns(self.filepath, delimiter=self.delimiter).columns
-            cols_param = "{" + ", ".join(f"'{c}': 'VARCHAR'" for c in cols) + "}"
+            cols_param = self._build_lenient_columns_param(cols)
             return f"""
                 CREATE OR REPLACE TABLE {self.database_table_name} AS
                 SELECT *
-                FROM read_csv('{self.filepath}',
+                FROM read_csv('{self._escaped_filepath_literal}',
                                 delim='{self.delimiter}',
                                 header=true,
                                 columns={cols_param},
@@ -176,7 +236,7 @@ class DuckDBQueries:
             return f"""
                 CREATE OR REPLACE TABLE {self.database_table_name} AS
                 SELECT *
-                FROM read_csv('{self.filepath}',
+                FROM read_csv('{self._escaped_filepath_literal}',
                                 auto_detect=true,
                                 delim='{self.delimiter}',
                                 header=true,
@@ -203,7 +263,7 @@ class DuckDBQueries:
         Returns:
             str: The SQL query to export the table to a CSV file.
         """
-        filename = self.set_export_filename(default_filename, export_filename)
+        filename = self._escape_sql_literal(self.set_export_filename(default_filename, export_filename))
         return f"COPY {self.database_table_name} TO '{filename}' (HEADER, DELIMITER ',');"  # noqa: E501
 
     def export_excel_query(self, default_filename, export_filename=None):
@@ -217,7 +277,7 @@ class DuckDBQueries:
         Returns:
             str: The SQL query to export the table to an Excel file.
         """
-        filename = self.set_export_filename(default_filename, export_filename)
+        filename = self._escape_sql_literal(self.set_export_filename(default_filename, export_filename))
         return f"""
             INSTALL spatial;
             LOAD spatial;
@@ -236,7 +296,7 @@ class DuckDBQueries:
         Returns:
             str: The SQL query to export the table to a JSON file.
         """
-        filename = self.set_export_filename(default_filename, export_filename)
+        filename = self._escape_sql_literal(self.set_export_filename(default_filename, export_filename))
         return f"COPY (SELECT * FROM {self.database_table_name}) TO '{filename}' (ARRAY true)"  # noqa: E501
 
     def export_json_newline_delimited_query(self, default_filename, export_filename=None):
@@ -251,7 +311,7 @@ class DuckDBQueries:
             str: The SQL query to export the table to a JSON file with newline
             delimited.
         """
-        filename = self.set_export_filename(default_filename, export_filename)
+        filename = self._escape_sql_literal(self.set_export_filename(default_filename, export_filename))
         return f"COPY (SELECT * FROM {self.database_table_name}) TO '{filename}'"  # noqa: E501
 
     def export_parquet_query(self, default_filename, export_filename=None):
@@ -265,7 +325,7 @@ class DuckDBQueries:
         Returns:
             str: The SQL query to export the table to a Parquet file.
         """
-        filename = self.set_export_filename(default_filename, export_filename)
+        filename = self._escape_sql_literal(self.set_export_filename(default_filename, export_filename))
         return f"COPY (SELECT * FROM {self.database_table_name}) TO '{filename}'(FORMAT PARQUET)"  # noqa: E501
 
     def update_and_normalize_column_names(self):
@@ -282,7 +342,11 @@ class DuckDBQueries:
         table_columns = self.connection.sql(f"SELECT * FROM {self.database_table_name} LIMIT 0").columns
         normalizer = CSVColumnNameNormalizer(self.filepath, columns=table_columns)
         for old_name, new_name in zip(table_columns, normalizer.columns_normalized):
-            sql_string = f'ALTER TABLE {self.database_table_name} RENAME COLUMN "{old_name}" TO "{new_name}"'
+            # Double-quote-escape both identifiers; a quote in a header cell
+            # would otherwise break the RENAME COLUMN SQL.
+            safe_old = self._escape_identifier(old_name)
+            safe_new = self._escape_identifier(new_name)
+            sql_string = f'ALTER TABLE {self.database_table_name} RENAME COLUMN "{safe_old}" TO "{safe_new}"'
             self.connection.sql(sql_string)
 
     def create_table(self, normalize_columns=False):

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -440,12 +440,29 @@ class TestDuckDBSqlEscaping:
         """A ``'`` in a header cell must not break the lenient columns dict."""
         csv_file = tmp_path / "quoted_header.csv"
         # Header cell contains a single quote; lenient mode builds an explicit
-        # column dict ({'col': 'VARCHAR'}) that must escape the quote.
-        csv_file.write_text("o'clock,value\n1,2\n3,4\n")
+        # column dict ({'col': 'VARCHAR'}) that must escape the quote. The
+        # header has more commas than quotes so delimiter inference picks ','.
+        csv_file.write_text("o'clock,value,extra\n1,2,3\n4,5,6\n")
 
         reader = CSVEngineFactory(str(csv_file), "duckdb", lenient=True).create_reader()
         df = reader.to_dataframe()
-        assert df.columns == ["o'clock", "value"]
+        assert df.columns == ["o'clock", "value", "extra"]
+        assert len(df) == 2
+
+    def test_single_quote_inferred_delimiter_duckdb(self, tmp_path):
+        """An inferred ``'`` delimiter must not break the delim SQL literal.
+
+        Delimiter inference counts non-alphanumeric characters in the first
+        row, so a header like ``a'b'c`` infers ``'`` as the delimiter. The
+        ``delim='...'`` literal must escape it (``delim=''''``) or every
+        DuckDB read of the file raises a ParserException.
+        """
+        csv_file = tmp_path / "quote_delimited.csv"
+        csv_file.write_text("a'b'c\n1'2'3\n4'5'6\n")
+
+        reader = CSVEngineFactory(str(csv_file), "duckdb").create_reader()
+        df = reader.to_dataframe()
+        assert df.columns == ["a", "b", "c"]
         assert len(df) == 2
 
     def test_apostrophe_in_filename_writes_correctly_duckdb(self, tmp_path):

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -416,3 +416,45 @@ class TestEngines:
         assert "last_name" in df.columns
         assert "e_mail" in df.columns
         assert "phone" in df.columns
+
+
+class TestDuckDBSqlEscaping:
+    """The DuckDB engine must escape interpolated literals and identifiers.
+
+    A single quote in a filename or a header cell previously produced broken
+    SQL (a ParserException). The threat model is a trusted caller, so this is
+    robustness / defense-in-depth, not RCE.
+    """
+
+    def test_apostrophe_in_filename_reads_correctly_duckdb(self, tmp_path):
+        """A ``'`` in the file path must not break the read_csv SQL literal."""
+        csv_file = tmp_path / "o'hara.csv"
+        csv_file.write_text("name,age\nJohn,30\nJane,25\n")
+
+        reader = CSVEngineFactory(str(csv_file), "duckdb").create_reader()
+        df = reader.to_dataframe()
+        assert df.columns == ["name", "age"]
+        assert len(df) == 2
+
+    def test_single_quote_in_header_lenient_duckdb(self, tmp_path):
+        """A ``'`` in a header cell must not break the lenient columns dict."""
+        csv_file = tmp_path / "quoted_header.csv"
+        # Header cell contains a single quote; lenient mode builds an explicit
+        # column dict ({'col': 'VARCHAR'}) that must escape the quote.
+        csv_file.write_text("o'clock,value\n1,2\n3,4\n")
+
+        reader = CSVEngineFactory(str(csv_file), "duckdb", lenient=True).create_reader()
+        df = reader.to_dataframe()
+        assert df.columns == ["o'clock", "value"]
+        assert len(df) == 2
+
+    def test_apostrophe_in_filename_writes_correctly_duckdb(self, tmp_path):
+        """A ``'`` in the SOURCE path must not break export COPY queries."""
+        csv_file = tmp_path / "o'hara.csv"
+        csv_file.write_text("name,age\nJohn,30\n")
+
+        writer = CSVEngineFactory(str(csv_file), "duckdb").create_writer()
+        out = tmp_path / "out.csv"
+        writer.write_csv(str(out))
+        assert out.exists()
+        assert "John" in out.read_text()


### PR DESCRIPTION
Closes #82 106. 

- fix(databases): escape DuckDB SQL literals and identifiers
- fix(databases): escape the inferred delimiter in DuckDB read_csv literals

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

**Merge-order note:** Conflicts with the branch for #75 (fix/4-normalize-columns-duckdb) in update_and_normalize_column_names. Combined resolution: keep #75's atomic CREATE-OR-REPLACE projection and apply this branch's _escape_identifier to the projected names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)