### PR TITLE
fix(pdf): make pdfium coordinate mapping rotation-aware

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
@@ -61,16 +61,47 @@ class PdfiumPage:
         self._raw.FPDFTextObj_GetText(obj.raw, self._textpage.raw, ctypes.cast(buf, ctypes.POINTER(ctypes.c_ushort)), n)
         return buf.raw[: n * 2].decode("utf-16-le").rstrip("\x00").strip()
 
+    @staticmethod
+    def _display_edges(left, bottom, right, top, rotation, disp_w, disp_h):
+        """Map pdfium's unrotated bounds to display-space ``(x0, y_top, x1, y_bot)``.
+
+        ``obj.get_bounds()`` always reports bounds in UNROTATED page space, while
+        ``get_size()`` reports ROTATION-AWARE width/height. Flipping y with the
+        rotation-aware height alone yields negative / out-of-range coordinates on
+        /Rotate 90|270 pages, so apply the page rotation to land every edge within
+        ``[0, disp_w] x [0, disp_h]`` (top-left origin). Rotation 0 reduces to the
+        original ``x0=left, x1=right, y_top=disp_h-top, y_bot=disp_h-bottom``,
+        leaving unrotated pages byte-for-byte unchanged. Returns unrounded floats
+        so callers round exactly once.
+        """
+        r = rotation % 360
+        if r == 90:
+            return bottom, left, top, right
+        if r == 180:
+            return disp_w - right, bottom, disp_w - left, top
+        if r == 270:
+            return disp_w - top, disp_h - right, disp_w - bottom, disp_h - left
+        # rotation 0 (and any unexpected value) -- original behavior
+        return left, disp_h - top, right, disp_h - bottom
+
+    @classmethod
+    def _display_box(cls, left, bottom, right, top, rotation, disp_w, disp_h) -> BBox:
+        """Display-space ``BBox`` (rounded) for an image; see ``_display_edges``."""
+        x0, y_top, x1, y_bot = cls._display_edges(left, bottom, right, top, rotation, disp_w, disp_h)
+        return BBox(x=round(x0, 2), y=round(y_top, 2), w=round(x1 - x0, 2), h=round(y_bot - y_top, 2))
+
     def text_items(self):
         """Yield a ``TextItem`` per text object (own text, matrix-scaled size)."""
         from math import hypot
 
-        _, height = self.size()
+        disp_w, disp_h = self.size()
+        rotation = self.rotation()
         for obj in self._page.get_objects(filter=(self._raw.FPDF_PAGEOBJ_TEXT,), max_depth=15):
             text = self._object_text(obj)
             if not text:
                 continue
             left, bottom, right, top = obj.get_bounds()
+            x0, y_top, x1, y_bot = self._display_edges(left, bottom, right, top, rotation, disp_w, disp_h)
             font_name, weight = "", 400
             try:
                 font = obj.get_font()
@@ -86,10 +117,10 @@ class PdfiumPage:
             lower = font_name.lower()
             yield TextItem(
                 text=text,
-                x0=round(left, 2),
-                x1=round(right, 2),
-                y_top=round(height - top, 2),
-                y_bot=round(height - bottom, 2),
+                x0=round(x0, 2),
+                x1=round(x1, 2),
+                y_top=round(y_top, 2),
+                y_bot=round(y_bot, 2),
                 size=round(obj.get_font_size() * scale, 1),
                 font=font_name,
                 is_bold=weight >= 600,
@@ -116,14 +147,15 @@ class PdfiumPage:
 
     def image_items(self, output_dir: str = None, name_prefix: str = "page", page_number: int = 0):
         """Yield an ``ImageBlock`` per embedded image >= MIN_IMAGE_DIMENSION."""
-        _, height = self.size()
+        disp_w, disp_h = self.size()
+        rotation = self.rotation()
         idx = 0
         for obj in self._page.get_objects(filter=(self._raw.FPDF_PAGEOBJ_IMAGE,), max_depth=15):
             px_w, px_h = obj.get_px_size()
             if px_w < MIN_IMAGE_DIMENSION or px_h < MIN_IMAGE_DIMENSION:
                 continue
             left, bottom, right, top = obj.get_bounds()
-            bbox = BBox.from_pdfium_bounds(left, bottom, right, top, height)
+            bbox = self._display_box(left, bottom, right, top, rotation, disp_w, disp_h)
             file_path, fmt = None, "png"
             if output_dir:
                 written = self._extract_image(obj, Path(output_dir) / f"{name_prefix}_page{page_number}_img{idx}")

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_document.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_document.py
@@ -1,6 +1,23 @@
 """Tests for the PdfiumDocument / PdfiumPage wrapper."""
 
+import pytest
+
 from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
+
+
+def _rotated_text_pdf(tmp_path, rotation):
+    """Build a one-page PDF with text near the top and bottom, then rotate it."""
+    import pymupdf
+
+    doc = pymupdf.open()
+    page = doc.new_page(width=612, height=792)
+    page.insert_text((72, 100), "Top of the page line", fontsize=18)
+    page.insert_text((72, 700), "Bottom of the page line", fontsize=18)
+    page.set_rotation(rotation)
+    path = tmp_path / f"rotated_{rotation}.pdf"
+    doc.save(str(path))
+    doc.close()
+    return str(path)
 
 
 class TestPdfiumDocument:
@@ -30,3 +47,86 @@ class TestPdfiumDocument:
         with PdfiumDocument(sample_pdf) as doc:
             img = doc.page(0).render_pil(dpi=72)
             assert img.size[0] > 0 and img.mode == "RGB"
+
+
+class TestRotatedPageCoordinates:
+    """``get_size()`` is rotation-aware but ``obj.get_bounds()`` is not.
+
+    Mixing the two when flipping y produced negative / out-of-range coordinates
+    on /Rotate 90|270 pages. Coordinates must land within ``[0, page_height]``.
+    """
+
+    @pytest.mark.parametrize("rotation", [90, 180, 270])
+    def test_rotated_text_y_within_page_height(self, tmp_path, rotation):
+        pdf = _rotated_text_pdf(tmp_path, rotation)
+        with PdfiumDocument(pdf) as doc:
+            page = doc.page(0)
+            _, page_height = page.size()
+            items = list(page.text_items())
+        assert items
+        for it in items:
+            assert 0 <= it.y_top <= page_height, f"y_top {it.y_top} out of [0,{page_height}] (rot {rotation})"
+            assert 0 <= it.y_bot <= page_height, f"y_bot {it.y_bot} out of [0,{page_height}] (rot {rotation})"
+
+    @pytest.mark.parametrize("rotation", [90, 180, 270])
+    def test_rotated_image_bbox_within_page(self, tmp_path, rotation):
+        import pymupdf
+
+        doc = pymupdf.open()
+        page = doc.new_page(width=612, height=792)
+        pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 100, 100))
+        pix.set_rect(pix.irect, (255, 0, 0))
+        page.insert_image(pymupdf.Rect(72, 100, 172, 250), stream=pix.tobytes("png"))
+        page.set_rotation(rotation)
+        path = tmp_path / f"rot_img_{rotation}.pdf"
+        doc.save(str(path))
+        doc.close()
+
+        with PdfiumDocument(str(path)) as d:
+            pg = d.page(0)
+            page_width, page_height = pg.size()
+            images = list(pg.image_items())
+        assert images
+        for im in images:
+            box = im.bbox
+            assert 0 <= box.y and box.y + box.h <= page_height, f"image y span out of [0,{page_height}] (rot {rotation})"
+            assert 0 <= box.x and box.x + box.w <= page_width, f"image x span out of [0,{page_width}] (rot {rotation})"
+
+
+class TestUnrotatedCoordinatesRegressionGuard:
+    """Lock the exact rotation-0 coordinates so the rotation fix can't drift them.
+
+    These literals were captured from the pre-fix code; an unrotated page MUST be
+    byte-for-byte unchanged by any rotation-handling change.
+    """
+
+    @staticmethod
+    def _baseline_pdf(tmp_path):
+        import pymupdf
+
+        doc = pymupdf.open()
+        page = doc.new_page(width=612, height=792)
+        page.insert_text((72, 72), "Quarterly Report", fontsize=24)
+        page.insert_text((72, 120), "Body line one here.", fontsize=11)
+        pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 100, 100))
+        pix.set_rect(pix.irect, (255, 0, 0))
+        page.insert_image(pymupdf.Rect(72, 200, 172, 300), stream=pix.tobytes("png"))
+        path = tmp_path / "baseline.pdf"
+        doc.save(str(path))
+        doc.close()
+        return str(path)
+
+    def test_unrotated_text_coords_unchanged(self, tmp_path):
+        pdf = self._baseline_pdf(tmp_path)
+        with PdfiumDocument(pdf) as doc:
+            items = list(doc.page(0).text_items())
+        coords = {it.text: (it.x0, it.x1, it.y_top, it.y_bot) for it in items}
+        assert coords["Quarterly Report"] == (73.03, 249.22, 54.5, 77.02)
+        assert coords["Body line one here."] == (72.8, 165.82, 112.12, 122.3)
+
+    def test_unrotated_image_bbox_unchanged(self, tmp_path):
+        pdf = self._baseline_pdf(tmp_path)
+        with PdfiumDocument(pdf) as doc:
+            images = list(doc.page(0).image_items())
+        assert len(images) == 1
+        assert images[0].bbox.to_dict() == {"x": 72.0, "y": 200.0, "w": 100.0, "h": 100.0}


### PR DESCRIPTION
Closes #78. 

- fix(pdf): make pdfium coordinate mapping rotation-aware

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)