### PR TITLE
perf(pdf): parse pymupdf documents with the document open once, not per page

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -125,28 +125,57 @@ class PDFReaderPyMuPDFEngine(PDFBaseReaderEngine):
             return len(doc)
 
     def to_dicts(self, image_output_dir: Optional[str] = None, drop_layout_tables: bool = False) -> dict:
-        """Parse all pages concurrently into the unified document dict."""
+        """Parse all pages into the unified document dict.
+
+        Sequentially (the default, ``workers <= 1``) the document is held open
+        once via ``DocumentAssembler.parse_document`` instead of being reopened
+        per page. With multiple workers each worker holds its thread-local
+        backend / table-extractor contexts open across the pages it owns, so the
+        document is opened once per worker rather than once per page (issue #102).
+        """
         assembler = pdfcomponents.DocumentAssembler(self.filepath)
         total_pages = self._total_pages()
-        page_results = {}
-        errors = []
-        with ThreadPoolExecutor(max_workers=self.workers) as executor:
-            futures = {
-                executor.submit(assembler.parse_page, idx, image_output_dir): idx
-                for idx in range(total_pages)
-            }
-            for future in as_completed(futures):
-                idx = futures[future]
-                try:
-                    page = future.result()
-                    page_results[page["page_number"]] = page
-                except Exception as e:  # noqa: BLE001 - per-page isolation
-                    errors.append(f"Page {idx + 1}: {e}")
-        ordered = [page_results[p] for p in sorted(page_results.keys())]
-        document = assembler.combine(total_pages, ordered, errors)
+        if self.workers <= 1 or total_pages <= 1:
+            document = assembler.parse_document(total_pages, image_output_dir)
+        else:
+            document = self._to_dicts_threaded(assembler, total_pages, image_output_dir)
         if drop_layout_tables:
             pdfcomponents.ParsedDocument(document).drop_layout_tables()
         return document
+
+    def _to_dicts_threaded(self, assembler, total_pages, image_output_dir) -> dict:
+        """Parse pages across a thread pool, holding contexts open per worker.
+
+        Each worker enters the thread-local backend / table-extractor contexts
+        once and parses an interleaved slice of pages, so the document is opened
+        once per worker (not once per page) while preserving the exact per-page
+        ``"Page N: <error>"`` envelope.
+        """
+        worker_count = min(self.workers, total_pages)
+        page_results = {}
+        errors = []
+
+        def parse_slice(start: int) -> tuple:
+            slice_pages, slice_errors = {}, []
+            with assembler.backend, assembler.table_extractor:
+                for idx in range(start, total_pages, worker_count):
+                    try:
+                        page = assembler.parse_page(idx, image_output_dir)
+                        slice_pages[page["page_number"]] = page
+                    except Exception as e:  # noqa: BLE001 - per-page isolation
+                        slice_errors.append((idx, e))
+            return slice_pages, slice_errors
+
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            futures = [executor.submit(parse_slice, start) for start in range(worker_count)]
+            for future in as_completed(futures):
+                slice_pages, slice_errors = future.result()
+                page_results.update(slice_pages)
+                errors.extend(slice_errors)
+
+        ordered = [page_results[p] for p in sorted(page_results.keys())]
+        error_messages = [f"Page {idx + 1}: {e}" for idx, e in sorted(errors, key=lambda item: item[0])]
+        return assembler.combine(total_pages, ordered, error_messages)
 
     def get_sample(self) -> dict:
         """Parse and return the first page only."""

--- a/src/datagrunt/core/pdf_io/extraction/tables.py
+++ b/src/datagrunt/core/pdf_io/extraction/tables.py
@@ -28,29 +28,39 @@ class PdfPlumberTableExtractor:
         self._local = threading.local()
 
     def __enter__(self):
+        # Mark a held-open scope but defer the pdfplumber.open() until a page
+        # actually needs tables. Text-only documents (no line drawings, has a
+        # text layer) never call extract(), so they must never pay for opening
+        # pdfplumber. The shared handle is opened lazily on first extract() and
+        # closed when the outermost scope exits.
         if not hasattr(self._local, "depth"):
             self._local.depth = 0
-        if self._local.depth == 0:
-            pdfplumber = _import_pdfplumber()
-            self._local.pdf = pdfplumber.open(self.filepath)
+            self._local.pdf = None
         self._local.depth += 1
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._local.depth -= 1
         if self._local.depth == 0:
-            if hasattr(self._local, "pdf") and self._local.pdf:
+            if getattr(self._local, "pdf", None):
                 self._local.pdf.close()
-                self._local.pdf = None
+            self._local.pdf = None
 
     def _get_pdf(self):
-        if hasattr(self._local, "pdf") and self._local.pdf:
+        # Inside a held-open scope (depth > 0) the handle is opened once and
+        # cached for the scope; __exit__ owns closing it. Outside a scope it is
+        # opened transiently and the caller closes it.
+        if getattr(self._local, "pdf", None):
             return self._local.pdf, False
         pdfplumber = _import_pdfplumber()
         try:
-            return pdfplumber.open(self.filepath), True
+            pdf = pdfplumber.open(self.filepath)
         except Exception:
             return None, False
+        if getattr(self._local, "depth", 0) > 0:
+            self._local.pdf = pdf
+            return pdf, False
+        return pdf, True
 
     def extract(self, page_number: int) -> list:
         """Return ``TableBlock`` objects on ``page_number`` (0-indexed).

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -105,7 +105,7 @@ class DocumentAssembler:
                 try:
                     pages.append(self.parse_page(idx, image_output_dir))
                 except Exception as e:  # noqa: BLE001 - per-page isolation
-                    errors.append(str(e))
+                    errors.append(f"Page {idx + 1}: {e}")
         return self.combine(total_pages, pages, errors)
 
     def combine(self, total_pages, pages, errors) -> dict:

--- a/tests/core_tests/pdf_io_tests/test_pymupdf_open_once.py
+++ b/tests/core_tests/pdf_io_tests/test_pymupdf_open_once.py
@@ -1,0 +1,135 @@
+"""Guard tests for issue #102: the PyMuPDF engine must open the document once
+per document, not once per page.
+
+The historical ``to_dicts`` submitted bare ``assembler.parse_page`` calls to a
+thread pool without holding the backend / table-extractor contexts open, so each
+page entered the thread-local context at depth 0 and reran both ``pymupdf.open``
+and ``pdfplumber.open`` once per page. For an N-page document that is N + N opens
+instead of 1 + 1, which the issue measured at 3.1x slower.
+
+These tests spy on ``pymupdf.open`` and ``pdfplumber.open`` and assert each is
+called exactly once for a multi-page sequential parse, while pinning the
+``to_dicts`` output so the optimization stays output-preserving.
+"""
+
+import copy
+
+import pytest
+
+from datagrunt.core.pdf_io.engines import PDFReaderPyMuPDFEngine
+
+
+def _normalize(document):
+    """Strip volatile fields (timestamps) so two parses compare for equality."""
+    doc = copy.deepcopy(document)
+    doc["document"]["processing_id"] = "<id>"
+    return doc
+
+
+@pytest.fixture
+def open_spy(monkeypatch):
+    """Wrap ``pymupdf.open`` and ``pdfplumber.open`` with call counters.
+
+    Both libraries are imported lazily inside the extraction modules, so patching
+    the attribute on the real module object is observed by every caller.
+    """
+    import pdfplumber
+    import pymupdf
+
+    counts = {"pymupdf": 0, "pdfplumber": 0}
+
+    real_pymupdf_open = pymupdf.open
+    real_pdfplumber_open = pdfplumber.open
+
+    def spy_pymupdf_open(*args, **kwargs):
+        counts["pymupdf"] += 1
+        return real_pymupdf_open(*args, **kwargs)
+
+    def spy_pdfplumber_open(*args, **kwargs):
+        counts["pdfplumber"] += 1
+        return real_pdfplumber_open(*args, **kwargs)
+
+    monkeypatch.setattr(pymupdf, "open", spy_pymupdf_open)
+    monkeypatch.setattr(pdfplumber, "open", spy_pdfplumber_open)
+    return counts
+
+
+class TestPyMuPDFOpensOncePerDocument:
+    """The sequential PyMuPDF engine must hold the document open across pages."""
+
+    def test_pymupdf_opened_once_for_multipage_parse(self, multipage_pdf, open_spy):
+        engine = PDFReaderPyMuPDFEngine(multipage_pdf, workers=1)
+        document = engine.to_dicts()
+
+        # 3-page fixture: must be opened ONCE, not once per page.
+        assert document["document"]["total_pages"] == 3
+        assert open_spy["pymupdf"] == 1, (
+            f"pymupdf.open called {open_spy['pymupdf']}x; expected 1 (once per document)"
+        )
+
+    def test_pdfplumber_opened_at_most_once_for_multipage_parse(self, multipage_pdf, open_spy):
+        engine = PDFReaderPyMuPDFEngine(multipage_pdf, workers=1)
+        engine.to_dicts()
+
+        # Held-open: at most one pdfplumber.open for the whole document. The
+        # multipage fixture is text-only with no line drawings, so the lazy
+        # table extractor need never open it at all.
+        assert open_spy["pdfplumber"] <= 1, (
+            f"pdfplumber.open called {open_spy['pdfplumber']}x; expected <= 1 per document"
+        )
+
+    def test_text_only_pages_do_not_open_pdfplumber(self, multipage_pdf, open_spy):
+        # The multipage fixture has a text layer and no line drawings, so the
+        # table extractor is never consulted: pdfplumber must not be opened.
+        engine = PDFReaderPyMuPDFEngine(multipage_pdf, workers=1)
+        engine.to_dicts()
+        assert open_spy["pdfplumber"] == 0, (
+            f"pdfplumber.open called {open_spy['pdfplumber']}x for a text-only "
+            "document; expected 0 (lazy table extractor)"
+        )
+
+
+class TestThreadedOpensOncePerWorker:
+    """With multiple workers the document is opened once per worker, not per page."""
+
+    def test_pymupdf_opened_once_per_worker(self, multipage_pdf, open_spy):
+        # 3-page fixture parsed with 2 workers: at most one open per worker
+        # (<= 2), never one per page (which would be 3).
+        engine = PDFReaderPyMuPDFEngine(multipage_pdf, workers=2)
+        document = engine.to_dicts()
+        assert document["document"]["total_pages"] == 3
+        assert open_spy["pymupdf"] <= 2, (
+            f"pymupdf.open called {open_spy['pymupdf']}x for 2 workers; "
+            "expected <= 2 (once per worker)"
+        )
+
+    def test_threaded_output_matches_sequential(self, multipage_pdf):
+        sequential = PDFReaderPyMuPDFEngine(multipage_pdf, workers=1).to_dicts()
+        threaded = PDFReaderPyMuPDFEngine(multipage_pdf, workers=2).to_dicts()
+        assert _normalize(threaded) == _normalize(sequential)
+
+
+class TestOutputUnchanged:
+    """The held-open path must produce identical output to per-page parsing."""
+
+    def test_to_dicts_matches_per_page_assembly(self, multipage_pdf):
+        from datagrunt.core.pdf_io import pdfcomponents
+
+        engine = PDFReaderPyMuPDFEngine(multipage_pdf, workers=1)
+        produced = engine.to_dicts()
+
+        # Reconstruct the expected document the per-page way: parse each page
+        # through the public assembler entry point and combine. parse_page is the
+        # stable per-page contract that to_dicts must continue to honor.
+        assembler = pdfcomponents.DocumentAssembler(multipage_pdf)
+        total_pages = engine._total_pages()
+        pages = [assembler.parse_page(idx) for idx in range(total_pages)]
+        expected = assembler.combine(total_pages, pages, [])
+
+        assert _normalize(produced) == _normalize(expected)
+
+    def test_to_dicts_is_deterministic(self, multipage_pdf):
+        engine = PDFReaderPyMuPDFEngine(multipage_pdf, workers=1)
+        first = engine.to_dicts()
+        second = engine.to_dicts()
+        assert _normalize(first) == _normalize(second)


### PR DESCRIPTION
Closes #102. 

- perf(pdf): parse pymupdf documents with the document open once, not per page

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

**Merge-order note:** Overlaps with the branch for #77 (fix/6-pymupdf-threading): both rewrite PDFReaderPyMuPDFEngine.to_dicts. If both are approved, the combined resolution keeps #77's workers>1 warning plus this branch's parse_document delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)