### PR TITLE
perf(csv): import each CSV once for repeated query_data calls

### DIFF
--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -41,6 +41,10 @@ class DuckDBQueries:
         self.database_table_name = self._set_database_table_name()
         self.connection = duckdb.connect(":memory:")
         self.skip_rows = _count_leading_comments(self.filepath)
+        # Tracks how the cached table was imported (None until first import,
+        # then True/False for normalize_columns) so create_table can reuse the
+        # table for matching calls and re-import only when the mode changes.
+        self._imported_normalize_columns = None
 
     @cached_property
     def delimiter(self):
@@ -285,18 +289,44 @@ class DuckDBQueries:
             sql_string = f'ALTER TABLE {self.database_table_name} RENAME COLUMN "{old_name}" TO "{new_name}"'
             self.connection.sql(sql_string)
 
+    def _table_is_current(self, normalize_columns):
+        """Return True if the cached table already matches the requested import.
+
+        The table name is deterministic per file path, so once the import has
+        run on this instance's connection the table can be reused - but only
+        when the requested ``normalize_columns`` mode matches how the table was
+        originally imported. A mode change requires a fresh import.
+
+        Args:
+            normalize_columns (bool): The requested normalization mode.
+
+        Returns:
+            bool: Whether the existing table can be reused as-is.
+        """
+        return self._imported_normalize_columns == normalize_columns
+
     def create_table(self, normalize_columns=False):
         """Create a DuckDB table from the CSV file.
+
+        The import is skipped when the table already exists on this instance's
+        connection with the same ``normalize_columns`` mode: the table name is
+        deterministic per file path, so a single import serves every subsequent
+        matching call. This keeps repeated reads - notably ``query_data`` - from
+        paying a full file import each time (issue #104). A change in
+        ``normalize_columns`` triggers a fresh import so column names stay
+        correct.
 
         Args:
             normalize_columns (bool): Whether to normalize column names.
         """
-        if self.lenient:
-            _check_csv_ragged_and_warn(self.filepath, self.delimiter)
-        if normalize_columns:
-            self.update_and_normalize_column_names()
-        else:
-            self.connection.sql(self.import_csv_query())
+        if not self._table_is_current(normalize_columns):
+            if self.lenient:
+                _check_csv_ragged_and_warn(self.filepath, self.delimiter)
+            if normalize_columns:
+                self.update_and_normalize_column_names()
+            else:
+                self.connection.sql(self.import_csv_query())
+            self._imported_normalize_columns = normalize_columns
         return self.connection.sql(self.select_from_duckdb_table()).execute()
 
     def _normalize_dataframe_columns(self, dataframe):

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -4,6 +4,7 @@ objects.
 """
 
 # standard library
+from functools import cached_property
 from pathlib import Path
 
 # third party libraries
@@ -37,9 +38,24 @@ class CSVReader(CSVComponents):
         """Return an empty object of the specified type."""
         return object
 
-    def _create_reader(self):
-        """Create a reader object."""
+    @cached_property
+    def _reader(self):
+        """Return this reader's engine, built once and reused.
+
+        The engine owns the DuckDB connection (and, for the DuckDB engine, the
+        imported table). Caching it here means repeated calls - notably
+        ``query_data`` - reuse a single import instead of rebuilding a fresh
+        engine and re-importing the file on every call (issue #104).
+        """
         return CSVEngineFactory(self.filepath, self.engine, lenient=self.lenient).create_reader()
+
+    def _create_reader(self):
+        """Return this reader's cached engine.
+
+        Retained for backward compatibility; delegates to the cached ``_reader``
+        so callers share a single engine and a single CSV import.
+        """
+        return self._reader
 
     def get_sample(self, normalize_columns=False):
         """Return a sample of the CSV file.

--- a/tests/core_tests/databases_tests/test_databases.py
+++ b/tests/core_tests/databases_tests/test_databases.py
@@ -61,3 +61,35 @@ def test_csv_quotes_after_sniffer_sample(tmp_path):
     assert res[4][1] == "hello, world"
     queries.close()
 
+
+class TestCreateTableIdempotent:
+    """create_table imports each file once per connection (issue #104)."""
+
+    def test_repeated_create_table_imports_once(self, tmp_path, monkeypatch):
+        """Repeated create_table calls must import the CSV only once.
+
+        The table name is deterministic per file path, so once the table
+        exists on this instance's connection there is no need to re-run the
+        expensive CREATE OR REPLACE TABLE import. Subsequent calls reuse the
+        already-imported table.
+        """
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1,col2\n1,A\n2,B\n")
+        queries = DuckDBQueries(str(csv))
+
+        import_calls = {"count": 0}
+        original_import_query = queries.import_csv_query
+
+        def counting_import_query():
+            import_calls["count"] += 1
+            return original_import_query()
+
+        monkeypatch.setattr(queries, "import_csv_query", counting_import_query)
+
+        first = queries.create_table().fetchall()
+        second = queries.create_table().fetchall()
+
+        assert import_calls["count"] == 1
+        assert first == second == [("1", "A"), ("2", "B")]
+        queries.close()
+

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -306,6 +306,62 @@ class TestCSVReader:
                 # Polars, PyArrow, and DuckDB must raise a parsing/execution error
                 assert isinstance(e, Exception)
 
+    def test_query_data_imports_file_once_across_repeated_calls(self, sample_csv, monkeypatch):
+        """Repeated query_data calls on one reader must import the CSV only once.
+
+        Regression test for issue #104: previously the DuckDB engine rebuilt a
+        fresh engine (and connection) on every query_data call and unconditionally
+        re-ran CREATE OR REPLACE TABLE, paying a full file import every time. The
+        engine is now cached on the reader and create_table is idempotent per
+        connection, so the file is imported exactly once no matter how many times
+        query_data is called. Results must stay identical across calls.
+        """
+        from datagrunt.core.databases import DuckDBQueries
+
+        import_calls = {"count": 0}
+        original_import_query = DuckDBQueries.import_csv_query
+
+        def counting_import_query(self):
+            import_calls["count"] += 1
+            return original_import_query(self)
+
+        monkeypatch.setattr(DuckDBQueries, "import_csv_query", counting_import_query)
+
+        reader = CSVReader(sample_csv, engine="duckdb")
+        query = f"SELECT name FROM {reader.db_table} ORDER BY name"
+
+        first = reader.query_data(query).pl()["name"].to_list()
+        second = reader.query_data(query).pl()["name"].to_list()
+        third = reader.query_data(query).pl()["name"].to_list()
+
+        # The file is imported exactly once for the lifetime of the reader.
+        assert import_calls["count"] == 1
+        # Results are unchanged across repeated calls.
+        assert first == second == third == ["Jane", "John"]
+
+    def test_duckdb_cached_engine_reimports_when_normalize_mode_changes(self, tmp_path):
+        """Caching the engine must not freeze the table's normalization mode.
+
+        The engine (and its imported table) is now reused across calls on one
+        reader. The idempotent import is keyed on normalize_columns, so toggling
+        the flag must still produce the correct column names rather than serving
+        a stale table from a prior call (issue #104 correctness guard).
+        """
+        csv_file = tmp_path / "people.csv"
+        csv_file.write_text("First Name,Last Name\nJohn,Doe\nJane,Smith")
+
+        reader = CSVReader(str(csv_file), engine="duckdb")
+
+        raw = reader.to_dataframe(normalize_columns=False)
+        assert list(raw.columns) == ["First Name", "Last Name"]
+
+        normalized = reader.to_dataframe(normalize_columns=True)
+        assert list(normalized.columns) == ["first_name", "last_name"]
+
+        # Toggling back must restore the original column names, not stay stuck.
+        raw_again = reader.to_dataframe(normalize_columns=False)
+        assert list(raw_again.columns) == ["First Name", "Last Name"]
+
     def test_ragged_rows_lenient(self, tmp_path):
         """Test that Polars, PyArrow, and DuckDB load ragged rows successfully with warnings when lenient=True."""
         import warnings


### PR DESCRIPTION
Closes #104. 

- perf(csv): import each CSV once for repeated query_data calls

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

**Merge-order note:** Overlaps with the branch for #81 (fix/9-duckdb-connection-lifecycle) on the databases.py connection-lifecycle seam; whichever merges second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)