### PR TITLE
perf(csv): stream the first rows for get_sample instead of materializing the file

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -217,8 +217,10 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         Returns:
             A Polars DataFrame containing the sample rows.
         """
-        relation = self.queries.create_table(normalize_columns)
-        return relation.limit(CSVEngineProperties.dataframe_sample_rows).pl()
+        return self.queries.sample_dataframe(
+            CSVEngineProperties.dataframe_sample_rows,
+            normalize_columns,
+        )
 
     def to_dataframe(self, normalize_columns=False):
         """
@@ -714,15 +716,31 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
             return table
         try:
             skip_count = _count_leading_comments(self.filepath) + 1
-            table = pacsv.read_csv(
+            sample_rows = CSVEngineProperties.dataframe_sample_rows
+            # Stream the file in batches and stop once we have enough rows,
+            # rather than materializing the whole file just to slice the head.
+            reader = pacsv.open_csv(
                 self.filepath,
                 read_options=pacsv.ReadOptions(column_names=columns, skip_rows=skip_count),
                 parse_options=pacsv.ParseOptions(delimiter=self.delimiter),
                 convert_options=pacsv.ConvertOptions(column_types=string_schema),
             )
+            batches = []
+            collected = 0
+            try:
+                while collected < sample_rows:
+                    batch = reader.read_next_batch()
+                    if batch.num_rows == 0:
+                        continue
+                    batches.append(batch)
+                    collected += batch.num_rows
+            except StopIteration:
+                # Fewer rows than the sample size; return whatever was read.
+                pass
+            finally:
+                reader.close()
 
-            # Take sample rows
-            sample_table = table.slice(0, CSVEngineProperties.dataframe_sample_rows)
+            sample_table = pa.Table.from_batches(batches, schema=string_schema).slice(0, sample_rows)
 
             if normalize_columns:
                 column_normalizer = CSVColumnNameNormalizer(self.filepath, columns=columns)

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -192,6 +192,48 @@ class DuckDBQueries:
         """Query to select from a DuckDB table."""
         return f"SELECT * FROM {self.database_table_name}"
 
+    def sample_csv_query(self, limit):
+        """Query to stream the first ``limit`` rows directly from the CSV file.
+
+        Unlike :meth:`import_csv_query`, this does not create a table; the
+        ``LIMIT`` lets DuckDB stop reading once enough rows are produced, so the
+        whole file is never materialized just to return a small sample. The
+        ``read_csv`` options mirror :meth:`import_csv_query` so the sampled rows
+        and column headers match a full import.
+
+        Args:
+            limit (int): The maximum number of rows to return.
+
+        Returns:
+            str: The SQL query to stream the sample rows.
+        """
+        if self.lenient:
+            from datagrunt.core.csv_io import CSVColumns
+
+            cols = CSVColumns(self.filepath, delimiter=self.delimiter).columns
+            cols_param = "{" + ", ".join(f"'{c}': 'VARCHAR'" for c in cols) + "}"
+            read_csv = f"""read_csv('{self.filepath}',
+                                delim='{self.delimiter}',
+                                header=true,
+                                columns={cols_param},
+                                quote='{self.quotechar.replace("'", "''")}',
+                                null_padding=true,
+                                all_varchar=True,
+                                auto_detect=false,
+                                strict_mode=false,
+                                skip={self.skip_rows})"""
+        else:
+            read_csv = f"""read_csv('{self.filepath}',
+                                auto_detect=true,
+                                delim='{self.delimiter}',
+                                header=true,
+                                quote='{self.quotechar.replace("'", "''")}',
+                                null_padding=true,
+                                all_varchar=True,
+                                strict_mode=true,
+                                skip={self.skip_rows})"""
+        return f"SELECT * FROM {read_csv} LIMIT {limit}"
+
     def export_csv_query(self, default_filename, export_filename=None):
         """
         Query to export a DuckDB table to a CSV file.
@@ -298,6 +340,28 @@ class DuckDBQueries:
         else:
             self.connection.sql(self.import_csv_query())
         return self.connection.sql(self.select_from_duckdb_table()).execute()
+
+    def sample_dataframe(self, limit, normalize_columns=False):
+        """Return the first ``limit`` rows of the CSV as a Polars DataFrame.
+
+        Streams the rows via :meth:`sample_csv_query` rather than importing the
+        full file into a table, so memory and time stay bounded by the sample
+        size instead of the file size. Column normalization is applied to the
+        small result frame, matching the headers a full import would produce.
+
+        Args:
+            limit (int): The maximum number of rows to return.
+            normalize_columns (bool): Whether to normalize column names.
+
+        Returns:
+            polars.DataFrame: The sampled rows.
+        """
+        if self.lenient:
+            _check_csv_ragged_and_warn(self.filepath, self.delimiter)
+        dataframe = self.connection.sql(self.sample_csv_query(limit)).pl()
+        if normalize_columns:
+            dataframe = self._normalize_dataframe_columns(dataframe)
+        return dataframe
 
     def _normalize_dataframe_columns(self, dataframe):
         """Applies column name normalization to a Polars DataFrame.

--- a/tests/core_tests/csv_io_tests/test_get_sample_streaming.py
+++ b/tests/core_tests/csv_io_tests/test_get_sample_streaming.py
@@ -1,0 +1,114 @@
+"""Tests that ``get_sample`` streams the first N rows instead of materializing
+the entire file on the pyarrow and duckdb engines.
+
+See https://github.com/pmgraham/datagrunt/issues/105.
+"""
+
+import polars as pl
+import pyarrow.csv as pacsv
+import pytest
+
+from datagrunt.core import (
+    CSVEngineFactory,
+    CSVEngineProperties,
+)
+from datagrunt.core.databases import databases as databases_module
+
+ALL_ENGINES = ["duckdb", "polars", "pyarrow"]
+SAMPLE_ROWS = CSVEngineProperties.dataframe_sample_rows
+
+
+@pytest.fixture
+def large_csv(tmp_path):
+    """A CSV with many more rows than the sample size.
+
+    The row ``id`` equals its position so we can assert ordering precisely.
+    """
+    total_rows = SAMPLE_ROWS * 50
+    lines = ["id,name,city"]
+    for i in range(total_rows):
+        lines.append(f"{i},name_{i},city_{i}")
+    csv_file = tmp_path / "large.csv"
+    csv_file.write_text("\n".join(lines))
+    return str(csv_file)
+
+
+def _sample(engine, filepath, normalize_columns=False):
+    reader = CSVEngineFactory(filepath, engine).create_reader()
+    return reader.get_sample(normalize_columns=normalize_columns)
+
+
+def test_get_sample_returns_same_first_n_rows_across_engines(large_csv):
+    """All three engines return identical first-N rows for the sample."""
+    samples = {engine: _sample(engine, large_csv) for engine in ALL_ENGINES}
+
+    for engine, sample in samples.items():
+        assert isinstance(sample, pl.DataFrame), engine
+        assert len(sample) == SAMPLE_ROWS, engine
+        # First-N rows means ids 0..N-1 in order.
+        assert sample["id"].to_list() == [str(i) for i in range(SAMPLE_ROWS)], engine
+
+    reference = samples["polars"]
+    for engine, sample in samples.items():
+        assert sample.columns == reference.columns, engine
+        assert sample.to_dicts() == reference.to_dicts(), engine
+
+
+def test_get_sample_normalized_same_first_n_rows_across_engines(large_csv):
+    """Normalized samples are also identical first-N rows across engines."""
+    samples = {engine: _sample(engine, large_csv, normalize_columns=True) for engine in ALL_ENGINES}
+
+    reference = samples["polars"]
+    for engine, sample in samples.items():
+        assert len(sample) == SAMPLE_ROWS, engine
+        assert sample.columns == reference.columns, engine
+        assert sample.to_dicts() == reference.to_dicts(), engine
+
+
+def test_pyarrow_get_sample_does_not_fully_read_the_file(large_csv, monkeypatch):
+    """The pyarrow sample must not call ``pacsv.read_csv`` (whole-file read)."""
+    calls = []
+    original_read_csv = pacsv.read_csv
+
+    def spy_read_csv(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_read_csv(*args, **kwargs)
+
+    # Patch the symbol as referenced inside the engines module.
+    import datagrunt.core.csv_io.engines as engines_module
+
+    monkeypatch.setattr(engines_module.pacsv, "read_csv", spy_read_csv)
+
+    sample = _sample("pyarrow", large_csv)
+    assert len(sample) == SAMPLE_ROWS
+    assert calls == [], "pyarrow get_sample fully materialized the file via pacsv.read_csv"
+
+
+def test_duckdb_get_sample_does_not_create_full_table(large_csv, monkeypatch):
+    """The duckdb sample must not import the whole file into a table."""
+    calls = []
+    original_create_table = databases_module.DuckDBQueries.create_table
+
+    def spy_create_table(self, *args, **kwargs):
+        calls.append((args, kwargs))
+        return original_create_table(self, *args, **kwargs)
+
+    monkeypatch.setattr(databases_module.DuckDBQueries, "create_table", spy_create_table)
+
+    sample = _sample("duckdb", large_csv)
+    assert len(sample) == SAMPLE_ROWS
+    assert calls == [], "duckdb get_sample materialized the full table via create_table"
+
+
+def test_get_sample_preserves_comment_handling(tmp_path):
+    """Leading comment lines are skipped consistently across engines."""
+    content = "# a leading comment\n# another comment\nid,name\n0,zero\n1,one\n2,two"
+    csv_file = tmp_path / "commented.csv"
+    csv_file.write_text(content)
+    filepath = str(csv_file)
+
+    samples = {engine: _sample(engine, filepath) for engine in ALL_ENGINES}
+    reference = samples["polars"]
+    for engine, sample in samples.items():
+        assert sample.columns == reference.columns, engine
+        assert sample.to_dicts() == reference.to_dicts(), engine


### PR DESCRIPTION
Closes #105. 

- perf(csv): stream the first rows for get_sample instead of materializing the file

Full root-cause analysis in the linked issue(s). Unit tests for the fix are included on this branch and the full pytest suite is green; an independent subagent validation report will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)