### PR TITLE
build: update external dependencies to latest versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,28 +20,28 @@ classifiers = [
 ]
 keywords = ["csv", "data", "duckdb", "polars", "pyarrow", "xlsx", "delimiter", "ai", "gemini", "pdf"]
 dependencies = [
-    "duckdb>=1.4.0",
-    "polars>=1.7.1",
-    "pyarrow>=17.0.0",
-    "XlsxWriter>=3.2.0",
-    "google-genai>=1.25.0"
+    "duckdb>=1.5.3",
+    "polars>=1.41.2",
+    "pyarrow>=24.0.0",
+    "XlsxWriter>=3.2.9",
+    "google-genai>=2.8.0"
 ]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
 pdf = [
-    "PyMuPDF>=1.27.0",
-    "pdfplumber>=0.11.0",
-    "pytesseract>=0.3.10",
-    "Pillow>=10.0.0",
-    "pypdfium2>=4.30.0",
+    "PyMuPDF>=1.27.2",
+    "pdfplumber>=0.11.9",
+    "pytesseract>=0.3.13",
+    "Pillow>=12.2.0",
+    "pypdfium2>=5.9.0",
 ]
 dev = [
-    "pytest>=8.3.4",
-    "pytest-cov>=6.0.0",
-    "ruff>=0.5.5",
-    "bumpver>=2024.1130",
-    "fastexcel>=0.13.0",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
+    "ruff>=0.15.17",
+    "bumpver>=2026.1132",
+    "fastexcel>=0.20.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Updates all external dependencies to their latest versions: the local lockfile was refreshed with `uv lock --upgrade` (uv.lock is gitignored in this repo) and the pyproject version floors are raised to the versions the test suite is verified against.

- Floors raised: duckdb 1.5.3, polars 1.41.2, pyarrow 24.0.0, XlsxWriter 3.2.9, google-genai 2.8.0; pdf extras: PyMuPDF 1.27.2, pdfplumber 0.11.9, pytesseract 0.3.13, Pillow 12.2.0, pypdfium2 5.9.0; dev extras: pytest 9.0.3, pytest-cov 7.1.0, ruff 0.15.17, bumpver 2026.1132, fastexcel 0.20.2
- Notable upgrades exercised: google-genai 2.7→2.8, pypdfium2 5.8→5.9, pyarrow 24, pytest 9

**Verification:** full pytest suite green on the upgraded set (281 passed). The 32 ruff findings present after the upgrade are byte-identical under ruff 0.15.15 and 0.15.17 — pre-existing on main, not introduced here.

An independent subagent validation report will be posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)