### PR TITLE
feat: class-level normalize_columns for CSVReader/CSVWriter [minor]

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ With the DuckDB engine, repeated `query_data()` calls on the same reader reuse
 a single import: the CSV is loaded into DuckDB once per reader instance, so
 follow-up queries skip the file import entirely and run dramatically faster.
 
+### Consistent Column Names with `normalize_columns`
+
+Pass `normalize_columns=True` at construction to work in normalized column names (lowercase, underscores, collision-safe) everywhere — including SQL:
+
+```python
+from datagrunt import CSVReader
+
+dg = CSVReader('electric_vehicle_population_data.csv', engine='duckdb', normalize_columns=True)
+
+# The DuckDB table is imported with normalized names, so you write your
+# query and read your results in the same vocabulary — no aliases needed.
+query = f"SELECT city, vin_1_10 FROM {dg.db_table} LIMIT 5"
+df = dg.query_data(query).pl()
+
+# Every other output honors the same setting
+dg.to_dataframe()   # columns: city, vin_1_10, ...
+dg.get_sample()     # same normalized names
+```
+
+`CSVWriter(..., normalize_columns=True)` does the same for every exported file. The older per-call form (`to_dataframe(normalize_columns=True)`) still works but is deprecated and emits a `DeprecationWarning`.
+
 ### Exporting Data to Multiple Formats
 
 ```python

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -58,6 +58,20 @@ def _is_legacy_mac_newlines(filepath):
         return False
 
 
+def _resolve_normalize_columns(instance_default, per_call_value):
+    """Resolve a per-call normalize flag against the engine's instance default.
+
+    Args:
+        instance_default (bool): The engine's constructor-level setting.
+        per_call_value (bool or None): The per-call argument; ``None`` means
+        "inherit the instance-level setting".
+
+    Returns:
+        bool: The effective normalization mode.
+    """
+    return instance_default if per_call_value is None else per_call_value
+
+
 @dataclass
 class CSVEngineProperties:
     """Base properties for CSV operations."""
@@ -80,15 +94,18 @@ class CSVEngineProperties:
 class CSVBaseReaderEngine(ABC):
     """Abstract base class defining the interface for reader engines."""
 
-    def __init__(self, filepath, lenient=False):
+    def __init__(self, filepath, lenient=False, normalize_columns=False):
         """Initialize the CSVReader class.
 
         Args:
             filepath (str or Path): Path to the file to read.
             lenient (bool): Whether to run in lenient mode.
+            normalize_columns (bool): Whether to normalize column names for
+            every operation on this engine. A per-call argument overrides it.
         """
         self.filepath = Path(filepath)
         self.lenient = lenient
+        self.normalize_columns = normalize_columns
         self.queries = DuckDBQueries(self.filepath, lenient=self.lenient)
         self.db_table = self.queries.database_table_name
         self.delimiter = self.queries.delimiter
@@ -152,16 +169,19 @@ class CSVBaseReaderEngine(ABC):
 class CSVBaseWriterEngine(ABC):
     """Abstract base class defining the interface for writer engines."""
 
-    def __init__(self, filepath, lenient=False):
+    def __init__(self, filepath, lenient=False, normalize_columns=False):
         """
         Initialize the CSV Writer DuckDB Engine class.
 
         Args:
             filepath (str or Path): Path to the file to write.
             lenient (bool): Whether to run in lenient mode.
+            normalize_columns (bool): Whether to normalize column names for
+            every operation on this engine. A per-call argument overrides it.
         """
         self.filepath = Path(filepath)
         self.lenient = lenient
+        self.normalize_columns = normalize_columns
         self.queries = DuckDBQueries(self.filepath, lenient=self.lenient)
         self.db_table = self.queries.database_table_name
         if not self.filepath.exists():
@@ -505,10 +525,6 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
     by DuckDB.
     """
 
-    def __init__(self, filepath, lenient=False):
-        """Initialize the CSVWriterDuckDBEngine class."""
-        super().__init__(filepath, lenient=lenient)
-
     def write_csv(self, export_filename=None, normalize_columns=False):
         """
         Query to export a DuckDB table to a CSV file.
@@ -593,10 +609,6 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
 
 class CSVWriterPolarsEngine(CSVBaseWriterEngine):
     """Class to write CSVs to other file formats powered by Polars."""
-
-    def __init__(self, filepath, lenient=False):
-        """Initialize the CSVWriterPolarsEngine class."""
-        super().__init__(filepath, lenient=lenient)
 
     def write_csv(self, export_filename=None, normalize_columns=False):
         """
@@ -934,10 +946,6 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
 
 class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
     """Class to write CSVs to other file formats powered by PyArrow."""
-
-    def __init__(self, filepath, lenient=False):
-        """Initialize the CSVWriterPyArrowEngine class."""
-        super().__init__(filepath, lenient=lenient)
 
     def _create_table(self, normalize_columns=False):
         """Create a PyArrow table for writing operations."""

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -158,14 +158,16 @@ class CSVBaseReaderEngine(ABC):
         pass
 
     @abstractmethod
-    def query_data(self, sql_query: str, normalize_columns: Optional[bool] = None) -> Union[DuckDBPyRelation, pl.DataFrame]:
+    def query_data(
+        self, sql_query: str, normalize_columns: Optional[bool] = None
+    ) -> Union[DuckDBPyRelation, pl.DataFrame]:
         """
         Query the data using SQL.
 
         Args:
             sql_query (str): SQL query to execute.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
         pass
 

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -563,10 +563,10 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         Query to export a DuckDB table to a CSV file.
 
-            Args:
-                export_filename str: The name of the output file.
-                normalize_columns (bool or None): Whether to normalize column
-                names. ``None`` (default) inherits the instance-level setting.
+        Args:
+            export_filename (optional, str): The name of the output file.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.csv_export_filename, export_filename)

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -342,34 +342,40 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
             projections.append(f'"{safe_col}" AS "{safe_normalized}"')
         return relation.project(", ".join(projections))
 
-    def query_data(self, sql_query, normalize_columns=False):
-        """Queries as CSV file after importing into DuckDB.
+    def query_data(self, sql_query, normalize_columns=None):
+        """Queries a CSV file after importing into DuckDB.
 
         Args:
             sql_query (str): Query to run against DuckDB.
-            normalize_columns (optional, bool): Whether to normalize
-                column names.
+            normalize_columns (bool or None): ``None`` (default) inherits the
+                instance-level setting: the table is created in the configured
+                vocabulary, so the query is written and returned with the same
+                column names. An explicit bool keeps the legacy behavior: the
+                query runs against the original names and only the result
+                columns are renamed.
 
         Returns:
             A DuckDB DuckDBPyRelation with the query results.
 
         Example if DuckDB Engine:
-            dg = CSVReader('myfile.csv')
-            query = f"SELECT col1, col2 FROM {dg.db_table}"
-            dg.query_csv_data(query)
+            dg = CSVReader('myfile.csv', normalize_columns=True)
+            query = f"SELECT col_one, col_two FROM {dg.db_table}"
+            dg.query_data(query)
         """  # noqa: E501
-        # Ensure the base table is created with original column names
-        # so the user's query can reference them.
+        if normalize_columns is None:
+            # Instance-level mode: the table itself carries the configured
+            # column names, so query vocabulary and result vocabulary match.
+            self.queries.create_table(normalize_columns=self.normalize_columns)
+            # The returned relation keeps this per-instance connection alive,
+            # so it remains valid after this engine instance is GC'd.
+            return self.queries.connection.sql(sql_query)
+
+        # Legacy per-call mode: the table keeps original column names so the
+        # user's query can reference them; only the result is renamed.
         self.queries.create_table(normalize_columns=False)
-
-        # Execute the user's query on the same per-instance connection that
-        # holds the table. The returned relation keeps this connection alive,
-        # so it remains valid after this engine instance is garbage collected.
         result_relation = self.queries.connection.sql(sql_query)
-
         if normalize_columns:
             result_relation = self._normalize_relation_columns(result_relation)
-
         return result_relation
 
 
@@ -500,27 +506,29 @@ class CSVReaderPolarsEngine(CSVBaseReaderEngine):
         """
         return self._create_dataframe(_resolve_normalize_columns(self.normalize_columns, normalize_columns)).to_dicts()
 
-    def query_data(self, sql_query, normalize_columns=False):
+    def query_data(self, sql_query, normalize_columns=None):
         """
-        Queries as CSV file after importing into DuckDB.
+        Queries a CSV file after importing into DuckDB.
 
         Args:
             sql_query (str): Query to run against DuckDB.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): ``None`` (default) inherits the
+                instance-level setting: the table is created in the configured
+                vocabulary, so the query is written and returned with the same
+                column names. An explicit bool keeps the legacy behavior: the
+                query runs against the original names and only the result
+                columns are renamed.
 
         Returns:
-            A DuckDB DuckDBPyRelation with the query results.
-
-        Example if DuckDB Engine:
-            dg = CSVReader('myfile.csv')
-            query = "SELECT col1, col2 FROM {dg.db_table}" # f string assumed
-            dg.query_csv_data(query)
+            A Polars DataFrame with the query results.
         """
         # The result is a fully-materialized polars DataFrame, so the
         # connection can be disposed deterministically (unlike the duckdb
         # engine, whose query_data returns a live relation).
         try:
+            if normalize_columns is None:
+                self.queries.create_table(normalize_columns=self.normalize_columns)
+                return self.queries.connection.sql(sql_query).pl()
             return self.queries.sql_query_to_dataframe(sql_query, normalize_columns)
         finally:
             self.queries.close()
@@ -928,27 +936,29 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
             df = df.to_frame()
         return df.to_dicts()
 
-    def query_data(self, sql_query, normalize_columns=False):
+    def query_data(self, sql_query, normalize_columns=None):
         """
-        Queries as CSV file after importing into DuckDB.
+        Queries a CSV file after importing into DuckDB.
 
         Args:
             sql_query (str): Query to run against DuckDB.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): ``None`` (default) inherits the
+                instance-level setting: the table is created in the configured
+                vocabulary, so the query is written and returned with the same
+                column names. An explicit bool keeps the legacy behavior: the
+                query runs against the original names and only the result
+                columns are renamed.
 
         Returns:
-            A DuckDB DuckDBPyRelation with the query results.
-
-        Example if DuckDB Engine:
-            dg = CSVReader('myfile.csv')
-            query = "SELECT col1, col2 FROM {dg.db_table}" # f string assumed
-            dg.query_csv_data(query)
+            A Polars DataFrame with the query results.
         """
         # The result is a fully-materialized polars DataFrame, so the
         # connection can be disposed deterministically (unlike the duckdb
         # engine, whose query_data returns a live relation).
         try:
+            if normalize_columns is None:
+                self.queries.create_table(normalize_columns=self.normalize_columns)
+                return self.queries.connection.sql(sql_query).pl()
             return self.queries.sql_query_to_dataframe(sql_query, normalize_columns)
         finally:
             self.queries.close()

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -5,7 +5,7 @@ import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 # third party libraries
 import polars as pl
@@ -113,11 +113,12 @@ class CSVBaseReaderEngine(ABC):
             raise FileNotFoundError
 
     @abstractmethod
-    def get_sample(self, normalize_columns: bool = False) -> pl.DataFrame:
+    def get_sample(self, normalize_columns: Optional[bool] = None) -> pl.DataFrame:
         """Return a sample of the data as a Polars DataFrame.
 
         Args:
-            normalize_columns (bool): Whether to normalize column names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A Polars DataFrame containing the sample rows.
@@ -125,36 +126,39 @@ class CSVBaseReaderEngine(ABC):
         pass
 
     @abstractmethod
-    def to_dataframe(self, normalize_columns: bool = False) -> pl.DataFrame:
+    def to_dataframe(self, normalize_columns: Optional[bool] = None) -> pl.DataFrame:
         """Convert data to a dataframe.
 
         Args:
-            normalize_columns (bool): Whether to normalize column names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
         pass
 
     @abstractmethod
-    def to_arrow_table(self, normalize_columns: bool = False) -> pa.Table:
+    def to_arrow_table(self, normalize_columns: Optional[bool] = None) -> pa.Table:
         """
         Convert data to a PyArrow table.
 
         Args:
-            normalize_columns (bool): Whether to normalize column names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
         pass
 
     @abstractmethod
-    def to_dicts(self, normalize_columns: bool = False) -> List[Dict]:
+    def to_dicts(self, normalize_columns: Optional[bool] = None) -> List[Dict]:
         """
         Convert data to a list of dictionaries.
 
         Args:
-            normalize_columns (bool): Whether to normalize column names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
         pass
 
     @abstractmethod
-    def query_data(self, sql_query: str, normalize_columns: bool = False) -> Union[DuckDBPyRelation, pl.DataFrame]:
+    def query_data(self, sql_query: str, normalize_columns: Optional[bool] = None) -> Union[DuckDBPyRelation, pl.DataFrame]:
         """
         Query the data using SQL.
 
@@ -239,17 +243,18 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
     Class to read CSV files and convert CSV files powered by DuckDB.
     """
 
-    def get_sample(self, normalize_columns=False):
+    def get_sample(self, normalize_columns=None):
         """
         Return a sample of the CSV file.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A Polars DataFrame containing the sample rows.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         # sample_dataframe streams the first rows (no full-table import) and
         # returns a materialized Polars frame, so the per-call connection can
         # be released deterministically rather than waiting on garbage
@@ -262,34 +267,36 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         finally:
             self.queries.close()
 
-    def to_dataframe(self, normalize_columns=False):
+    def to_dataframe(self, normalize_columns=None):
         """
         Converts CSV to a Polars dataframe.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A Polars dataframe.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         # Materialize fully (.pl()) before closing the per-call connection.
         try:
             return self.queries.create_table(normalize_columns).pl()
         finally:
             self.queries.close()
 
-    def to_arrow_table(self, normalize_columns=False):
+    def to_arrow_table(self, normalize_columns=None):
         """
         Converts CSV to a PyArrow table.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A PyArrow table.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         # Materialize into an in-memory pa.Table before closing the connection.
         try:
             result = self.queries.create_table(normalize_columns).arrow()
@@ -299,13 +306,13 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         finally:
             self.queries.close()
 
-    def to_dicts(self, normalize_columns=False):
+    def to_dicts(self, normalize_columns=None):
         """
         Converts CSV to a list of Python dictionaries.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A list of dictionaries.
@@ -439,59 +446,57 @@ class CSVReaderPolarsEngine(CSVBaseReaderEngine):
         except Exception as e:
             raise e
 
-    def get_sample(self, normalize_columns=False):
+    def get_sample(self, normalize_columns=None):
         """
         Return a sample of the CSV file.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A Polars dataframe.
         """
-        return self._create_dataframe_sample(normalize_columns)
+        return self._create_dataframe_sample(_resolve_normalize_columns(self.normalize_columns, normalize_columns))
 
-    def to_dataframe(self, normalize_columns=False):
+    def to_dataframe(self, normalize_columns=None):
         """
         Converts CSV to a Polars dataframe.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A Polars dataframe.
         """
-        return self._create_dataframe(normalize_columns)
+        return self._create_dataframe(_resolve_normalize_columns(self.normalize_columns, normalize_columns))
 
-    def to_arrow_table(self, normalize_columns=False):
+    def to_arrow_table(self, normalize_columns=None):
         """
         Converts CSV to a PyArrow table.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A PyArrow table.
         """
-        df = self._create_dataframe(normalize_columns).to_arrow()
-        return df
+        return self._create_dataframe(_resolve_normalize_columns(self.normalize_columns, normalize_columns)).to_arrow()
 
-    def to_dicts(self, normalize_columns=False):
+    def to_dicts(self, normalize_columns=None):
         """
         Converts CSV to a list of Python dictionaries.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A list of dictionaries.
         """
-        dicts = self._create_dataframe(normalize_columns).to_dicts()
-        return dicts
+        return self._create_dataframe(_resolve_normalize_columns(self.normalize_columns, normalize_columns)).to_dicts()
 
     def query_data(self, sql_query, normalize_columns=False):
         """
@@ -851,17 +856,18 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
         except Exception as e:
             raise e
 
-    def get_sample(self, normalize_columns=False):
+    def get_sample(self, normalize_columns=None):
         """
         Return a sample of the CSV file.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A Polars DataFrame containing the sample rows.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         table = self._create_table_sample(normalize_columns)
         # Convert to a Polars DataFrame for a consistent return type
         df = pl.from_arrow(table)
@@ -869,17 +875,18 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
             df = df.to_frame()
         return df
 
-    def to_dataframe(self, normalize_columns=False) -> pl.DataFrame:
+    def to_dataframe(self, normalize_columns=None) -> pl.DataFrame:
         """
         Converts CSV to a Polars dataframe.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A Polars dataframe.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         table = self._create_table(normalize_columns)
         df = pl.from_arrow(table)
         # Ensure we always return a DataFrame, not a Series
@@ -887,30 +894,31 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
             df = df.to_frame()
         return df
 
-    def to_arrow_table(self, normalize_columns=False):
+    def to_arrow_table(self, normalize_columns=None):
         """
         Converts CSV to a PyArrow table.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A PyArrow table.
         """
-        return self._create_table(normalize_columns)
+        return self._create_table(_resolve_normalize_columns(self.normalize_columns, normalize_columns))
 
-    def to_dicts(self, normalize_columns=False):
+    def to_dicts(self, normalize_columns=None):
         """
         Converts CSV to a list of Python dictionaries.
 
         Args:
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
 
         Returns:
             A list of dictionaries.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         table = self._create_table(normalize_columns)
         # Convert to Polars DataFrame and then to dicts
         df = pl.from_arrow(table)

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -361,13 +361,20 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
             dg = CSVReader('myfile.csv', normalize_columns=True)
             query = f"SELECT col_one, col_two FROM {dg.db_table}"
             dg.query_data(query)
+
+        Note:
+            The returned relation is lazy and bound to this reader's shared
+            DuckDB table. Mixing inherit-mode and explicit ``normalize_columns``
+            calls on the same reader re-imports that table with a different
+            column vocabulary, so evaluate (e.g. ``.pl()``) any relation you
+            need to keep before issuing a query in the other mode.
         """  # noqa: E501
         if normalize_columns is None:
             # Instance-level mode: the table itself carries the configured
             # column names, so query vocabulary and result vocabulary match.
             self.queries.create_table(normalize_columns=self.normalize_columns)
-            # The returned relation keeps this per-instance connection alive,
-            # so it remains valid after this engine instance is GC'd.
+            # The relation is lazy and bound to this engine's connection; it
+            # survives engine GC but not a later mode flip or close().
             return self.queries.connection.sql(sql_query)
 
         # Legacy per-call mode: the table keeps original column names so the

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -194,48 +194,60 @@ class CSVBaseWriterEngine(ABC):
             raise FileNotFoundError
 
     @abstractmethod
-    def write_csv(self, export_filename, normalize_columns=False):
-        """Write data to CSV format."""
+    def write_csv(self, export_filename, normalize_columns=None):
+        """Write data to CSV format.
+
+        Args:
+            export_filename (str): Path to the file to write.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
+        """
         pass
 
     @abstractmethod
-    def write_excel(self, export_filename, normalize_columns=False):
+    def write_excel(self, export_filename, normalize_columns=None):
         """
         Write data to Excel format.
 
         Args:
             export_filename (str): Path to the file to write.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
         pass
 
     @abstractmethod
-    def write_json(self, export_filename, normalize_columns=False):
-        """Write data to JSON format."""
+    def write_json(self, export_filename, normalize_columns=None):
+        """Write data to JSON format.
+
+        Args:
+            export_filename (str): Path to the file to write.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
+        """
         pass
 
     @abstractmethod
-    def write_json_newline_delimited(self, export_filename, normalize_columns=False):
+    def write_json_newline_delimited(self, export_filename, normalize_columns=None):
         """
         Write data to JSON Lines format.
 
         Args:
             export_filename (str): Path to the file to write.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
         pass
 
     @abstractmethod
-    def write_parquet(self, export_filename, normalize_columns=False):
+    def write_parquet(self, export_filename, normalize_columns=None):
         """
         Write data to Parquet format.
 
         Args:
             export_filename (str): Path to the file to write.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
         pass
 
@@ -547,14 +559,16 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
     by DuckDB.
     """
 
-    def write_csv(self, export_filename=None, normalize_columns=False):
+    def write_csv(self, export_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to a CSV file.
 
             Args:
                 export_filename str: The name of the output file.
-                normalize_columns bool: Whether to normalize column names.
+                normalize_columns (bool or None): Whether to normalize column
+                names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.csv_export_filename, export_filename)
         # COPY executes eagerly on .sql(), so the file is written before close()
         # releases the per-call connection.
@@ -564,15 +578,16 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         finally:
             self.queries.close()
 
-    def write_excel(self, export_filename=None, normalize_columns=False):
+    def write_excel(self, export_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to an Excel file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.excel_export_filename, export_filename)
         try:
             self.queries.create_table(normalize_columns)
@@ -580,15 +595,16 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         finally:
             self.queries.close()
 
-    def write_json(self, export_filename=None, normalize_columns=False):
+    def write_json(self, export_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to a JSON file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_export_filename, export_filename)
         try:
             self.queries.create_table(normalize_columns)
@@ -596,15 +612,16 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         finally:
             self.queries.close()
 
-    def write_json_newline_delimited(self, export_filename=None, normalize_columns=False):
+    def write_json_newline_delimited(self, export_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to a JSON newline delimited file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_newline_export_filename, export_filename)
         try:
             self.queries.create_table(normalize_columns)
@@ -612,15 +629,16 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         finally:
             self.queries.close()
 
-    def write_parquet(self, export_filename=None, normalize_columns=False):
+    def write_parquet(self, export_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to a Parquet file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.parquet_export_filename, export_filename)
         try:
             self.queries.create_table(normalize_columns)
@@ -632,67 +650,72 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
 class CSVWriterPolarsEngine(CSVBaseWriterEngine):
     """Class to write CSVs to other file formats powered by Polars."""
 
-    def write_csv(self, export_filename=None, normalize_columns=False):
+    def write_csv(self, export_filename=None, normalize_columns=None):
         """
         Export a Polars dataframe to a CSV file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.csv_export_filename, export_filename)
         df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
         df.write_csv(filename)
 
-    def write_excel(self, export_filename=None, normalize_columns=False):
+    def write_excel(self, export_filename=None, normalize_columns=None):
         """
         Export a Polars dataframe to an Excel file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.excel_export_filename, export_filename)
         df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
         df.write_excel(filename)
 
-    def write_json(self, export_filename=None, normalize_columns=False):
+    def write_json(self, export_filename=None, normalize_columns=None):
         """
         Export a Polars dataframe to a JSON file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_export_filename, export_filename)
         df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
         df.write_json(filename)
 
-    def write_json_newline_delimited(self, export_filename=None, normalize_columns=False):
+    def write_json_newline_delimited(self, export_filename=None, normalize_columns=None):
         """
         Export a Polars dataframe to a JSON newline delimited file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_newline_export_filename, export_filename)
         df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
         df.write_ndjson(filename)
 
-    def write_parquet(self, export_filename=None, normalize_columns=False):
+    def write_parquet(self, export_filename=None, normalize_columns=None):
         """
         Export a Polars dataframe to a Parquet file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.parquet_export_filename, export_filename)
         df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
         df.write_parquet(filename)
@@ -1029,29 +1052,31 @@ class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
         except Exception as e:
             raise e
 
-    def write_csv(self, export_filename=None, normalize_columns=False):
+    def write_csv(self, export_filename=None, normalize_columns=None):
         """
         Export a PyArrow table to a CSV file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.csv_export_filename, export_filename)
         table = self._create_table(normalize_columns)
         # Use native PyArrow CSV writer - no dataframe conversion needed
         pacsv.write_csv(table, filename)
 
-    def write_excel(self, export_filename=None, normalize_columns=False):
+    def write_excel(self, export_filename=None, normalize_columns=None):
         """
         Export a PyArrow table to an Excel file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.excel_export_filename, export_filename)
         table = self._create_table(normalize_columns)
         # Convert to Polars DataFrame for Excel export
@@ -1060,15 +1085,16 @@ class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
             df = df.to_frame()
         df.write_excel(filename)
 
-    def write_json(self, export_filename=None, normalize_columns=False):
+    def write_json(self, export_filename=None, normalize_columns=None):
         """
         Export a PyArrow table to a JSON file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_export_filename, export_filename)
         table = self._create_table(normalize_columns)
         # Use native PyArrow iteration to avoid dataframe conversion
@@ -1079,15 +1105,16 @@ class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
         with open(filename, "w") as f:
             json.dump(records, f, indent=4)
 
-    def write_json_newline_delimited(self, export_filename=None, normalize_columns=False):
+    def write_json_newline_delimited(self, export_filename=None, normalize_columns=None):
         """
         Export a PyArrow table to a JSON newline delimited file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_newline_export_filename, export_filename)
         table = self._create_table(normalize_columns)
         # Use native PyArrow iteration to avoid dataframe conversion
@@ -1096,15 +1123,16 @@ class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
                 record = {col: table[col][i].as_py() for col in table.column_names}
                 f.write(json.dumps(record) + "\n")
 
-    def write_parquet(self, export_filename=None, normalize_columns=False):
+    def write_parquet(self, export_filename=None, normalize_columns=None):
         """
         Export a PyArrow table to a Parquet file.
 
         Args:
             export_filename (optional, str): The name of the output file.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
         """
+        normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.parquet_export_filename, export_filename)
         table = self._create_table(normalize_columns)
         # Use native PyArrow Parquet writer - no dataframe conversion needed

--- a/src/datagrunt/core/csv_io/factories.py
+++ b/src/datagrunt/core/csv_io/factories.py
@@ -32,7 +32,7 @@ class CSVEngineFactory:
         "pyarrow": CSVWriterPyArrowEngine,
     }
 
-    def __init__(self, filepath, engine, lenient=False):
+    def __init__(self, filepath, engine, lenient=False, normalize_columns=False):
         """
         Initialize the Engine Factory class.
 
@@ -40,10 +40,13 @@ class CSVEngineFactory:
             filepath (str or Path): Path to the file to read.
             engine (str): type of engine to create by the factory.
             lenient (bool): Whether to run in lenient mode.
+            normalize_columns (bool): Instance-level column normalization
+            setting forwarded to the engines this factory creates.
         """
         self.filepath = Path(filepath)
         self.engine = engine.lower().replace(" ", "")
         self.lenient = lenient
+        self.normalize_columns = normalize_columns
         if not self.filepath.exists():
             raise FileNotFoundError
         self.validate_engine(self.engine)
@@ -78,7 +81,7 @@ class CSVEngineFactory:
         """
         engine_class = self.READER_ENGINES.get(self.engine)
         if engine_class:
-            return engine_class(self.filepath, lenient=self.lenient)
+            return engine_class(self.filepath, lenient=self.lenient, normalize_columns=self.normalize_columns)
         else:
             raise ValueError(f"Unsupported reader engine: {self.engine}")
 
@@ -94,6 +97,6 @@ class CSVEngineFactory:
         """
         engine_class = self.WRITER_ENGINES.get(self.engine)
         if engine_class:
-            return engine_class(self.filepath, lenient=self.lenient)
+            return engine_class(self.filepath, lenient=self.lenient, normalize_columns=self.normalize_columns)
         else:
             raise ValueError(f"Unsupported reader engine: {self.engine}")

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -533,6 +533,9 @@ class DuckDBQueries:
             _check_csv_ragged_and_warn(self.filepath, self.delimiter)
         # Ensure the table is created with original column names for querying
         self.connection.sql(self.import_csv_query())
+        # The raw import above replaced the table with original column names;
+        # record that so create_table cannot wrongly reuse a "normalized" table.
+        self._imported_normalize_columns = False
 
         # Execute the user's query
         result_df = self.connection.sql(sql_query).pl()

--- a/src/datagrunt/csv_api/_compat.py
+++ b/src/datagrunt/csv_api/_compat.py
@@ -2,9 +2,10 @@
 
 # standard library
 import warnings
+from typing import Optional
 
 
-def warn_per_call_normalize(normalize_columns):
+def warn_per_call_normalize(normalize_columns: Optional[bool]) -> Optional[bool]:
     """Warn when the deprecated per-call ``normalize_columns`` argument is used.
 
     Args:

--- a/src/datagrunt/csv_api/_compat.py
+++ b/src/datagrunt/csv_api/_compat.py
@@ -1,0 +1,25 @@
+"""Compatibility helpers for deprecated csv_api parameters."""
+
+# standard library
+import warnings
+
+
+def warn_per_call_normalize(normalize_columns):
+    """Warn when the deprecated per-call ``normalize_columns`` argument is used.
+
+    Args:
+        normalize_columns (bool or None): The per-call value. ``None`` means
+        "inherit the instance-level setting" and is the non-deprecated path.
+
+    Returns:
+        The value unchanged, so callers can pass through in one expression.
+    """
+    if normalize_columns is not None:
+        warnings.warn(
+            "Passing normalize_columns per call is deprecated and will be removed in a "
+            "future release. Set normalize_columns on the CSVReader/CSVWriter "
+            "constructor instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+    return normalize_columns

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -13,12 +13,13 @@ import pyarrow as pa
 
 # local libraries
 from datagrunt.core import CSVComponents, CSVEngineFactory, DuckDBQueries
+from datagrunt.csv_api._compat import warn_per_call_normalize
 
 
 class CSVReader(CSVComponents):
     """Class to unify the interface for reading CSV files."""
 
-    def __init__(self, filepath, engine="polars", lenient=False):
+    def __init__(self, filepath, engine="polars", lenient=False, normalize_columns=False):
         """
         Initialize the CSV Reader class.
 
@@ -27,9 +28,13 @@ class CSVReader(CSVComponents):
             engine (str, default 'polars'): Determines which reader engine
             class to instantiate.
             lenient (bool): Whether to run in lenient mode.
+            normalize_columns (bool): Whether to normalize column names for
+            every operation on this reader. With the DuckDB engine, queries
+            are then written against the normalized names.
         """
         filepath = Path(filepath)
         self.lenient = lenient
+        self.normalize_columns = normalize_columns
         super().__init__(filepath)
         self.db_table = DuckDBQueries(self.filepath, lenient=self.lenient).database_table_name
         self.engine = engine.lower().replace(" ", "")
@@ -48,7 +53,12 @@ class CSVReader(CSVComponents):
         ``query_data`` - reuse a single import instead of rebuilding a fresh
         engine and re-importing the file on every call (issue #104).
         """
-        return CSVEngineFactory(self.filepath, self.engine, lenient=self.lenient).create_reader()
+        return CSVEngineFactory(
+            self.filepath,
+            self.engine,
+            lenient=self.lenient,
+            normalize_columns=self.normalize_columns,
+        ).create_reader()
 
     def _create_reader(self):
         """Return this reader's cached engine.
@@ -58,79 +68,86 @@ class CSVReader(CSVComponents):
         """
         return self._reader
 
-    def get_sample(self, normalize_columns=False):
+    def get_sample(self, normalize_columns=None):
         """Return a sample of the CSV file.
 
         Args:
-            normalize_columns (bool): Whether to normalize column names.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
 
         Returns:
             A Polars DataFrame containing the sample rows.
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pl.DataFrame())
-        return self._create_reader().get_sample(normalize_columns)
+        return self._create_reader().get_sample(warn_per_call_normalize(normalize_columns))
 
-    def to_dataframe(self, normalize_columns=False):
+    def to_dataframe(self, normalize_columns=None):
         """Converts CSV to a Polars dataframe.
 
         Args:
-            normalize_columns (bool): Whether to normalize column names.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
 
         Returns:
             A Polars dataframe.
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pl.DataFrame())
-        return self._create_reader().to_dataframe(normalize_columns)
+        return self._create_reader().to_dataframe(warn_per_call_normalize(normalize_columns))
 
-    def to_arrow_table(self, normalize_columns=False):
+    def to_arrow_table(self, normalize_columns=None):
         """Converts CSV to a PyArrow table.
 
         Args:
-            normalize_columns (bool): Whether to normalize column names.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
 
         Returns:
             A PyArrow table.
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pa.Table.from_pydict({}))
-        return self._create_reader().to_arrow_table(normalize_columns)
+        return self._create_reader().to_arrow_table(warn_per_call_normalize(normalize_columns))
 
-    def to_dicts(self, normalize_columns=False):
+    def to_dicts(self, normalize_columns=None):
         """Converts CSV to a list of dictionaries.
 
         Args:
-            normalize_columns (bool): Whether to normalize column names.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
 
         Returns:
             A list of dictionaries.
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(list())
-        return self._create_reader().to_dicts(normalize_columns)
+        return self._create_reader().to_dicts(warn_per_call_normalize(normalize_columns))
 
-    def query_data(self, sql_query, normalize_columns=False):
+    def query_data(self, sql_query, normalize_columns=None):
         """
-        Queries as CSV file after importing into DuckDB.
+        Queries a CSV file after importing into DuckDB.
 
         Args:
             sql_query (str): Query to run against DuckDB.
-            normalize_columns (optional, bool): Whether to normalize column
-            names.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
 
         Returns:
-            A DuckDB DuckDBPyRelation with the query results.
+            A DuckDB DuckDBPyRelation with the query results (DuckDB engine)
+            or a Polars DataFrame (polars/pyarrow engines).
 
         Example if DuckDB Engine:
-            dg = CSVReader('myfile.csv')
-            query = "SELECT col1, col2 FROM {dg.db_table}" # f string assumed
-            dg.query_csv_data(query)
+            dg = CSVReader('myfile.csv', normalize_columns=True)
+            query = f"SELECT col_one, col_two FROM {dg.db_table}"
+            dg.query_data(query)
 
-        If you set normalize_columns=True, the column names will be normalized
-        to lowercase and spaces will be replaced with underscores, and you
-        must reference the new column names in your query.
+        If the reader was constructed with normalize_columns=True, the table
+        is imported with normalized column names, so write your SQL against
+        those names (see ``columns_normalized`` for the list). The deprecated
+        per-call argument keeps the legacy behavior instead: the query runs
+        against the original column names and only the result is renamed.
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(list())
-        return self._create_reader().query_data(sql_query, normalize_columns)
+        return self._create_reader().query_data(sql_query, warn_per_call_normalize(normalize_columns))

--- a/src/datagrunt/csv_api/csvwriter.py
+++ b/src/datagrunt/csv_api/csvwriter.py
@@ -11,6 +11,7 @@ from datagrunt.core import (
     CSVEngineProperties,
     DuckDBQueries,
 )
+from datagrunt.csv_api._compat import warn_per_call_normalize
 
 
 class CSVWriter(CSVComponents):
@@ -19,7 +20,7 @@ class CSVWriter(CSVComponents):
     supported file types.
     """
 
-    def __init__(self, filepath, engine="duckdb", lenient=False):
+    def __init__(self, filepath, engine="duckdb", lenient=False, normalize_columns=False):
         """
         Initialize the CSV Writer class.
 
@@ -28,9 +29,12 @@ class CSVWriter(CSVComponents):
             engine (str, default 'duckdb'): Determines which writer engine
             class to instantiate.
             lenient (bool): Whether to run in lenient mode.
+            normalize_columns (bool): Whether to normalize column names in
+            every file this writer exports.
         """
         filepath = Path(filepath)
         self.lenient = lenient
+        self.normalize_columns = normalize_columns
         super().__init__(filepath)
         self.queries = DuckDBQueries(self.filepath, lenient=self.lenient)
         self.db_table = self.queries.database_table_name
@@ -38,8 +42,13 @@ class CSVWriter(CSVComponents):
         CSVEngineFactory.validate_engine(self.engine)
 
     def _create_writer(self):
-        """Create a reader object."""
-        return CSVEngineFactory(self.filepath, self.engine, lenient=self.lenient).create_writer()
+        """Create a writer object."""
+        return CSVEngineFactory(
+            self.filepath,
+            self.engine,
+            lenient=self.lenient,
+            normalize_columns=self.normalize_columns,
+        ).create_writer()
 
     def _write_empty_output(self, default_filename, out_filename=None):
         """Write a truly empty output file for an empty/blank source.
@@ -52,69 +61,71 @@ class CSVWriter(CSVComponents):
         filename = self.queries.set_export_filename(default_filename, out_filename)
         Path(filename).write_bytes(b"")
 
-    def write_csv(self, out_filename=None, normalize_columns=False):
+    def write_csv(self, out_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to a CSV file.
 
-            Args:
-                out_filename str: The name of the output file.
-                normalize_columns optional, bool: Whether to normalize column
-                names.
+        Args:
+            out_filename str: The name of the output file.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(CSVEngineProperties.csv_export_filename, out_filename)
-        return self._create_writer().write_csv(out_filename, normalize_columns)
+        return self._create_writer().write_csv(out_filename, warn_per_call_normalize(normalize_columns))
 
-    def write_excel(self, out_filename=None, normalize_columns=False):
+    def write_excel(self, out_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to an Excel file.
 
         Args:
             out_filename str: The name of the output file.
-            normalize_columns optional, bool: Whether to normalize column
-            names.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(CSVEngineProperties.excel_export_filename, out_filename)
-        return self._create_writer().write_excel(out_filename, normalize_columns)  # noqa: E501
+        return self._create_writer().write_excel(out_filename, warn_per_call_normalize(normalize_columns))
 
-    def write_json(self, out_filename=None, normalize_columns=False):
+    def write_json(self, out_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to a JSON file.
 
         Args:
             out_filename str: The name of the output file.
-            normalize_columns optional, bool: Whether to normalize column
-            names.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(CSVEngineProperties.json_export_filename, out_filename)
-        return self._create_writer().write_json(out_filename, normalize_columns)  # noqa: E501
+        return self._create_writer().write_json(out_filename, warn_per_call_normalize(normalize_columns))
 
-    def write_json_newline_delimited(self, out_filename=None, normalize_columns=False):
+    def write_json_newline_delimited(self, out_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to a JSON newline delimited file.
 
         Args:
             out_filename str: The name of the output file.
-            normalize_columns optional, bool: Whether to normalize column
-            names.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(
                 CSVEngineProperties.json_newline_export_filename, out_filename
             )
-        return self._create_writer().write_json_newline_delimited(out_filename, normalize_columns)
+        return self._create_writer().write_json_newline_delimited(
+            out_filename, warn_per_call_normalize(normalize_columns)
+        )
 
-    def write_parquet(self, out_filename=None, normalize_columns=False):
+    def write_parquet(self, out_filename=None, normalize_columns=None):
         """
         Query to export a DuckDB table to a Parquet file.
 
         Args:
             out_filename str: The name of the output file.
-            normalize_columns optional, bool: Whether to normalize column
-            names.
+            normalize_columns (bool or None): Deprecated per-call override.
+            ``None`` (default) inherits the constructor-level setting.
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(CSVEngineProperties.parquet_export_filename, out_filename)
-        return self._create_writer().write_parquet(out_filename, normalize_columns)  # noqa: E501
+        return self._create_writer().write_parquet(out_filename, warn_per_call_normalize(normalize_columns))

--- a/src/datagrunt/csv_api/csvwriter.py
+++ b/src/datagrunt/csv_api/csvwriter.py
@@ -110,9 +110,7 @@ class CSVWriter(CSVComponents):
             ``None`` (default) inherits the constructor-level setting.
         """
         if self.is_empty or self.is_blank:
-            return self._write_empty_output(
-                CSVEngineProperties.json_newline_export_filename, out_filename
-            )
+            return self._write_empty_output(CSVEngineProperties.json_newline_export_filename, out_filename)
         return self._create_writer().write_json_newline_delimited(
             out_filename, warn_per_call_normalize(normalize_columns)
         )

--- a/tests/csv_api_tests/test_normalize_class_level.py
+++ b/tests/csv_api_tests/test_normalize_class_level.py
@@ -40,3 +40,39 @@ class TestEngineFactoryPlumbing:
             writer_engine = CSVEngineFactory(mixed_headers_csv, engine).create_writer()
             assert reader_engine.normalize_columns is False
             assert writer_engine.normalize_columns is False
+
+
+class TestReaderEngineInstanceNormalization:
+    """Reader engines apply the constructor-level flag when no per-call value is given."""
+
+    def test_to_dataframe_uses_instance_flag(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_reader()
+            assert list(reader_engine.to_dataframe().columns) == NORMALIZED_HEADERS
+
+    def test_get_sample_uses_instance_flag(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_reader()
+            assert list(reader_engine.get_sample().columns) == NORMALIZED_HEADERS
+
+    def test_to_arrow_table_uses_instance_flag(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_reader()
+            assert reader_engine.to_arrow_table().column_names == NORMALIZED_HEADERS
+
+    def test_to_dicts_uses_instance_flag(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_reader()
+            assert list(reader_engine.to_dicts()[0].keys()) == NORMALIZED_HEADERS
+
+    def test_per_call_false_overrides_instance_true(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_reader()
+            df = reader_engine.to_dataframe(normalize_columns=False)
+            assert list(df.columns) == ORIGINAL_HEADERS
+
+    def test_per_call_true_overrides_instance_false(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine).create_reader()
+            df = reader_engine.to_dataframe(normalize_columns=True)
+            assert list(df.columns) == NORMALIZED_HEADERS

--- a/tests/csv_api_tests/test_normalize_class_level.py
+++ b/tests/csv_api_tests/test_normalize_class_level.py
@@ -135,3 +135,21 @@ class TestQueryDataInstanceNormalization:
         assert reader_engine.query_data(inherit_sql).pl().columns == ["first_name"]
         assert reader_engine.query_data(legacy_sql, normalize_columns=False).pl().columns == ["First Name"]
         assert reader_engine.query_data(inherit_sql).pl().columns == ["first_name"]
+
+
+class TestWriterEngineInstanceNormalization:
+    """Writer engines apply the constructor-level flag when no per-call value is given."""
+
+    def test_write_csv_uses_instance_flag(self, mixed_headers_csv, tmp_path):
+        for engine in ALL_ENGINES:
+            writer_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_writer()
+            out_file = tmp_path / f"out_{engine}.csv"
+            writer_engine.write_csv(str(out_file))
+            assert pl.read_csv(out_file).columns == NORMALIZED_HEADERS
+
+    def test_write_csv_per_call_false_overrides_instance_true(self, mixed_headers_csv, tmp_path):
+        for engine in ALL_ENGINES:
+            writer_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_writer()
+            out_file = tmp_path / f"out_raw_{engine}.csv"
+            writer_engine.write_csv(str(out_file), normalize_columns=False)
+            assert pl.read_csv(out_file).columns == ORIGINAL_HEADERS

--- a/tests/csv_api_tests/test_normalize_class_level.py
+++ b/tests/csv_api_tests/test_normalize_class_level.py
@@ -196,3 +196,27 @@ class TestCSVReaderClassLevelAPI:
         for engine in ALL_ENGINES:
             reader = CSVReader(mixed_headers_csv, engine=engine)
             assert list(reader.to_dataframe().columns) == ORIGINAL_HEADERS
+
+
+class TestCSVWriterClassLevelAPI:
+    """The public CSVWriter carries normalize_columns on the constructor."""
+
+    def test_constructor_flag_normalizes_written_headers(self, mixed_headers_csv, tmp_path):
+        for engine in ALL_ENGINES:
+            writer = CSVWriter(mixed_headers_csv, engine=engine, normalize_columns=True)
+            out_file = tmp_path / f"api_out_{engine}.csv"
+            writer.write_csv(str(out_file))
+            assert pl.read_csv(out_file).columns == NORMALIZED_HEADERS
+
+    def test_per_call_argument_emits_deprecation_warning(self, mixed_headers_csv, tmp_path):
+        writer = CSVWriter(mixed_headers_csv, engine="duckdb")
+        out_file = tmp_path / "api_out_warn.csv"
+        with pytest.warns(DeprecationWarning, match="normalize_columns"):
+            writer.write_csv(str(out_file), normalize_columns=True)
+        assert pl.read_csv(out_file).columns == NORMALIZED_HEADERS
+
+    def test_default_writer_behavior_unchanged(self, mixed_headers_csv, tmp_path):
+        writer = CSVWriter(mixed_headers_csv, engine="duckdb")
+        out_file = tmp_path / "api_out_raw.csv"
+        writer.write_csv(str(out_file))
+        assert pl.read_csv(out_file).columns == ORIGINAL_HEADERS

--- a/tests/csv_api_tests/test_normalize_class_level.py
+++ b/tests/csv_api_tests/test_normalize_class_level.py
@@ -153,3 +153,46 @@ class TestWriterEngineInstanceNormalization:
             out_file = tmp_path / f"out_raw_{engine}.csv"
             writer_engine.write_csv(str(out_file), normalize_columns=False)
             assert pl.read_csv(out_file).columns == ORIGINAL_HEADERS
+
+
+class TestCSVReaderClassLevelAPI:
+    """The public CSVReader carries normalize_columns on the constructor."""
+
+    def test_constructor_flag_normalizes_all_read_outputs(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader = CSVReader(mixed_headers_csv, engine=engine, normalize_columns=True)
+            assert list(reader.to_dataframe().columns) == NORMALIZED_HEADERS
+            assert list(reader.get_sample().columns) == NORMALIZED_HEADERS
+            assert reader.to_arrow_table().column_names == NORMALIZED_HEADERS
+            assert list(reader.to_dicts()[0].keys()) == NORMALIZED_HEADERS
+
+    def test_constructor_flag_enables_normalized_query_vocabulary(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader = CSVReader(mixed_headers_csv, engine=engine, normalize_columns=True)
+            sql = f"SELECT first_name FROM {reader.db_table} WHERE last_name = 'Doe'"
+            df = _query_result_to_dataframe(reader.query_data(sql), engine)
+            assert df["first_name"].to_list() == ["John"]
+
+    def test_per_call_argument_emits_deprecation_warning(self, mixed_headers_csv):
+        reader = CSVReader(mixed_headers_csv, engine="polars")
+        with pytest.warns(DeprecationWarning, match="normalize_columns"):
+            df = reader.to_dataframe(normalize_columns=True)
+        assert list(df.columns) == NORMALIZED_HEADERS
+
+    def test_per_call_query_data_emits_deprecation_warning(self, mixed_headers_csv):
+        reader = CSVReader(mixed_headers_csv, engine="duckdb")
+        sql = f'SELECT "First Name" FROM {reader.db_table}'
+        with pytest.warns(DeprecationWarning, match="normalize_columns"):
+            result = reader.query_data(sql, normalize_columns=True)
+        assert result.pl().columns == ["first_name"]
+
+    def test_no_warning_without_per_call_argument(self, mixed_headers_csv, recwarn):
+        reader = CSVReader(mixed_headers_csv, engine="polars", normalize_columns=True)
+        reader.to_dataframe()
+        deprecations = [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+        assert not deprecations
+
+    def test_default_reader_behavior_unchanged(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader = CSVReader(mixed_headers_csv, engine=engine)
+            assert list(reader.to_dataframe().columns) == ORIGINAL_HEADERS

--- a/tests/csv_api_tests/test_normalize_class_level.py
+++ b/tests/csv_api_tests/test_normalize_class_level.py
@@ -1,0 +1,42 @@
+"""Tests for class-level normalize_columns on engines, CSVReader, and CSVWriter."""
+
+import polars as pl
+import pytest
+
+from datagrunt import CSVReader, CSVWriter
+from datagrunt.core import CSVEngineFactory
+
+ALL_ENGINES = ["polars", "duckdb", "pyarrow"]
+
+MIXED_HEADERS_CSV = "First Name,Last Name,Age Group\nJohn,Doe,30-40\nJane,Smith,20-30"
+ORIGINAL_HEADERS = ["First Name", "Last Name", "Age Group"]
+NORMALIZED_HEADERS = ["first_name", "last_name", "age_group"]
+
+
+@pytest.fixture
+def mixed_headers_csv(tmp_path):
+    """A CSV whose headers change under normalization."""
+    csv_file = tmp_path / "mixed_headers.csv"
+    csv_file.write_text(MIXED_HEADERS_CSV)
+    return csv_file
+
+
+class TestEngineFactoryPlumbing:
+    """The factory forwards normalize_columns into every engine it builds."""
+
+    def test_factory_forwards_flag_to_reader_engines(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_reader()
+            assert reader_engine.normalize_columns is True
+
+    def test_factory_forwards_flag_to_writer_engines(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            writer_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_writer()
+            assert writer_engine.normalize_columns is True
+
+    def test_engines_default_to_no_normalization(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine).create_reader()
+            writer_engine = CSVEngineFactory(mixed_headers_csv, engine).create_writer()
+            assert reader_engine.normalize_columns is False
+            assert writer_engine.normalize_columns is False

--- a/tests/csv_api_tests/test_normalize_class_level.py
+++ b/tests/csv_api_tests/test_normalize_class_level.py
@@ -114,3 +114,24 @@ class TestQueryDataInstanceNormalization:
             sql = f'SELECT "First Name" FROM {reader_engine.db_table}'
             df = _query_result_to_dataframe(reader_engine.query_data(sql, normalize_columns=True), engine)
             assert df.columns == ["first_name"]
+
+    def test_per_call_false_overrides_instance_true_query(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_reader()
+            sql = f'SELECT "First Name" FROM {reader_engine.db_table}'
+            df = _query_result_to_dataframe(reader_engine.query_data(sql, normalize_columns=False), engine)
+            assert df.columns == ["First Name"]
+
+    def test_mixed_modes_reimport_table_correctly(self, mixed_headers_csv):
+        """Alternating inherit and legacy calls re-imports the table per mode.
+
+        Each fresh query must see the vocabulary its mode implies; stale
+        relations from prior calls are documented as invalidated.
+        """
+        reader_engine = CSVEngineFactory(mixed_headers_csv, "duckdb", normalize_columns=True).create_reader()
+        inherit_sql = f"SELECT first_name FROM {reader_engine.db_table}"
+        legacy_sql = f'SELECT "First Name" FROM {reader_engine.db_table}'
+
+        assert reader_engine.query_data(inherit_sql).pl().columns == ["first_name"]
+        assert reader_engine.query_data(legacy_sql, normalize_columns=False).pl().columns == ["First Name"]
+        assert reader_engine.query_data(inherit_sql).pl().columns == ["first_name"]

--- a/tests/csv_api_tests/test_normalize_class_level.py
+++ b/tests/csv_api_tests/test_normalize_class_level.py
@@ -76,3 +76,41 @@ class TestReaderEngineInstanceNormalization:
             reader_engine = CSVEngineFactory(mixed_headers_csv, engine).create_reader()
             df = reader_engine.to_dataframe(normalize_columns=True)
             assert list(df.columns) == NORMALIZED_HEADERS
+
+
+def _query_result_to_dataframe(result, engine):
+    """DuckDB's query_data returns a relation; polars/pyarrow return a DataFrame."""
+    return result.pl() if engine == "duckdb" else result
+
+
+class TestQueryDataInstanceNormalization:
+    """With the instance flag set, SQL is written AND returned in normalized names."""
+
+    def test_query_written_against_normalized_names(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_reader()
+            sql = f"SELECT first_name FROM {reader_engine.db_table} WHERE last_name = 'Doe'"
+            df = _query_result_to_dataframe(reader_engine.query_data(sql), engine)
+            assert df.columns == ["first_name"]
+            assert df["first_name"].to_list() == ["John"]
+
+    def test_select_star_returns_normalized_names(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine, normalize_columns=True).create_reader()
+            sql = f"SELECT * FROM {reader_engine.db_table}"
+            df = _query_result_to_dataframe(reader_engine.query_data(sql), engine)
+            assert df.columns == NORMALIZED_HEADERS
+
+    def test_default_instance_still_queries_original_names(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine).create_reader()
+            sql = f'SELECT "First Name" FROM {reader_engine.db_table}'
+            df = _query_result_to_dataframe(reader_engine.query_data(sql), engine)
+            assert df.columns == ["First Name"]
+
+    def test_legacy_per_call_true_queries_original_and_renames_result(self, mixed_headers_csv):
+        for engine in ALL_ENGINES:
+            reader_engine = CSVEngineFactory(mixed_headers_csv, engine).create_reader()
+            sql = f'SELECT "First Name" FROM {reader_engine.db_table}'
+            df = _query_result_to_dataframe(reader_engine.query_data(sql, normalize_columns=True), engine)
+            assert df.columns == ["first_name"]


### PR DESCRIPTION
## Summary

- `CSVReader` and `CSVWriter` now accept `normalize_columns=True` at construction; every read, query, and export on that instance uses normalized column names (lowercase, underscores, collision-safe).
- **Fixes the `query_data` vocabulary mismatch:** with the constructor flag set, the DuckDB table itself is imported with normalized names, so SQL is written *and* returned in the same column vocabulary — no aliases, no post-hoc renaming. (Previously the table always kept original names and only result columns were renamed.)
- Per-call `normalize_columns=` on methods is deprecated: it still works with its exact legacy semantics but emits a `DeprecationWarning` pointing at the caller. Method defaults changed from `False` to `None` ("inherit the instance setting"), so existing code without the argument behaves identically and warning-free.
- Hardening found during review: `sql_query_to_dataframe` now keeps the DuckDB import-cache flag honest after raw imports; the lazy-relation lifetime across mode flips is documented and pinned by a regression test.
- README documents the new flag; the stale `query_data` docstring (which claimed the opposite of actual behavior) is fixed.

## Test Plan

- [x] 26 new tests in `tests/csv_api_tests/test_normalize_class_level.py` covering factory plumbing, instance-flag inheritance, per-call overrides, query vocabulary on all 3 engines, deprecation warnings (incl. stacklevel attribution), and writer exports
- [x] Full suite: 434 passed, 0 failed
- [x] `ruff check` clean on all touched files
- [x] Manual end-to-end: `CSVReader(..., engine='duckdb', normalize_columns=True)` + `SELECT county, city FROM {db_table}` returns normalized columns against the EV population dataset

Note: merge commit must keep `[minor]` for CI versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)