### PR TITLE
docs: point pyproject URLs at canonical www.datagrunt.io (#148)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://pmgraham.github.io/datagrunt"
+Homepage = "https://www.datagrunt.io/"
 "Bug Tracker" = "https://github.com/pmgraham/datagrunt/issues"
-Documentation = "https://pmgraham.github.io/datagrunt"
+Documentation = "https://www.datagrunt.io/"
 "Source Code" = "https://github.com/pmgraham/datagrunt"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

`pyproject.toml` `[project.urls]` linked `Homepage` and `Documentation` to the retired GitHub Pages site (`https://pmgraham.github.io/datagrunt`), which now returns **404**. The canonical docs are published by the datagrunt-site Hugo config at `https://www.datagrunt.io/`. This points the PyPI sidebar links at the live canonical site.

## Changes

- `Homepage`: `https://pmgraham.github.io/datagrunt` → `https://www.datagrunt.io/`
- `Documentation`: `https://pmgraham.github.io/datagrunt` → `https://www.datagrunt.io/`

## Verification

- `https://www.datagrunt.io/` → `200`
- `https://pmgraham.github.io/datagrunt` → `404` (already retired; no redirect to preserve)

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)