### PR TITLE
fix: escape interpolated literals in sample_csv_query (#152)

### DIFF
--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -315,9 +315,9 @@ class DuckDBQueries:
             from datagrunt.core.csv_io import CSVColumns
 
             cols = CSVColumns(self.filepath, delimiter=self.delimiter).columns
-            cols_param = "{" + ", ".join(f"'{c}': 'VARCHAR'" for c in cols) + "}"
-            read_csv = f"""read_csv('{self.filepath}',
-                                delim='{self.delimiter}',
+            cols_param = self._build_lenient_columns_param(cols)
+            read_csv = f"""read_csv('{self._escaped_filepath_literal}',
+                                delim='{self._escape_sql_literal(self.delimiter)}',
                                 header=true,
                                 columns={cols_param},
                                 quote='{self.quotechar.replace("'", "''")}',
@@ -327,10 +327,10 @@ class DuckDBQueries:
                                 strict_mode=false,
                                 skip={self.skip_rows})"""
         else:
-            read_csv = f"""read_csv('{self.filepath}',
+            read_csv = f"""read_csv('{self._escaped_filepath_literal}',
                                 auto_detect=true,
                                 comment='',
-                                delim='{self.delimiter}',
+                                delim='{self._escape_sql_literal(self.delimiter)}',
                                 header=true,
                                 quote='{self.quotechar.replace("'", "''")}',
                                 null_padding=true,

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -601,6 +601,55 @@ class TestDuckDBSqlEscaping:
         assert "John" in out.read_text()
 
 
+class TestDuckDBSampleSqlEscaping:
+    """``get_sample`` must escape interpolated literals like the import path.
+
+    ``sample_csv_query`` builds its own ``read_csv`` call separately from
+    ``import_csv_query``; an unescaped ``'`` in the file path, an inferred
+    ``'`` delimiter, or a lenient header cell previously produced broken SQL
+    (a ParserException). These mirror :class:`TestDuckDBSqlEscaping` but drive
+    the streaming-sample path via ``get_sample`` (issue #152).
+    """
+
+    def test_apostrophe_in_filename_samples_correctly_duckdb(self, tmp_path):
+        """A ``'`` in the file path must not break the sample read_csv literal."""
+        csv_file = tmp_path / "o'hara.csv"
+        csv_file.write_text("name,age\nJohn,30\nJane,25\n")
+
+        reader = CSVEngineFactory(str(csv_file), "duckdb").create_reader()
+        sample = reader.get_sample()
+        assert sample.columns == ["name", "age"]
+        assert len(sample) == 2
+
+    def test_single_quote_in_header_lenient_samples_duckdb(self, tmp_path):
+        """A ``'`` in a header cell must not break the lenient sample columns dict."""
+        csv_file = tmp_path / "quoted_header.csv"
+        # Header cell contains a single quote; lenient mode builds an explicit
+        # column dict ({'col': 'VARCHAR'}) that must escape the quote. The
+        # header has more commas than quotes so delimiter inference picks ','.
+        csv_file.write_text("o'clock,value,extra\n1,2,3\n4,5,6\n")
+
+        reader = CSVEngineFactory(str(csv_file), "duckdb", lenient=True).create_reader()
+        sample = reader.get_sample()
+        assert sample.columns == ["o'clock", "value", "extra"]
+        assert len(sample) == 2
+
+    def test_single_quote_inferred_delimiter_samples_duckdb(self, tmp_path):
+        """An inferred ``'`` delimiter must not break the sample delim literal.
+
+        A header like ``a'b'c`` infers ``'`` as the delimiter, so the
+        ``delim='...'`` literal must escape it (``delim=''''``) or every
+        DuckDB sample of the file raises a ParserException.
+        """
+        csv_file = tmp_path / "quote_delimited.csv"
+        csv_file.write_text("a'b'c\n1'2'3\n4'5'6\n")
+
+        reader = CSVEngineFactory(str(csv_file), "duckdb").create_reader()
+        sample = reader.get_sample()
+        assert sample.columns == ["a", "b", "c"]
+        assert len(sample) == 2
+
+
 class TestNonUtf8FileConstruction:
     """Constructing readers/writers on non-UTF-8 files must not raise."""
 


### PR DESCRIPTION
## Summary

`DuckDBQueries.sample_csv_query` built its `read_csv` call with **raw interpolation** of the filepath, delimiter, and (in lenient mode) header-derived column names — unlike the `import_csv_query` / `import_csv_query_normalize_columns` builders directly above it, which use the escaped variants. This broke the docstring's "options mirror `import_csv_query`" contract and is the missed site of the #82/#106 SQL-escaping work.

**Root cause:** a merge-seam gap. The #82/#106 escaping fix (PR #133) covered the import builders that existed on that branch; `sample_csv_query` arrived later via the streaming-sample work (#105 / PR #136) on a parallel branch and never received the same treatment.

## Impact

Per the library's threat model the caller controls the filepath, so this is a **content-triggered crash**, not file-write/RCE. A path like `/data/o'hara.csv`, an inferred `'` delimiter, or a lenient-mode header containing an apostrophe made `get_sample()` fail with a DuckDB `ParserException`.

## Fix

In both branches of `sample_csv_query`, replace the raw interpolations with the existing helpers used by the import builders:

| Before | After |
|---|---|
| `'{self.filepath}'` | `'{self._escaped_filepath_literal}'` |
| `delim='{self.delimiter}'` | `delim='{self._escape_sql_literal(self.delimiter)}'` |
| inline `cols_param` | `self._build_lenient_columns_param(cols)` |

## Tests

Adds `TestDuckDBSampleSqlEscaping`, mirroring the existing `TestDuckDBSqlEscaping` import-path cases against `get_sample()` on the duckdb engine: apostrophe filepath, apostrophe lenient header, and quote-inferred delimiter. All three fail on `main` (ParserException) and pass with the fix. Full CSV + databases suite: **190 passed**.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)