### PR TITLE
fix: stop BlankFile misclassifying binary files as blank (#146)

### DIFF
--- a/src/datagrunt/core/file_io/fileproperties.py
+++ b/src/datagrunt/core/file_io/fileproperties.py
@@ -1,6 +1,7 @@
 """Module for deriving and evaluating file properties."""
 
 # standard library
+import codecs
 from functools import cached_property
 from pathlib import Path
 
@@ -119,6 +120,7 @@ class BlankFile:
     """Class for checking if a file is blank."""
 
     FILE_SIZE_MB_FACTOR = 10.0
+    READ_CHUNK_SIZE = 65_536  # 64 KiB bounded reads; never the whole file at once
 
     def __init__(self, filepath):
         """Initialize the BlankFile object.
@@ -130,18 +132,44 @@ class BlankFile:
 
     @cached_property
     def is_blank(self):
-        """Check if the file is blank. Blank files contain only whitespace."""
+        """Check if the file is blank. Blank files contain only whitespace.
 
+        The file is read in bounded binary chunks and decoded strictly. Any
+        byte sequence that is not valid text - a binary PDF/Parquet/Excel body
+        or a run of invalid-UTF-8 bytes - counts as content, instead of being
+        silently dropped by ``errors="ignore"`` and misreported as blank
+        (issue #146). Only a file that decodes cleanly and holds nothing but
+        whitespace is blank.
+        """
         filestats = FileStatistics(self.filepath)
 
         # Very low probability of being blank if file is 10MB or larger in size
         if filestats.size_in_mb >= self.FILE_SIZE_MB_FACTOR:
             return False
-        with open(self.filepath, "r", encoding=DEFAULT_ENCODING, errors="ignore") as f:
-            for line in f:
-                if line.strip():
-                    return False
-        return True
+        return not self._has_content()
+
+    def _has_content(self):
+        """Return True if the file holds binary bytes or non-whitespace text.
+
+        Decoding is strict so undecodable bytes are treated as content rather
+        than dropped; an incremental decoder keeps multibyte characters that
+        straddle a chunk boundary intact.
+        """
+        decoder = codecs.getincrementaldecoder(DEFAULT_ENCODING)(errors="strict")
+        with open(self.filepath, "rb") as f:
+            while chunk := f.read(self.READ_CHUNK_SIZE):
+                try:
+                    text = decoder.decode(chunk)
+                except UnicodeDecodeError:
+                    return True  # undecodable bytes => binary content
+                if text.strip():
+                    return True
+        # Flush any buffered partial character; a multibyte sequence truncated
+        # at EOF is not clean text, so treat it as content.
+        try:
+            return bool(decoder.decode(b"", final=True).strip())
+        except UnicodeDecodeError:
+            return True
 
 
 class EmptyFile:

--- a/tests/core_tests/file_io_tests/test_fileproperties.py
+++ b/tests/core_tests/file_io_tests/test_fileproperties.py
@@ -92,6 +92,58 @@ class TestFileProperties:
         assert not pdf_file.is_semi_structured
 
 
+class TestBlankFileBinaryDetection:
+    """is_blank must not misclassify binary/invalid-UTF-8 files as blank (#146).
+
+    The old heuristic decoded any sub-10MB file as text with ``errors="ignore"``,
+    which silently dropped undecodable bytes — so a non-empty binary file could
+    decode to whitespace and be reported blank. Strict decoding now treats any
+    non-text bytes as content.
+    """
+
+    def test_invalid_utf8_bytes_not_blank(self, tmp_path):
+        """A non-empty file of invalid-UTF-8 bytes must not be blank."""
+        garbage = tmp_path / "garbage.csv"
+        garbage.write_bytes(b"\xff" * 4096)
+
+        assert not FileProperties(garbage).is_blank
+
+    def test_pdf_bytes_not_blank(self, tmp_path):
+        """A sub-10MB PDF with a binary body must not be blank."""
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n" + bytes(range(256)) * 16)
+
+        assert not FileProperties(pdf).is_blank
+
+    def test_parquet_bytes_not_blank(self, tmp_path):
+        """A sub-10MB Parquet file with a binary body must not be blank."""
+        parquet = tmp_path / "data.parquet"
+        parquet.write_bytes(b"PAR1" + bytes(range(256)) * 16 + b"PAR1")
+
+        assert not FileProperties(parquet).is_blank
+
+    def test_whitespace_only_text_still_blank(self, tmp_path):
+        """A whitespace-only text file must remain blank."""
+        blank = tmp_path / "blank.csv"
+        blank.write_text("   \n\t\n  \n")
+
+        assert FileProperties(blank).is_blank
+
+    def test_empty_file_still_blank(self, tmp_path):
+        """An empty file must remain blank."""
+        empty = tmp_path / "empty.csv"
+        empty.write_bytes(b"")
+
+        assert FileProperties(empty).is_blank
+
+    def test_normal_text_not_blank(self, tmp_path):
+        """A normal text file with content must not be blank."""
+        data = tmp_path / "data.csv"
+        data.write_text("name,age\nalice,30\n")
+
+        assert not FileProperties(data).is_blank
+
+
 class TestPathValidation:
     """Test path validation at construction for FileProperties and CSV APIs."""
 


### PR DESCRIPTION
## Summary

`BlankFile.is_blank` opened any sub-10MB file in **text mode with `errors="ignore"`** and reported "blank" when no decoded line had non-whitespace content. Two defects fall out of this:

1. **Misclassification (the real bug):** `errors="ignore"` silently drops undecodable bytes, so a non-empty binary file whose bytes are mostly invalid UTF-8 (e.g. runs of `0xFF`) decodes to nothing/whitespace and is classified `is_blank=True`. A downstream blank-file guard would then reject a real, non-empty file with a misleading "blank file" error instead of a real parse error.
2. **Unbounded read:** a binary file with no newline byte is read as a single line, materializing up to 10MB for a boolean check.

Severity is low in practice — real PDFs start with ASCII `%PDF` and Parquet with `PAR1`, so the common formats early-return on the first chunk — but the `errors="ignore"` edge is a genuine correctness hole and text-decoding binary formats is conceptually wrong.

## Fix

Read the file in **bounded 64 KiB binary chunks** and decode them **strictly**:

- any `UnicodeDecodeError` → undecodable bytes → counts as content (not blank)
- any non-whitespace decoded text → content (not blank)
- only a file that decodes cleanly and holds nothing but whitespace is blank

An incremental decoder keeps multibyte characters intact across chunk boundaries, and the final flush treats a multibyte sequence truncated at EOF as content. `utf-8-sig` BOM stripping, whitespace-only-text, and empty-file semantics are all preserved.

This is **extension-agnostic** — an invalid-bytes file with a `.csv` name is still caught — so it's strictly more robust than special-casing binary extensions.

## Tests

Adds `TestBlankFileBinaryDetection`:
- invalid-UTF-8 bytes (`0xFF` run) → **not blank** (fails on `main`, the documented defect)
- a PDF body and a Parquet body → not blank
- whitespace-only text → blank
- empty file → blank
- normal text → not blank

Full suite: **448 passed**, no regressions.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)