### PR TITLE
fix: capture negative-Y elements in layout reading order (#145)

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
+++ b/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
@@ -230,7 +230,11 @@ class PageLayoutSorter:
     def _slice_y_bands(self, columns: list, intervals: list[dict]) -> list[list]:
         """Slice Y bands based on spanning intervals."""
         segments = []
-        last_y = 0.0
+        # Start below every finite coordinate so the first "above" band captures
+        # elements with a negative y_top (off-page/cropped/rotated content);
+        # 0.0 would drop them to the leftover fallback and corrupt reading order
+        # (issue #145). With no intervals, the "below" pass then captures all.
+        last_y = -math.inf
         placed = set()
 
         for interval in intervals:

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_layout_sorter.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_layout_sorter.py
@@ -190,3 +190,46 @@ class TestPartitionNormalLayout:
         segments = PageLayoutSorter(TextItemAdapter()).partition(items)
 
         assert segments == [items]
+
+
+class TestSliceYBandsNegativeY:
+    """_slice_y_bands must place negative-Y elements in reading order (#145).
+
+    last_y started at 0.0, so any element with a negative y_top failed every
+    band check (above/mid/below) and fell through to the leftover fallback,
+    which blindly appends to the end of the first segment - even though those
+    elements are the topmost content. Initializing last_y to -inf captures
+    them in the first "above"/"below" pass instead.
+    """
+
+    def test_negative_y_above_interval_sorts_before_it(self):
+        """Negative-Y items above a spanning interval precede it, not appended."""
+        sorter = PageLayoutSorter(TextItemAdapter())
+        above_negative = [_text_item(50, 90, -20), _text_item(50, 90, -10)]
+        below_interval = [_text_item(50, 90, 100), _text_item(50, 90, 110)]
+        span = _text_item(0, 500, 50)
+        interval = {"y_top": 50.0, "y_bot": 58.0, "items": [span]}
+
+        segments = sorter._slice_y_bands(
+            above_negative + below_interval, [interval]
+        )
+        flattened = _flatten(segments)
+
+        # Every column item plus the spanning item is placed exactly once.
+        assert len(flattened) == len(above_negative) + len(below_interval) + 1
+        # The topmost (negative-Y) items come before the spanning interval.
+        order = [id(it) for it in flattened]
+        for negative in above_negative:
+            assert order.index(id(negative)) < order.index(id(span))
+
+    def test_no_interval_negative_y_preserves_top_to_bottom_order(self):
+        """With no intervals, negative-Y items keep their top-to-bottom order."""
+        sorter = PageLayoutSorter(TextItemAdapter())
+        # Already in top-to-bottom order; a single narrow column so partition
+        # returns them unsplit and order is unambiguous.
+        items = [_text_item(50, 90, -30), _text_item(50, 90, -10), _text_item(50, 90, 20)]
+
+        segments = sorter._slice_y_bands(items, [])
+        flattened = _flatten(segments)
+
+        assert flattened == items


### PR DESCRIPTION
## Summary

`PageLayoutSorter._slice_y_bands` initialized `last_y = 0.0`, assuming all Y coordinates are non-negative. Any element with a **negative `y_top`** (off-page/cropped content, coordinate-transform shifts, rotated-page artifacts — the same coordinate regimes already acknowledged in `_find_widest_gutter`'s clamp comment) failed every band check:

- **above** band: `last_y <= y_top < interval_top` was false because `0.0 <= y_top` failed
- **below** band: `y_top >= last_y` failed

Such elements fell through to the `leftover` fallback and were blindly **appended to the end of `segments[0]`**, corrupting the layout-aware reading order — even though, being negative-Y, they are the *topmost* content and should sort first.

## Fix

Initialize `last_y = -math.inf` (one line). Now the first "above" band captures everything above the first spanning interval, including negative-Y elements; with no intervals, the "below" pass captures all elements top-to-bottom. The `leftover` fallback stays as a safety net but is unreachable for finite coordinates. (`math` is already imported.)

## Tests

Adds `TestSliceYBandsNegativeY` (direct unit tests on `_slice_y_bands`, the documented root cause):
- negative-Y items above a spanning interval sort **before** it, not appended at the end of the first segment
- a no-interval page with negative-Y items preserves top-to-bottom order

Both fail on `main` (negatives dumped to the end via the leftover path) and pass with the fix. Full PDF extraction + pdf_api suites: **196 passed**, no regressions.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)