### PR TITLE
refactor: single virtual-FileProperties initializer for PDFComponents (#153)

### DIFF
--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -10,10 +10,10 @@ from pathlib import Path
 from datagrunt.core.file_io import FileProperties
 from datagrunt.core.pdf_io.extraction import PdfPlumberTableExtractor
 from datagrunt.core.pdf_io.extraction.image_dedupe import dedupe_image_files
+from datagrunt.core.pdf_io.extraction.layout_sorter import ElementAdapter, PageLayoutSorter
 from datagrunt.core.pdf_io.extraction.markdown_escape import escape_leading_markdown
 from datagrunt.core.pdf_io.extraction.ocr import dpi_for_page
 from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
-from datagrunt.core.pdf_io.extraction.layout_sorter import PageLayoutSorter, ElementAdapter
 
 PIPELINE_TYPE = "pure_python_local_v1"
 
@@ -289,7 +289,7 @@ class ParsedDocument:
         def cell_str(val):
             text = "" if val is None else str(val)
             return text.replace("\n", " ").replace("|", "\\|").strip()
-            
+
         rows = [[cell_str(c) for c in row] for row in content]
         width = max(len(r) for r in rows)
         rows = [r + [""] * (width - len(r)) for r in rows]
@@ -313,61 +313,73 @@ class PDFComponents(FileProperties):
         """
         self._parsed_dict = None
         if isinstance(filepath, dict):
+            # In-memory parsed document: not a file on disk, so there is always
+            # content (never empty/blank).
             self._parsed_dict = filepath
-            # Setup dummy FileProperties attributes
-            self.filepath = Path("in_memory.json")
-            self.filename = "in_memory.json"
-            self.extension = ".json"
-            self.extension_string = "json"
-            self.size_in_bytes = 0
-            self.size_in_kb = 0.0
-            self.size_in_mb = 0.0
-            self.size_in_gb = 0.0
-            self.size_in_tb = 0.0
-            self.is_structured = True
-            self.is_semi_structured = True
-            self.is_unstructured = False
-            self.is_standard = True
-            self.is_proprietary = False
-            self.is_csv = False
-            self.is_pdf = False
-            self.is_excel = False
-            self.is_apache = False
-            self.is_empty = False
-            self.is_blank = False
-            self.is_large = False
-            self.is_tabular = False
-            self.is_tsv = False
+            self._apply_virtual_file_properties(
+                filepath=Path("in_memory.json"), size_in_bytes=0, is_empty=False, is_blank=False
+            )
         else:
             filepath_path = Path(filepath)
             if filepath_path.suffix.lower() == ".json":
                 with open(filepath_path, "r", encoding="utf-8") as f:
                     self._parsed_dict = json.load(f)
-                self.filepath = filepath_path
-                self.filename = filepath_path.name
-                self.extension = filepath_path.suffix
-                self.extension_string = self.extension.replace(".", "")
-                self.size_in_bytes = filepath_path.stat().st_size
-                self.size_in_kb = round(self.size_in_bytes / 1000.0, 5)
-                self.size_in_mb = round(self.size_in_kb / 1000.0, 5)
-                self.size_in_gb = round(self.size_in_mb / 1000.0, 5)
-                self.size_in_tb = round(self.size_in_gb / 1000.0, 5)
-                self.is_structured = True
-                self.is_semi_structured = True
-                self.is_unstructured = False
-                self.is_standard = True
-                self.is_proprietary = False
-                self.is_csv = False
-                self.is_pdf = False
-                self.is_excel = False
-                self.is_apache = False
-                self.is_empty = self.size_in_bytes == 0
-                self.is_blank = self.size_in_bytes <= 100
-                self.is_large = False
-                self.is_tabular = False
-                self.is_tsv = False
+                size_in_bytes = filepath_path.stat().st_size
+                self._apply_virtual_file_properties(
+                    filepath=filepath_path,
+                    size_in_bytes=size_in_bytes,
+                    is_empty=size_in_bytes == 0,
+                    is_blank=size_in_bytes <= 100,
+                )
             else:
                 super().__init__(filepath_path)
+
+    def _apply_virtual_file_properties(self, *, filepath, size_in_bytes, is_empty, is_blank):
+        """Populate the full ``FileProperties`` surface for non-PDF inputs.
+
+        A parsed-document dict or a ``.json`` document file is not a PDF backed
+        by the helper objects ``FileProperties.__init__`` builds (``_stats`` /
+        ``_ext`` / ``_empty`` / ``_blank``), so the inherited ``cached_property``
+        flags cannot delegate. Set every public ``FileProperties`` attribute
+        here - in one place shared by both virtual entry points - so the two
+        cannot diverge and a newly added ``FileProperties`` attribute has a
+        single mirror site (guarded by the attribute-parity test). The flag
+        values describe a parsed document, not the real ``.json``/dict extension.
+
+        Args:
+            filepath (Path): The (possibly synthetic) source path.
+            size_in_bytes (int): Source size; the kB/MB/GB/TB tiers derive from it.
+            is_empty (bool): Whether the source has no content.
+            is_blank (bool): Whether the source is effectively blank.
+        """
+        self.filepath = Path(filepath)
+        self.filename = self.filepath.name
+        self.extension = self.filepath.suffix
+        self.extension_string = self.extension.replace(".", "")
+
+        self.size_in_bytes = size_in_bytes
+        self.size_in_kb = round(size_in_bytes / 1000.0, 5)
+        self.size_in_mb = round(self.size_in_kb / 1000.0, 5)
+        self.size_in_gb = round(self.size_in_mb / 1000.0, 5)
+        self.size_in_tb = round(self.size_in_gb / 1000.0, 5)
+
+        self.is_empty = is_empty
+        self.is_blank = is_blank
+
+        # A parsed document is treated as structured, semi-structured, standard
+        # content and never as any concrete file format or a large/tabular file.
+        self.is_structured = True
+        self.is_semi_structured = True
+        self.is_unstructured = False
+        self.is_standard = True
+        self.is_proprietary = False
+        self.is_csv = False
+        self.is_pdf = False
+        self.is_excel = False
+        self.is_apache = False
+        self.is_large = False
+        self.is_tabular = False
+        self.is_tsv = False
 
     @cached_property
     def total_pages(self):

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -1,8 +1,25 @@
 """Tests for PDF component assembly."""
 
+import json
+from functools import cached_property
+
 import pytest
 
+from datagrunt.core.file_io import FileProperties
 from datagrunt.core.pdf_io import pdfcomponents
+
+# The public FileProperties surface that virtual-mode (JSON/dict) PDFComponents
+# must mirror. The cached_property flags are discovered dynamically, so a NEW
+# flag added to FileProperties automatically enters the sweep and fails if a
+# virtual-mode instance does not expose it (issue #153).
+FILE_PROPERTY_FLAGS = sorted(
+    name for name, attr in vars(FileProperties).items() if isinstance(attr, cached_property)
+)
+FILE_PROPERTY_INIT_ATTRS = [
+    "filepath", "filename", "extension", "extension_string",
+    "size_in_bytes", "size_in_kb", "size_in_mb", "size_in_gb", "size_in_tb",
+]
+FILE_PROPERTY_SURFACE = FILE_PROPERTY_FLAGS + FILE_PROPERTY_INIT_ATTRS
 
 
 @pytest.fixture
@@ -135,6 +152,43 @@ class TestPDFComponents:
 
         comp = pdfcomponents.PDFComponents(path)
         assert comp.total_pages == 0
+
+
+class TestVirtualFilePropertiesSurface:
+    """JSON/dict-mode PDFComponents must expose the full FileProperties surface.
+
+    Virtual-mode instances bypass FileProperties.__init__ and so lack the helper
+    objects the cached_property flags delegate to. The single shared initializer
+    must set every public FileProperties attribute; this sweep fails (rather than
+    failing in production with AttributeError) if a new attribute is unmirrored
+    (issue #153).
+    """
+
+    PARSED_DOC = {"document": {"pages": []}}
+
+    @pytest.fixture
+    def dict_mode(self):
+        return pdfcomponents.PDFComponents(dict(self.PARSED_DOC))
+
+    @pytest.fixture
+    def json_mode(self, tmp_path):
+        path = tmp_path / "doc.json"
+        path.write_text(json.dumps(self.PARSED_DOC))
+        return pdfcomponents.PDFComponents(str(path))
+
+    def test_surface_discovery_is_not_vacuous(self):
+        """The dynamic flag sweep must actually find the known flags."""
+        assert {"is_pdf", "is_csv", "is_large", "is_blank"} <= set(FILE_PROPERTY_FLAGS)
+
+    @pytest.mark.parametrize("attr", FILE_PROPERTY_SURFACE)
+    def test_dict_mode_exposes_attribute(self, dict_mode, attr):
+        """Accessing any FileProperties attribute on a dict-mode instance must not raise."""
+        getattr(dict_mode, attr)
+
+    @pytest.mark.parametrize("attr", FILE_PROPERTY_SURFACE)
+    def test_json_mode_exposes_attribute(self, json_mode, attr):
+        """Accessing any FileProperties attribute on a json-mode instance must not raise."""
+        getattr(json_mode, attr)
 
 
 class TestDedupeImages:


### PR DESCRIPTION
## Summary

`PDFComponents.__init__` had two virtual-mode branches — in-memory **dict** and **`.json`** file — that bypass `FileProperties.__init__` and hand-mirror ~21 attributes **each**. Because every `FileProperties` flag is a `cached_property` delegating to helper objects (`_stats`/`_ext`/`_empty`/`_blank`) created only in `FileProperties.__init__`, those helpers don't exist in virtual mode — so any new flag had to be remembered in both branches or it would `AttributeError` on the missing helper at first access. A silent divergence trap maintained by hand in two places.

## Approach: option (b), shared initializer

The issue floats (a) full composition vs (b) a shared initializer. `PDFReader`/`PDFWriter` **subclass** `PDFComponents` → `FileProperties` and expose the properties surface directly (`reader.is_pdf`, `reader.size_in_mb`, …), so full composition would mean delegating ~23 attributes (boilerplate `@property` stubs or a fragile `__getattr__`) — the larger, higher-regression change. Per maintainer decision, this keeps inheritance and extracts a single:

```python
_apply_virtual_file_properties(*, filepath, size_in_bytes, is_empty, is_blank)
```

that sets the **entire** `FileProperties` surface in one place shared by both virtual entry points. The kB/MB/GB/TB tiers derive from `size_in_bytes`; the dict and `.json` branches differ only in size and empty/blank, passed as arguments. **Behavior is unchanged** (full suite green).

## Future-proofing test

`TestVirtualFilePropertiesSurface` parametrizes a sweep over the `FileProperties` `cached_property` flags — **discovered dynamically** via introspection — plus the `__init__` attributes, asserting both dict-mode and json-mode instances expose every one. A newly added `FileProperties` attribute automatically enters the sweep and **fails in tests instead of in production**.

Verified the guard is not vacuous: temporarily dropping one mirrored flag makes the sweep fail with `AttributeError` (at the `cached_property` hitting the absent helper), exactly the production symptom it prevents.

Also sorts the pre-existing unsorted import block in the touched file.

## Tests

Full suite: **506 passed** (+47 from the parametrized sweep), lint clean.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)