### PR TITLE
feat: deprecate AI/LLM features ahead of 4.0.0 removal (#144) [minor]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Datagrunt is not an extension of or a replacement for DuckDB, Polars, or PyArrow
 - **Flexible Data Transformation:** Easily convert your processed CSV data into various formats including CSV, Excel, JSON, JSONL, and Parquet.
 - **Robust by Default:** Fail-fast validation with clear errors (invalid engine names, missing paths, directories, encrypted PDFs), graceful handling of empty files, no `UnicodeDecodeError` when constructing a reader over a non-UTF-8 file, and sane comment semantics — only leading `#` lines are treated as comments, so `#`-prefixed data rows such as hex colors are preserved on all engines.
 - **PDF Parsing & OCR:** Extract text, tables, and images from PDF files as dicts, DataFrames, or JSON, with optional [Tesseract](https://github.com/tesseract-ocr/tesseract) OCR for scanned pages. Powered by the permissively-licensed **PDFium** engine by default, with **PyMuPDF** available as an alternative.
-- **AI-Powered Schema Analysis:** Use Google's Gemini models to automatically generate detailed schema reports for your CSV files, including data types, column classifications, and data quality checks.
+- **AI-Powered Schema Analysis (deprecated):** Use Google's Gemini models to automatically generate detailed schema reports for your CSV files. _Deprecated in 3.3.0, removed in 4.0.0 — see [#144](https://github.com/pmgraham/datagrunt/issues/144)._
 - **Pythonic API:** Enjoy a clean and intuitive API that integrates seamlessly into your existing Python workflows.
 
 ### Powertools Under The Hood
@@ -26,7 +26,7 @@ Datagrunt is not an extension of or a replacement for DuckDB, Polars, or PyArrow
 | [DuckDB](https://duckdb.org)| Fast in-process analytical database with excellent SQL support |
 | [Polars](https://pola.rs) | Multi-threaded DataFrame library written in Rust, optimized for performance |
 | [PyArrow](https://arrow.apache.org/docs/python/) | Python bindings for Apache Arrow with efficient columnar data processing |
-| [Google Gemini](https://deepmind.google/technologies/gemini/) | A powerful family of generative AI models for schema analysis |
+| [Google Gemini](https://deepmind.google/technologies/gemini/) | A powerful family of generative AI models for schema analysis (deprecated — removed in 4.0.0, see [#144](https://github.com/pmgraham/datagrunt/issues/144)) |
 | [PDFium](https://github.com/pypdfium2-team/pypdfium2) | Default PDF engine (via `pypdfium2`) — permissively licensed (BSD-3 / Apache-2.0); fast text + image extraction, with a structured mode at parity with PyMuPDF |
 | [pdfplumber](https://github.com/jsvine/pdfplumber) | Table detection and extraction (MIT), shared by both PDF engines |
 | [PyMuPDF](https://pymupdf.readthedocs.io/) | Alternative PDF engine for text, tables, and images (AGPL-3.0 / commercial) |
@@ -146,6 +146,9 @@ Every `write_*` method — including `write_parquet` — honors `lenient=True` f
 ragged CSVs, and empty source files produce empty output instead of an error.
 
 ### AI-Powered Schema Analysis
+
+> [!WARNING]
+> **Deprecated.** The AI/LLM features (`CSVSchemaReportAIGenerated` and `datagrunt.core.ai`) are deprecated as of **3.3.0** and will be **removed in 4.0.0**. Constructing these classes now emits a `DeprecationWarning`. See [#144](https://github.com/pmgraham/datagrunt/issues/144).
 
 ```python
 from datagrunt import CSVSchemaReportAIGenerated

--- a/src/datagrunt/core/ai/_deprecation.py
+++ b/src/datagrunt/core/ai/_deprecation.py
@@ -1,0 +1,29 @@
+"""Shared deprecation notice for the AI/LLM surface (issue #144).
+
+The AI/LLM features are deprecated in 3.3.0 and will be removed in 4.0.0. This
+module is the single source of the deprecation message so every deprecated
+entry point warns with identical wording.
+"""
+
+import warnings
+
+AI_DEPRECATION_MESSAGE = (
+    "datagrunt's AI/LLM features are deprecated and will be removed in datagrunt "
+    "4.0.0. See https://github.com/pmgraham/datagrunt/issues/144."
+)
+
+
+def warn_ai_deprecated(name, stacklevel=3):
+    """Emit a ``DeprecationWarning`` for a deprecated AI/LLM class.
+
+    Args:
+        name (str): The deprecated class name, named in the warning.
+        stacklevel (int): Stack frames to skip so the warning points at the
+            caller's construction site. Defaults to 3 for the
+            ``caller -> __init__ -> warn_ai_deprecated`` call chain.
+    """
+    warnings.warn(
+        f"{name} is deprecated: {AI_DEPRECATION_MESSAGE}",
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )

--- a/src/datagrunt/core/ai/engines.py
+++ b/src/datagrunt/core/ai/engines.py
@@ -11,6 +11,9 @@ from dataclasses import dataclass
 from google import genai
 from google.genai import types
 
+# local imports
+from datagrunt.core.ai._deprecation import warn_ai_deprecated
+
 
 @dataclass
 class AIEngineProperties:
@@ -85,6 +88,7 @@ class GoogleAIEngine(BaseAIEngine):
         ground_google_search=False,
     ):
         """Initialize the Google AI provider."""
+        warn_ai_deprecated("GoogleAIEngine")
         super().__init__(api_key)
         self.vertexai = vertexai
         if not self.api_key and not self.vertexai:

--- a/src/datagrunt/core/ai/factories.py
+++ b/src/datagrunt/core/ai/factories.py
@@ -1,6 +1,7 @@
 """Factory module for creating AI factory instances."""
 
 # local libraries
+from datagrunt.core.ai._deprecation import warn_ai_deprecated
 from datagrunt.core.ai.engines import AIEngineProperties, GoogleAIEngine
 
 
@@ -20,6 +21,7 @@ class AIEngineFactory:
             engine (str): type of engine to create by the factory.
             **kwargs: Additional parameters for the AI provider.
         """
+        warn_ai_deprecated("AIEngineFactory")
         self.api_key = api_key
         self.engine = engine.lower().replace(" ", "")
         self.kwargs = kwargs

--- a/src/datagrunt/csv_api/csvai.py
+++ b/src/datagrunt/csv_api/csvai.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 # local imports
 from datagrunt.core import AIEngineFactory, AIEngineProperties, CSVStringSample, prompts
+from datagrunt.core.ai._deprecation import warn_ai_deprecated
 
 
 class CSVSchemaReportAIGenerated:
@@ -13,6 +14,7 @@ class CSVSchemaReportAIGenerated:
 
     def __init__(self, filepath, engine, api_key=None, **kwargs):
         """Initialize the CSV Schema Report class."""
+        warn_ai_deprecated("CSVSchemaReportAIGenerated")
         self.filepath = Path(filepath)
         self.engine = engine.lower().replace(" ", "")
         self.api_key = api_key

--- a/tests/core_tests/ai_tests/test_ai_engines.py
+++ b/tests/core_tests/ai_tests/test_ai_engines.py
@@ -7,6 +7,11 @@ from google.genai import types
 
 from datagrunt.core.ai.engines import AIEngineProperties, BaseAIEngine, GoogleAIEngine
 
+# The AI/LLM surface is deprecated (issue #144); these tests exercise it until
+# it is removed in 4.0.0, so suppress the construction warning here. The warning
+# itself is asserted explicitly in TestAIDeprecation.
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 
 class TestAIEngineProperties:
     """Test suite for AIEngineProperties class."""
@@ -309,3 +314,12 @@ class TestGoogleAIEngine:
         assert "contents" in call_args.kwargs
         assert "config" in call_args.kwargs
         assert call_args.kwargs["model"] == "gemini-pro"
+
+
+class TestAIDeprecation:
+    """The AI/LLM surface must warn on construction until removal (issue #144)."""
+
+    def test_google_ai_engine_construction_warns(self):
+        """Constructing GoogleAIEngine emits a DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            GoogleAIEngine(api_key="test_key")

--- a/tests/core_tests/ai_tests/test_ai_factories.py
+++ b/tests/core_tests/ai_tests/test_ai_factories.py
@@ -7,6 +7,10 @@ import pytest
 from datagrunt.core.ai.engines import GoogleAIEngine
 from datagrunt.core.ai.factories import AIEngineFactory
 
+# The AI/LLM surface is deprecated (issue #144); suppress the construction
+# warning here. It is asserted explicitly in TestAIFactoryDeprecation.
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 
 class TestAIEngineFactory:
     """Test suite for AIEngineFactory class."""
@@ -143,3 +147,12 @@ class TestAIEngineFactory:
         for engine_name in test_cases:
             factory = AIEngineFactory(api_key="test_key", engine=engine_name)
             assert factory.engine == "google"
+
+
+class TestAIFactoryDeprecation:
+    """AIEngineFactory must warn on construction until removal (issue #144)."""
+
+    def test_ai_engine_factory_construction_warns(self):
+        """Constructing AIEngineFactory emits a DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            AIEngineFactory(api_key="test_key", engine="google")

--- a/tests/csv_api_tests/test_csvai.py
+++ b/tests/csv_api_tests/test_csvai.py
@@ -11,6 +11,10 @@ from datagrunt.csv_api.csvai import CSVSchemaReportAIGenerated
 # All supported AI engines for CSVSchemaReportAIGenerated
 ALL_AI_ENGINES = ["google"]
 
+# The AI/LLM surface is deprecated (issue #144); suppress the construction
+# warning here. It is asserted explicitly in TestCSVAIDeprecation.
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 
 class TestCSVSchemaReportAIGenerated:
     """Test suite for CSVSchemaReportAIGenerated class."""
@@ -320,3 +324,12 @@ class TestCSVSchemaReportAIGenerated:
         assert result == complex_response
         assert result["schema"]["columns"][0]["name"] == "id"
         assert result["schema"]["metadata"]["rows"] == 100
+
+
+class TestCSVAIDeprecation:
+    """CSVSchemaReportAIGenerated must warn on construction until removal (issue #144)."""
+
+    def test_csv_schema_report_construction_warns(self):
+        """Constructing CSVSchemaReportAIGenerated emits a DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            CSVSchemaReportAIGenerated(filepath="test.csv", engine="google", api_key="test_key")


### PR DESCRIPTION
## Summary

**Step 1** of the AI/LLM removal plan in #144: deprecate the surface now (3.3.0), remove it in 4.0.0. This PR adds the deprecation warnings only — **no functional changes**.

Constructing any of the three public entry points now emits a `DeprecationWarning`:

- `CSVSchemaReportAIGenerated` (`datagrunt.csv_api.csvai`)
- `GoogleAIEngine` (`datagrunt.core.ai.engines`)
- `AIEngineFactory` (`datagrunt.core.ai.factories`)

A single helper — `datagrunt.core.ai._deprecation.warn_ai_deprecated` — holds the one deprecation message so every entry point warns with identical wording and a `stacklevel` that points at the caller's construction site.

## Explicitly NOT done here (deferred to the 4.0.0 removal PR)

- Deleting `datagrunt.core.ai` / `csvai.py` and their exports
- Removing the `google-genai>=2.8.0` dependency
- Removing the `"ai"`/`"gemini"` keywords
- Removing the AI tests

These all stay functional until 4.0.0, per the plan.

## Docs

Marked the README AI sections as deprecated (feature bullet, powertools-table row, and the usage section with a `> [!WARNING]` callout). The datagrunt-site docs are a separate repo and will be updated there.

## Tests

- Added an explicit `pytest.warns(DeprecationWarning)` test for each of the three classes.
- Suppressed the now-expected warning in the existing AI test modules via module-level `pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")`, so they keep exercising the surface until removal.
- Verified no AI deprecation warning leaks from an unsuppressed test.

Full suite: **509 passed**, lint clean.

## Release

Tagged `[minor]` → **3.3.0** (the deprecation release). Issue #144 stays **open** to track the 4.0.0 removal.

Refs #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)