### PR TITLE
feat: context manager protocol for DuckDBQueries and CSVReader (#150) [minor]

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ With the DuckDB engine, repeated `query_data()` calls on the same reader reuse
 a single import: the CSV is loaded into DuckDB once per reader instance, so
 follow-up queries skip the file import entirely and run dramatically faster.
 
+Because that reuse keeps a DuckDB connection open, hold the reader in a `with`
+block (or call `reader.close()`) to release it deterministically when you are
+done. The reader stays usable afterward — a later call transparently reopens:
+
+```python
+with CSVReader('vehicles.csv', engine='duckdb') as dg:
+    df = dg.query_data(f"SELECT city, COUNT(*) FROM {dg.db_table} GROUP BY 1").pl()
+# connection is closed here, even if the block raises
+```
+
 ### Consistent Column Names with `normalize_columns`
 
 Pass `normalize_columns=True` at construction to work in normalized column names (lowercase, underscores, collision-safe) everywhere — including SQL:

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -112,6 +112,15 @@ class CSVBaseReaderEngine(ABC):
         if not self.filepath.exists():
             raise FileNotFoundError
 
+    def close(self):
+        """Close the underlying DuckDB connection.
+
+        Idempotent. Only the DuckDB engine ever opens a connection (the
+        polars/pyarrow engines leave it lazily unopened), so for those engines
+        this resets already-clean state. The engine stays usable afterward.
+        """
+        self.queries.close()
+
     @abstractmethod
     def get_sample(self, normalize_columns: Optional[bool] = None) -> pl.DataFrame:
         """Return a sample of the data as a Polars DataFrame.

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -167,6 +167,20 @@ class DuckDBQueries:
             # re-imports instead of reusing a table that no longer exists.
             self._imported_normalize_columns = None
 
+    def __enter__(self):
+        """Enter a ``with`` block, returning this instance."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Close the connection on leaving the ``with`` block (normal or error).
+
+        ``close()`` is idempotent and resets the lazy-connection/import-cache
+        state, so the instance stays usable after the block - a later access
+        transparently reopens. Returns ``None`` so any in-flight exception
+        propagates.
+        """
+        self.close()
+
     def _format_filename_string(self):
         """Remove all non alphanumeric characters from the file stem."""
         return re.sub(r"[^a-zA-Z0-9]", "", self.filepath.stem)

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -44,6 +44,30 @@ class CSVReader(CSVComponents):
         """Return an empty object of the specified type."""
         return object
 
+    def close(self):
+        """Close the DuckDB connection held by this reader's engine, if any.
+
+        Only the DuckDB engine holds a live connection, and only once an
+        operation has built the cached engine; if no operation has run yet there
+        is nothing to close, so this never forces the engine (and its import)
+        into existence. ``close()`` is idempotent and the reader stays usable
+        afterward - a later call transparently rebuilds/reopens (issue #150).
+        """
+        reader = self.__dict__.get("_reader")
+        if reader is not None:
+            reader.close()
+
+    def __enter__(self):
+        """Enter a ``with`` block, returning this reader."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Close the engine's connection on leaving the ``with`` block.
+
+        Returns ``None`` so any in-flight exception propagates.
+        """
+        self.close()
+
     @cached_property
     def _reader(self):
         """Return this reader's engine, built once and reused.

--- a/tests/core_tests/databases_tests/test_databases.py
+++ b/tests/core_tests/databases_tests/test_databases.py
@@ -206,3 +206,48 @@ class TestNumericLeadingFilename:
         first = DuckDBQueries(str(csv_file))
         second = DuckDBQueries(str(csv_file))
         assert first.database_table_name == second.database_table_name
+
+
+class TestDuckDBQueriesContextManager:
+    """DuckDBQueries supports the with-statement, closing on exit (issue #150)."""
+
+    def test_enter_returns_self(self, tmp_path):
+        """__enter__ returns the instance so ``with ... as q`` binds it."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("a,b\n1,2\n")
+        queries = DuckDBQueries(str(csv_file))
+        with queries as bound:
+            assert bound is queries
+
+    def test_with_block_closes_connection_on_normal_exit(self, tmp_path):
+        """Leaving the block closes the live connection."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("a,b\n1,2\n")
+        queries = DuckDBQueries(str(csv_file))
+        with queries:
+            queries.create_table()
+            assert queries._connection is not None
+        assert queries._connection is None
+
+    def test_with_block_closes_connection_on_exception(self, tmp_path):
+        """An exception inside the block still closes the connection and propagates."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("a,b\n1,2\n")
+        queries = DuckDBQueries(str(csv_file))
+        with pytest.raises(ValueError, match="boom"):
+            with queries:
+                queries.create_table()
+                raise ValueError("boom")
+        assert queries._connection is None
+
+    def test_reuse_after_block_reopens(self, tmp_path):
+        """The instance stays usable after the block: a later use reopens."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("a,b\n1,2\n3,4\n")
+        queries = DuckDBQueries(str(csv_file))
+        with queries:
+            queries.create_table()
+        # Connection was closed on exit; reuse transparently reopens and re-imports.
+        relation = queries.create_table()
+        assert relation.fetchall() == [("1", "2"), ("3", "4")]
+        queries.close()

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -2,6 +2,7 @@
 
 import polars as pl
 import pyarrow as pa
+import pytest
 from duckdb import DuckDBPyRelation
 
 from datagrunt import CSVReader
@@ -413,3 +414,58 @@ class TestCSVReader:
                 # The extra field should have been truncated
                 assert list(df.columns) == ["id", "name", "age"]
                 assert df.row(1) == ("2", "Jane", "25")
+
+
+class TestCSVReaderContextManager:
+    """CSVReader supports the with-statement, closing its engine (issue #150)."""
+
+    def _csv(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("a,b\n1,2\n3,4\n")
+        return str(csv_file)
+
+    def test_enter_returns_self(self, tmp_path):
+        """``with CSVReader(...) as r`` binds the reader."""
+        reader = CSVReader(self._csv(tmp_path), engine="duckdb")
+        with reader as bound:
+            assert bound is reader
+
+    def test_with_block_closes_duckdb_engine_connection(self, tmp_path):
+        """Leaving the block closes the DuckDB engine's connection."""
+        reader = CSVReader(self._csv(tmp_path), engine="duckdb")
+        with reader:
+            reader.query_data(f"SELECT * FROM {reader.db_table}")
+            engine = reader.__dict__["_reader"]
+            assert engine.queries._connection is not None
+        assert engine.queries._connection is None
+
+    def test_with_block_closes_on_exception(self, tmp_path):
+        """An exception inside the block still closes the connection and propagates."""
+        reader = CSVReader(self._csv(tmp_path), engine="duckdb")
+        with pytest.raises(ValueError, match="boom"):
+            with reader:
+                reader.query_data(f"SELECT * FROM {reader.db_table}")
+                raise ValueError("boom")
+        assert reader.__dict__["_reader"].queries._connection is None
+
+    def test_close_does_not_build_engine_when_unused(self, tmp_path):
+        """close() on a reader that ran no operation must not create the engine."""
+        reader = CSVReader(self._csv(tmp_path), engine="duckdb")
+        reader.close()
+        assert "_reader" not in reader.__dict__
+
+    def test_reader_usable_after_close(self, tmp_path):
+        """The reader stays usable after the block: a later query reopens."""
+        reader = CSVReader(self._csv(tmp_path), engine="duckdb")
+        with reader:
+            reader.query_data(f"SELECT * FROM {reader.db_table}")
+        result = reader.query_data(f"SELECT a, b FROM {reader.db_table} ORDER BY a")
+        assert result.fetchall() == [("1", "2"), ("3", "4")]
+        reader.close()
+
+    def test_with_block_harmless_for_non_duckdb_engines(self, tmp_path):
+        """polars/pyarrow engines have no open connection; the block is harmless."""
+        for engine in ("polars", "pyarrow"):
+            with CSVReader(self._csv(tmp_path), engine=engine) as reader:
+                df = reader.to_dataframe()
+            assert len(df) == 2


### PR DESCRIPTION
## Summary

`DuckDBQueries` had a documented, idempotent `close()` (deliberately no `__del__`) but no `__enter__`/`__exit__`, so a user of the public export had to pair every use with a manual `close()` — an exception mid-use leaked the lazy connection until GC. The README-documented "hold a reader for repeated `query_data()`" pattern (import caching, #104) had the same gap on **`CSVReader`**, which is where it actually bites. Every PDF backend already implements the protocol, so this also closes a consistency gap.

Per maintainer decision, this covers **both** `DuckDBQueries` and `CSVReader`.

## Changes

- **`DuckDBQueries`** — `__enter__` returns self; `__exit__` calls the existing idempotent `close()`. Returns `None` so in-flight exceptions propagate; the instance stays usable after the block (a later access transparently reopens, per the existing contract).
- **`CSVBaseReaderEngine.close()`** — delegates to `self.queries.close()` (clean layering; all three engines hold a `queries`).
- **`CSVReader`** — public `close()` + `__enter__`/`__exit__`. `close()` only closes the engine **if an operation already built the cached `_reader`** (checks `__dict__`), so it never forces the engine — and its CSV import — into existence. For polars/pyarrow the connection was never opened, so `close()` is a harmless reset.

## Docs

Added the `with CSVReader(...) as dg:` idiom to the README next to the repeated-`query_data` reuse note — the exposure the issue called out.

## Tests (10 new)

`DuckDBQueries` and `CSVReader`, each: `with` closes on normal exit **and** on exception (propagating); reuse after the block reopens. Plus: `CSVReader.close()` does **not** build the engine when unused; non-duckdb engines are harmless.

Full suite: **521 passed**, lint clean.

## Release

Tagged `[minor]` (backward-compatible public-API addition) → **3.4.0**.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)