### PR TITLE
refactor: narrow or DEBUG-log silent except-Exception probes (#151)

### DIFF
--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -2,6 +2,7 @@
 
 # standard library
 import csv
+import logging
 import re
 from collections import Counter, OrderedDict
 from functools import cached_property
@@ -12,6 +13,8 @@ import polars as pl
 
 # local libraries
 from datagrunt.core.file_io import FileProperties
+
+logger = logging.getLogger(__name__)
 
 
 def _count_leading_comments(filepath):
@@ -65,7 +68,9 @@ def _is_legacy_mac_newlines(filepath):
         with open(filepath, "rb") as f:
             chunk = f.read(4096)
         return b"\r" in chunk and b"\n" not in chunk
-    except Exception:
+    except OSError:
+        # Unreadable/missing file: treat as not legacy-mac and let the real
+        # read surface the error. Any other exception is a bug worth raising.
         return False
 
 
@@ -103,8 +108,8 @@ def _check_csv_ragged_and_warn(filepath, delimiter):
                     return True
                 if row_count >= 10000:
                     break
-    except Exception:
-        pass
+    except Exception:  # noqa: BLE001 - best-effort ragged-row warning; never break a read
+        logger.debug("Ragged-row check failed for %s; skipping warning", filepath, exc_info=True)
     return False
 
 
@@ -151,8 +156,8 @@ class CSVStringSample:
                             if len(lines) >= self.SAMPLE_ROWS + 1:
                                 break
                 return "".join(lines)
-            except Exception:
-                pass
+            except Exception:  # noqa: BLE001 - best-effort legacy-mac sample; fall back to polars
+                logger.debug("Legacy-mac sample read failed for %s; using polars", self.filepath, exc_info=True)
         df = pl.read_csv(
             self.filepath,
             separator=self.delimiter,
@@ -518,8 +523,8 @@ class CSVColumns:
 
                             reader = csv.reader([line], delimiter=self.delimiter)
                             return next(reader)
-            except Exception:
-                pass
+            except Exception:  # noqa: BLE001 - best-effort legacy-mac header; fall back to polars
+                logger.debug("Legacy-mac column read failed for %s; using polars", self.filepath, exc_info=True)
         df = pl.read_csv(
             self.filepath,
             separator=self.delimiter,

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -54,7 +54,9 @@ def _is_legacy_mac_newlines(filepath):
         with open(filepath, "rb") as f:
             chunk = f.read(4096)
         return b"\r" in chunk and b"\n" not in chunk
-    except Exception:
+    except OSError:
+        # Unreadable/missing file: treat as not legacy-mac and let the real
+        # read surface the error. Any other exception is a bug worth raising.
         return False
 
 

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -2,6 +2,7 @@
 
 # standard library
 import hashlib
+import logging
 import re
 from functools import cached_property
 from pathlib import Path
@@ -17,6 +18,8 @@ from datagrunt.core.csv_io import (
     _check_csv_ragged_and_warn,
     _count_leading_physical_lines_before_header,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class DuckDBQueries:
@@ -91,7 +94,8 @@ class DuckDBQueries:
         """Get the quote character."""
         try:
             return CSVDialect(self.filepath).quotechar
-        except Exception:
+        except Exception:  # noqa: BLE001 - dialect sniffing is best-effort; default to "
+            logger.debug("Quote-char sniffing failed for %s; defaulting to double quote", self.filepath, exc_info=True)
             return '"'
 
     @staticmethod

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
@@ -6,9 +6,12 @@ imported lazily.
 """
 
 import ctypes
+import logging
 from pathlib import Path
 
 from datagrunt.core.pdf_io.extraction.shapes import BBox, ImageBlock, TextItem
+
+logger = logging.getLogger(__name__)
 
 PDF_EXTRA_HINT = "PDF parsing requires extra dependencies. Install with: pip install datagrunt[pdf]"
 
@@ -224,8 +227,9 @@ class PdfiumPage:
                         img.save(png_path, "PNG")
                     path.unlink()
                     return png_path
-                except Exception:
+                except Exception:  # noqa: BLE001 - PIL raises many types; fall back to bitmap
                     # PIL failed (e.g. missing format plugin), clean up and fall back to bitmap
+                    logger.debug("PIL conversion of %s failed; falling back to bitmap", path, exc_info=True)
                     try:
                         path.unlink()
                     except OSError:
@@ -241,8 +245,8 @@ class PdfiumPage:
                 png_path = base.with_suffix(".png")
                 img.save(png_path, "PNG")
                 return png_path
-        except Exception:
-            pass
+        except Exception:  # noqa: BLE001 - bitmap fallback is best-effort; return no image
+            logger.debug("Bitmap image extraction failed for %s; no image emitted", base, exc_info=True)
 
         return None
 

--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -1,10 +1,14 @@
 """pymupdf-backed extraction backend (the reference engine)."""
 
+import logging
+
 from datagrunt.core.pdf_io.extraction.base import ExtractionBackend
 from datagrunt.core.pdf_io.extraction.ocr import ocr_data_to_blocks
 from datagrunt.core.pdf_io.extraction.pdfium_document import ENCRYPTED_PDF_MESSAGE
 from datagrunt.core.pdf_io.extraction.shapes import BBox, ImageBlock, PageAnalysis, TextBlock
 from datagrunt.core.pdf_io.extraction.text_block_builder import classify_font_size
+
+logger = logging.getLogger(__name__)
 
 
 def _import_pymupdf():
@@ -233,8 +237,8 @@ class PyMuPDFBackend(ExtractionBackend):
                     pix = pymupdf.Pixmap(pymupdf.csRGB, pix)
                 image_bytes = pix.tobytes("png")
                 ext = "png"
-            except Exception:
-                pass
+            except Exception:  # noqa: BLE001 - Pixmap conversion is best-effort; keep original bytes
+                logger.debug("Pixmap PNG conversion failed; keeping original image bytes", exc_info=True)
 
         file_path = None
         if output_dir:

--- a/src/datagrunt/core/pdf_io/extraction/tables.py
+++ b/src/datagrunt/core/pdf_io/extraction/tables.py
@@ -1,8 +1,11 @@
 """Engine-independent table extraction via pdfplumber."""
 
+import logging
 from pathlib import Path
 
 from datagrunt.core.pdf_io.extraction.shapes import BBox, TableBlock
+
+logger = logging.getLogger(__name__)
 
 
 def _import_pdfplumber():
@@ -55,7 +58,8 @@ class PdfPlumberTableExtractor:
         pdfplumber = _import_pdfplumber()
         try:
             pdf = pdfplumber.open(self.filepath)
-        except Exception:
+        except Exception:  # noqa: BLE001 - pdfplumber raises many types; tables are best-effort
+            logger.debug("pdfplumber.open failed for %s; skipping table extraction", self.filepath, exc_info=True)
             return None, False
         if getattr(self._local, "depth", 0) > 0:
             self._local.pdf = pdf

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -275,7 +275,9 @@ class ParsedDocument:
                             md_dir = Path(export_filename).parent.resolve()
                             abs_img_path = Path(path).resolve()
                             path = os.path.relpath(abs_img_path, md_dir)
-                        except Exception:
+                        except (OSError, ValueError):
+                            # resolve()/relpath can fail (unresolvable path, or a
+                            # cross-drive relpath on Windows); keep the original path.
                             pass
                     blocks.append(f"![{Path(path).name or 'image'}]({path})")
                 elif isinstance(content, str) and content.strip():

--- a/tests/core_tests/csv_io_tests/test_csvcomponents.py
+++ b/tests/core_tests/csv_io_tests/test_csvcomponents.py
@@ -7,6 +7,32 @@ from datagrunt.core import (
     CSVRows,
     CSVStringSample,
 )
+from datagrunt.core.csv_io.csvcomponents import _is_legacy_mac_newlines
+
+
+class TestLegacyMacNewlineProbe:
+    """_is_legacy_mac_newlines narrows to OSError (issue #151).
+
+    The probe is a best-effort binary read; an unreadable file must still fall
+    back to ``False`` (not legacy-mac), while any non-OSError is now a real bug
+    that propagates instead of being silently swallowed.
+    """
+
+    def test_missing_file_returns_false(self, tmp_path):
+        """A missing/unreadable path is caught as OSError and yields False."""
+        assert _is_legacy_mac_newlines(tmp_path / "does_not_exist.csv") is False
+
+    def test_legacy_mac_file_detected(self, tmp_path):
+        """A genuine \\r-only file is still detected as legacy-mac."""
+        mac_file = tmp_path / "legacy.csv"
+        mac_file.write_bytes(b"a,b,c\r1,2,3\r4,5,6")
+        assert _is_legacy_mac_newlines(mac_file) is True
+
+    def test_unix_file_not_detected(self, tmp_path):
+        """A normal \\n file is not legacy-mac."""
+        unix_file = tmp_path / "unix.csv"
+        unix_file.write_bytes(b"a,b,c\n1,2,3\n")
+        assert _is_legacy_mac_newlines(unix_file) is False
 
 
 class TestCSVStringSample:


### PR DESCRIPTION
## Summary

Several best-effort probes swallowed `Exception` with a bare `pass`/default and **no trace**, so when an underlying API broke (encoding config, PIL/format changes, filesystem `OSError`) the failure was invisible and debugging meant bisecting by hand. This addresses all 11 unannotated sites from the issue, per its preference order, **with no behavior change — every fallback stays identical**.

## Narrowed the exception type (3 sites)

So a real bug (e.g. `TypeError` from an API change) now **propagates** instead of being masked:

- `_is_legacy_mac_newlines` (csvcomponents + csv_io/engines) — pure binary read → `OSError`
- `pdfcomponents` markdown-image relpath — `resolve()`/`relpath` → `(OSError, ValueError)`

## Kept `Exception` + added `logger.debug(..., exc_info=True)` (8 sites)

Where any-exception tolerance is genuinely intended (multi-step library probes), the failure is now traceable at DEBUG before falling back, with a `# noqa: BLE001` rationale matching the convention already used elsewhere in `pdf_io`:

- `_check_csv_ragged_and_warn`, legacy-mac sample read, legacy-mac column read
- `DuckDBQueries.quotechar` dialect-sniff fallback
- `tables.py` `pdfplumber.open`, `pymupdf_backend` Pixmap conversion, `pdfium_document` PIL conversion + bitmap fallback

Module loggers (`logging.getLogger(__name__)`) match `pdf_io/engines.py`; the root `NullHandler` in `datagrunt/__init__.py` keeps the library quiet by default (DEBUG only surfaces when the app opts in).

## Tests

`TestLegacyMacNewlineProbe` pins the narrowed `OSError` fallback (missing file → `False`) plus legacy-mac (`\r`) / unix (`\n`) detection. Existing suites cover the unchanged fallbacks. I also verified end-to-end that a forced failure hits the new DEBUG log and still falls back correctly.

Full suite: **524 passed**, no behavior change. My edited files are lint-clean.

## Out of scope (noted, not touched)

`ruff` flags ~13 **pre-existing** errors in files unrelated to this issue (`pdf_io/engines.py`, `text_block_builder.py`, `pdfwriter.py`, and an inline import in an untouched part of `pdfium_document.py`). Verified they pre-date this branch; left alone to keep the diff focused on #151.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)