### PR TITLE
fix(pdf): close coverage gaps — markdown injection, JSON guardrail, single-parse

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -323,6 +323,20 @@ class PDFBaseWriterEngine(ABC):
         self.properties = PDFEngineProperties(filepath=self.filepath)
         if not self.filepath.exists():
             raise FileNotFoundError
+        self._reader_engine = None
+        self._cached_document = None
+        self._cached_parse_key = None
+
+    def _parse_document(self, image_output_dir, drop_layout_tables):
+        """Parse once per (image_output_dir, drop_layout_tables) and reuse the dict."""
+        key = (image_output_dir, drop_layout_tables)
+        if self._cached_parse_key != key:
+            self._cached_document = self._reader().to_dicts(
+                image_output_dir=image_output_dir,
+                drop_layout_tables=drop_layout_tables,
+            )
+            self._cached_parse_key = key
+        return self._cached_document
 
     @abstractmethod
     def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
@@ -353,7 +367,9 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
     """Write parsed PDF output (JSON + image files) using PyMuPDF."""
 
     def _reader(self):
-        return PDFReaderPyMuPDFEngine(self.filepath, workers=self.workers)
+        if self._reader_engine is None:
+            self._reader_engine = PDFReaderPyMuPDFEngine(self.filepath, workers=self.workers)
+        return self._reader_engine
 
     def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
         """Parse the PDF and write the unified document JSON.
@@ -369,7 +385,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
                 that are layout boxes rather than real tabular data.
         """
         filename = set_export_filename(self.properties.json_export_filename, export_filename)
-        document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
+        document = self._parse_document(image_output_dir, drop_layout_tables)
         if image_output_dir and dedupe_images:
             pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
         with open(filename, "w") as f:
@@ -381,7 +397,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
     ):
         """Parse the PDF and write one flattened element per line (JSONL)."""
         filename = set_export_filename(self.properties.json_newline_export_filename, export_filename)
-        document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
+        document = self._parse_document(image_output_dir, drop_layout_tables)
         if image_output_dir and dedupe_images:
             pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
         records = pdfcomponents.ParsedDocument(document).flatten()
@@ -403,7 +419,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
                 that are layout boxes rather than real tabular data.
         """
         filename = set_export_filename(self.properties.markdown_export_filename, export_filename)
-        document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
+        document = self._parse_document(image_output_dir, drop_layout_tables)
         if image_output_dir and dedupe_images:
             pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
         markdown_text = pdfcomponents.ParsedDocument(document).to_markdown(export_filename=filename)
@@ -420,7 +436,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
                 to a single file before returning paths.
         """
         directory = output_dir if output_dir else self.properties.images_export_dir
-        document = self._reader().to_dicts(image_output_dir=directory)
+        document = self._parse_document(directory, False)
         if dedupe:
             pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=directory)
         paths = []
@@ -443,7 +459,11 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
         self.structured = structured
 
     def _reader(self):
-        return PDFReaderPdfiumEngine(self.filepath, workers=self.workers, structured=self.structured)
+        if self._reader_engine is None:
+            self._reader_engine = PDFReaderPdfiumEngine(
+                self.filepath, workers=self.workers, structured=self.structured
+            )
+        return self._reader_engine
 
     def _dedupe(self, document, image_output_dir):
         if self.structured:
@@ -454,7 +474,7 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
     def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
         """Parse the PDF and write the document JSON (native or unified schema)."""
         filename = set_export_filename(self.properties.json_export_filename, export_filename)
-        document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
+        document = self._parse_document(image_output_dir, drop_layout_tables)
         if image_output_dir and dedupe_images:
             self._dedupe(document, image_output_dir)
         with open(filename, "w") as f:
@@ -466,7 +486,7 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
     ):
         """Parse the PDF and write one flattened element per line (JSONL)."""
         filename = set_export_filename(self.properties.json_newline_export_filename, export_filename)
-        document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
+        document = self._parse_document(image_output_dir, drop_layout_tables)
         if image_output_dir and dedupe_images:
             self._dedupe(document, image_output_dir)
         if self.structured:
@@ -481,7 +501,7 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
     def write_markdown(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
         """Parse the PDF and write the document Markdown (native or structured schema)."""
         filename = set_export_filename(self.properties.markdown_export_filename, export_filename)
-        document = self._reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
+        document = self._parse_document(image_output_dir, drop_layout_tables)
         if image_output_dir and dedupe_images:
             self._dedupe(document, image_output_dir)
         if self.structured:
@@ -495,7 +515,7 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
     def extract_images(self, output_dir=None, dedupe=True):
         """Parse the PDF, write embedded images to disk, return their paths."""
         directory = output_dir if output_dir else self.properties.images_export_dir
-        document = self._reader().to_dicts(image_output_dir=directory)
+        document = self._parse_document(directory, False)
         if dedupe:
             self._dedupe(document, directory)
         paths = []

--- a/src/datagrunt/core/pdf_io/extraction/markdown_escape.py
+++ b/src/datagrunt/core/pdf_io/extraction/markdown_escape.py
@@ -27,3 +27,22 @@ def escape_leading_markdown(text: str) -> str:
         return f"{indent}{digits}\\{dot}"
 
     return _LEADING_MARKDOWN_METACHAR.sub(_escape, text, count=1)
+
+
+def escape_markdown_link_text(text: str) -> str:
+    """Escape ``[`` / ``]`` / ``\\`` in markdown link *label* text (image alt)."""
+    if not isinstance(text, str):
+        return text
+    return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+
+
+def escape_markdown_link_target(target: str) -> str:
+    """Escape ``(`` / ``)`` / ``[`` / ``\\`` in markdown link *destination* URLs/paths."""
+    if not isinstance(target, str):
+        return target
+    return (
+        target.replace("\\", "\\\\")
+        .replace(")", "\\)")
+        .replace("(", "\\(")
+        .replace("[", "\\[")
+    )

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -11,7 +11,11 @@ from datagrunt.core.file_io import FileProperties
 from datagrunt.core.pdf_io.extraction import PdfPlumberTableExtractor
 from datagrunt.core.pdf_io.extraction.image_dedupe import dedupe_image_files
 from datagrunt.core.pdf_io.extraction.layout_sorter import ElementAdapter, PageLayoutSorter
-from datagrunt.core.pdf_io.extraction.markdown_escape import escape_leading_markdown
+from datagrunt.core.pdf_io.extraction.markdown_escape import (
+    escape_leading_markdown,
+    escape_markdown_link_target,
+    escape_markdown_link_text,
+)
 from datagrunt.core.pdf_io.extraction.ocr import dpi_for_page
 from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
 
@@ -279,7 +283,8 @@ class ParsedDocument:
                             # resolve()/relpath can fail (unresolvable path, or a
                             # cross-drive relpath on Windows); keep the original path.
                             pass
-                    blocks.append(f"![{Path(path).name or 'image'}]({path})")
+                    alt = escape_markdown_link_text(Path(path).name or "image")
+                    blocks.append(f"![{alt}]({escape_markdown_link_target(path)})")
                 elif isinstance(content, str) and content.strip():
                     blocks.append(escape_leading_markdown(content))
         return "\n\n".join(blocks) + "\n"
@@ -307,6 +312,9 @@ class ParsedDocument:
 class PDFComponents(FileProperties):
     """A class that combines PDF components into a single interface."""
 
+    # Guardrail for untrusted ``.json`` document paths (full file is loaded into memory).
+    MAX_JSON_DOCUMENT_BYTES = 50 * 1024 * 1024
+
     def __init__(self, filepath):
         """Initialize the PDFComponents object.
 
@@ -324,9 +332,14 @@ class PDFComponents(FileProperties):
         else:
             filepath_path = Path(filepath)
             if filepath_path.suffix.lower() == ".json":
+                size_in_bytes = filepath_path.stat().st_size
+                if size_in_bytes > self.MAX_JSON_DOCUMENT_BYTES:
+                    raise ValueError(
+                        f"JSON document exceeds maximum size of "
+                        f"{self.MAX_JSON_DOCUMENT_BYTES} bytes ({size_in_bytes} bytes)"
+                    )
                 with open(filepath_path, "r", encoding="utf-8") as f:
                     self._parsed_dict = json.load(f)
-                size_in_bytes = filepath_path.stat().st_size
                 self._apply_virtual_file_properties(
                     filepath=filepath_path,
                     size_in_bytes=size_in_bytes,

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -2,6 +2,7 @@
 
 # standard library
 import json
+from functools import cached_property
 from pathlib import Path
 
 # local libraries
@@ -39,6 +40,11 @@ class PDFWriter(PDFComponents):
     def _create_writer(self):
         """Create a writer engine instance."""
         return PDFEngineFactory(self.filepath, self.engine, self.workers, structured=not self.native).create_writer()
+
+    @cached_property
+    def _writer(self):
+        """Cached writer engine; reused across write_* calls on this instance."""
+        return self._create_writer()
 
     @staticmethod
     def _write_empty_file(filename, content=""):
@@ -83,7 +89,7 @@ class PDFWriter(PDFComponents):
         # document ({}) rather than a raw PdfiumError from loading the file.
         if self.is_empty:
             return self._write_empty_file(export_filename or "output.json", json.dumps({}))
-        return self._create_writer().write_json(export_filename, image_output_dir, dedupe_images, drop_layout_tables)
+        return self._writer.write_json(export_filename, image_output_dir, dedupe_images, drop_layout_tables)
 
     def write_json_newline_delimited(
         self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False
@@ -125,7 +131,7 @@ class PDFWriter(PDFComponents):
         # the JSONL output is an empty file rather than a raw PdfiumError.
         if self.is_empty:
             return self._write_empty_file(export_filename or "output.jsonl")
-        return self._create_writer().write_json_newline_delimited(
+        return self._writer.write_json_newline_delimited(
             export_filename, image_output_dir, dedupe_images, drop_layout_tables
         )
 
@@ -168,7 +174,7 @@ class PDFWriter(PDFComponents):
         # the Markdown output is an empty file rather than a raw PdfiumError.
         if self.is_empty:
             return self._write_empty_file(export_filename or "output.md")
-        return self._create_writer().write_markdown(
+        return self._writer.write_markdown(
             export_filename, image_output_dir, dedupe_images, drop_layout_tables
         )
 
@@ -212,4 +218,4 @@ class PDFWriter(PDFComponents):
         # Mirror PDFReader's is_empty handling: a 0-byte PDF has no images.
         if self.is_empty:
             return []
-        return self._create_writer().extract_images(output_dir, dedupe)
+        return self._writer.extract_images(output_dir, dedupe)

--- a/tests/core_tests/csv_io_tests/test_csvcomponents.py
+++ b/tests/core_tests/csv_io_tests/test_csvcomponents.py
@@ -362,6 +362,23 @@ class TestCSVRows:
         rows = CSVRows(str(csv_file))
         assert rows.row_count_without_header == 2
 
+    def test_row_count_with_header_large_file(self, tmp_path):
+        """Streaming row count must handle many records without loading the whole file."""
+        import time
+
+        csv_file = tmp_path / "large.csv"
+        row_total = 50_000
+        with open(csv_file, "w", encoding="utf-8") as f:
+            f.write("id,value\n")
+            for i in range(row_total):
+                f.write(f"{i},{i}\n")
+
+        rows = CSVRows(str(csv_file))
+        start = time.monotonic()
+        assert rows.row_count_with_header == row_total + 1
+        assert rows.row_count_without_header == row_total
+        assert time.monotonic() - start < 30.0
+
     def test_first_row_extraction(self, tmp_path):
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("Name,Age,City\nJohn,25,NYC")

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -191,6 +191,28 @@ class TestVirtualFilePropertiesSurface:
         getattr(json_mode, attr)
 
 
+class TestPDFComponentsJsonGuardrail:
+    """Guardrail tests for ``.json`` document paths loaded into memory."""
+
+    def test_json_document_below_size_limit_loads(self, tmp_path):
+        from datagrunt.core.pdf_io.pdfcomponents import PDFComponents
+
+        doc = {"document": {"pages": [{"elements": [{"type": "body_text", "content": "ok"}]}]}}
+        path = tmp_path / "doc.json"
+        path.write_text(json.dumps(doc), encoding="utf-8")
+        assert PDFComponents(str(path))._parsed_dict == doc
+
+    def test_json_document_above_size_limit_raises(self, tmp_path):
+        from datagrunt.core.pdf_io.pdfcomponents import PDFComponents
+
+        limit = PDFComponents.MAX_JSON_DOCUMENT_BYTES
+        path = tmp_path / "huge.json"
+        # Minimal JSON larger than the guardrail without allocating a giant string in RAM.
+        path.write_bytes(b'{"document":{"pages":[]}' + b"x" * (limit + 1) + b"}")
+        with pytest.raises(ValueError, match="exceeds maximum size"):
+            PDFComponents(str(path))
+
+
 class TestDedupeImages:
     """Test suite for ParsedDocument.dedupe_images."""
 
@@ -469,3 +491,21 @@ class TestMarkdownMetacharacterEscaping:
 
         rendered = ParsedDocument._render_table([["a|b", "c"]], has_header=False)
         assert "a\\|b" in rendered
+
+    @staticmethod
+    def _image_element(file_path):
+        return {"type": "image", "content": None, "metadata": {"file_path": file_path}}
+
+    def test_image_file_path_paren_does_not_inject_markdown(self):
+        malicious = "x) ![](https://evil.example/pwn.png"
+        md = self._markdown([self._image_element(malicious)])
+        # Must remain a single markdown image, not an injected second image link.
+        assert md.count("![") == 1
+        assert "\\)" in md
+
+    def test_image_file_path_bracket_in_alt_is_escaped(self):
+        from pathlib import Path
+
+        path = str(Path("/tmp/foo]bar.png"))
+        md = self._markdown([self._image_element(path)])
+        assert "foo\\]bar.png" in md

--- a/tests/pdf_api_tests/test_batch.py
+++ b/tests/pdf_api_tests/test_batch.py
@@ -62,6 +62,46 @@ class TestPDFBatchWriter:
         assert os.path.isdir(result["images_dir"])
         assert len(os.listdir(result["images_dir"])) >= 1
 
+    def test_multi_format_batch_parses_pdf_once(self, tmp_path, monkeypatch):
+        """JSON + JSONL + Markdown must share a single parse per document."""
+        pdf = _make_pdf(tmp_path / "doc.pdf")
+        out = tmp_path / "out"
+        parse_calls = 0
+
+        from datagrunt.core.pdf_io.engines import PDFReaderPyMuPDFEngine
+
+        original_to_dicts = PDFReaderPyMuPDFEngine.to_dicts
+
+        def counting_to_dicts(self, image_output_dir=None, drop_layout_tables=False):
+            nonlocal parse_calls
+            parse_calls += 1
+            return original_to_dicts(
+                self, image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables
+            )
+
+        monkeypatch.setattr(PDFReaderPyMuPDFEngine, "to_dicts", counting_to_dicts)
+
+        class _SyncExecutor:
+            """Run batch work in-process (avoids multiprocessing in restricted CI sandboxes)."""
+
+            def __init__(self, max_workers=None):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                return None
+
+            def map(self, fn, sources, options):
+                return [fn(s, o) for s, o in zip(sources, options)]
+
+        monkeypatch.setattr("datagrunt.pdf_api.batch.ProcessPoolExecutor", _SyncExecutor)
+
+        PDFBatchWriter(markdown=True, jsonl=True).process([pdf], str(out))
+
+        assert parse_calls == 1
+
     def test_markdown_written_only_when_enabled(self, tmp_path):
         pdf = _make_pdf(tmp_path / "doc.pdf")
         out = tmp_path / "out"

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -136,6 +136,32 @@ class TestPDFWriter:
         assert len(content) > 0
         assert "report_page" in content
 
+    def test_multi_format_writer_parses_pdf_once(self, sample_pdf, tmp_path, monkeypatch):
+        """write_json + write_jsonl + write_markdown must share one parse."""
+        monkeypatch.chdir(tmp_path)
+        parse_calls = 0
+
+        from datagrunt.core.pdf_io.engines import PDFReaderPyMuPDFEngine
+
+        original_to_dicts = PDFReaderPyMuPDFEngine.to_dicts
+
+        def counting_to_dicts(self, image_output_dir=None, drop_layout_tables=False):
+            nonlocal parse_calls
+            parse_calls += 1
+            return original_to_dicts(
+                self, image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables
+            )
+
+        monkeypatch.setattr(PDFReaderPyMuPDFEngine, "to_dicts", counting_to_dicts)
+
+        img_dir = tmp_path / "imgs"
+        writer = PDFWriter(sample_pdf, engine="pymupdf")
+        writer.write_json(image_output_dir=str(img_dir))
+        writer.write_json_newline_delimited(image_output_dir=str(img_dir))
+        writer.write_markdown(image_output_dir=str(img_dir))
+
+        assert parse_calls == 1
+
     def test_write_markdown_pdfium_native(self, sample_pdf, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         writer = PDFWriter(sample_pdf, engine="pdfium", native=True)


### PR DESCRIPTION
Closes #183.

Red-TDD on four PDF/CSV coverage gaps found during review: tests landed first (one passing, three red), then the fixes that turn them green. Two commits keep the red→green story explicit in history.

## Findings & fixes
- **Markdown image `file_path` injection** — `to_markdown` did not escape link metacharacters, so a crafted image path could inject a second markdown image/link. New `escape_markdown_link_text` / `escape_markdown_link_target` helpers escape `[ ] \` in alt text and `( ) [ \` in targets.
- **Multi-format re-parse (3×)** — `PDFBaseWriterEngine` now caches the reader and memoizes the parsed document per `(image_output_dir, drop_layout_tables)`; `PDFWriter` caches the writer via `cached_property`. JSON + JSONL + Markdown now parse the PDF once.
- **Unbounded `.json` input** — `PDFComponents.MAX_JSON_DOCUMENT_BYTES` (50MB) guardrail; oversized paths raise `ValueError` before loading into memory.
- **`row_count` large file** — added streaming coverage on 50k rows (guards existing behavior).

## Commits
- `118711f` test(pdf,csv): add coverage for known gaps (red TDD)
- `ee0cfcf` fix(pdf): escape markdown links, guard JSON size, parse once

## Verification
- Targeted tests: were 5 red / 2 green → now **7 passed**.
- Full suite: **957 passed**.
- Rust parity: fixes 1–3 are PDF-side (Rust core is CSV-only, no counterpart). Fix 4 added no compute change — verified identical under Rust native and the pure-Python oracle; parity suite **476 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)