### PR TITLE
perf(csv): cache Polars writer reads, load spatial once, PyArrow JSON via to_pylist, lazy skip_rows

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -591,6 +591,7 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         filename = self.queries.set_export_filename(CSVEngineProperties.excel_export_filename, export_filename)
         try:
             self.queries.create_table(normalize_columns)
+            self.queries.load_spatial_extension(self.queries.connection)
             self.queries.connection.sql(self.queries.export_excel_query(filename))
         finally:
             self.queries.close()
@@ -650,6 +651,25 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
 class CSVWriterPolarsEngine(CSVBaseWriterEngine):
     """Class to write CSVs to other file formats powered by Polars."""
 
+    def __init__(self, filepath, lenient=False, normalize_columns=False):
+        super().__init__(filepath, lenient=lenient, normalize_columns=normalize_columns)
+        # Cache the parsed frame per resolved normalize_columns value so that
+        # exporting one instance to several formats parses the source once.
+        self._frame_cache = {}
+
+    def _dataframe(self, normalize_columns):
+        """Return the parsed Polars frame, reading the source once per mode.
+
+        Writes never mutate the frame, so the same frame is safely shared
+        across export formats. Keyed on the resolved ``normalize_columns`` bool
+        so raw and normalized exports stay independent.
+        """
+        if normalize_columns not in self._frame_cache:
+            self._frame_cache[normalize_columns] = CSVReaderPolarsEngine(
+                self.filepath, lenient=self.lenient
+            ).to_dataframe(normalize_columns)
+        return self._frame_cache[normalize_columns]
+
     def write_csv(self, export_filename=None, normalize_columns=None):
         """
         Export a Polars dataframe to a CSV file.
@@ -661,7 +681,7 @@ class CSVWriterPolarsEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.csv_export_filename, export_filename)
-        df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
+        df = self._dataframe(normalize_columns)
         df.write_csv(filename)
 
     def write_excel(self, export_filename=None, normalize_columns=None):
@@ -675,7 +695,7 @@ class CSVWriterPolarsEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.excel_export_filename, export_filename)
-        df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
+        df = self._dataframe(normalize_columns)
         df.write_excel(filename)
 
     def write_json(self, export_filename=None, normalize_columns=None):
@@ -689,7 +709,7 @@ class CSVWriterPolarsEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_export_filename, export_filename)
-        df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
+        df = self._dataframe(normalize_columns)
         df.write_json(filename)
 
     def write_json_newline_delimited(self, export_filename=None, normalize_columns=None):
@@ -703,7 +723,7 @@ class CSVWriterPolarsEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_newline_export_filename, export_filename)
-        df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
+        df = self._dataframe(normalize_columns)
         df.write_ndjson(filename)
 
     def write_parquet(self, export_filename=None, normalize_columns=None):
@@ -717,7 +737,7 @@ class CSVWriterPolarsEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.parquet_export_filename, export_filename)
-        df = CSVReaderPolarsEngine(self.filepath, lenient=self.lenient).to_dataframe(normalize_columns)
+        df = self._dataframe(normalize_columns)
         df.write_parquet(filename)
 
 
@@ -1097,13 +1117,10 @@ class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_export_filename, export_filename)
         table = self._create_table(normalize_columns)
-        # Use native PyArrow iteration to avoid dataframe conversion
-        records = []
-        for i in range(table.num_rows):
-            record = {col: table[col][i].as_py() for col in table.column_names}
-            records.append(record)
+        # to_pylist does the Arrow->Python conversion in C, producing the same
+        # list-of-dicts the per-row loop built, without the Python-level scan.
         with open(filename, "w") as f:
-            json.dump(records, f, indent=4)
+            json.dump(table.to_pylist(), f, indent=4)
 
     def write_json_newline_delimited(self, export_filename=None, normalize_columns=None):
         """
@@ -1117,11 +1134,12 @@ class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_newline_export_filename, export_filename)
         table = self._create_table(normalize_columns)
-        # Use native PyArrow iteration to avoid dataframe conversion
+        # Convert per record batch (C-level) instead of cell-by-cell in Python,
+        # while still streaming one line at a time to keep memory bounded.
         with open(filename, "w") as f:
-            for i in range(table.num_rows):
-                record = {col: table[col][i].as_py() for col in table.column_names}
-                f.write(json.dumps(record) + "\n")
+            for batch in table.to_batches():
+                for record in batch.to_pylist():
+                    f.write(json.dumps(record) + "\n")
 
     def write_parquet(self, export_filename=None, normalize_columns=None):
         """

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -25,6 +25,11 @@ logger = logging.getLogger(__name__)
 class DuckDBQueries:
     """Class to store DuckDB database queries and query strings."""
 
+    # Process-wide guard: the spatial extension only needs INSTALL once per
+    # process (it persists to the on-disk extension directory). Each new
+    # connection still LOADs it, but redundant INSTALLs are skipped.
+    _spatial_installed = False
+
     def __init__(self, filepath, lenient=False):
         """
         Initialize the DuckDBQueries class.
@@ -47,13 +52,6 @@ class DuckDBQueries:
         # never touch DuckDB, so eagerly opening a connection here would waste
         # one on every such instance.
         self._connection = None
-        # DuckDB's read_csv ``skip`` operates on physical lines and, unlike
-        # Polars/PyArrow, does not natively ignore leading blank lines. Skip
-        # every leading physical line up to (but not including) the header,
-        # which ``header=true`` then consumes. See issue #85. ``max(..., 0)``
-        # guards files with no header line (empty/blank), where the helper
-        # returns 0 and DuckDB rejects a negative ``skip``.
-        self.skip_rows = max(_count_leading_physical_lines_before_header(self.filepath) - 1, 0)
         # Tracks how the cached table was imported (None until first import,
         # then True/False for normalize_columns) so create_table can reuse the
         # table for matching calls and re-import only when the mode changes.
@@ -83,6 +81,34 @@ class DuckDBQueries:
         if self._connection is None:
             self._connection = duckdb.connect(":memory:")
         return self._connection
+
+    @cached_property
+    def skip_rows(self):
+        """Leading physical lines DuckDB must skip before the header.
+
+        DuckDB's read_csv ``skip`` operates on physical lines and, unlike
+        Polars/PyArrow, does not natively ignore leading blank lines. Skip
+        every leading physical line up to (but not including) the header,
+        which ``header=true`` then consumes. See issue #85. ``max(..., 0)``
+        guards files with no header line (empty/blank), where the helper
+        returns 0 and DuckDB rejects a negative ``skip``.
+
+        Computed lazily: only the DuckDB import path consumes this, so
+        Polars/PyArrow engines (which build a DuckDBQueries only for the table
+        name) never pay the leading-line scan.
+        """
+        return max(_count_leading_physical_lines_before_header(self.filepath) - 1, 0)
+
+    def load_spatial_extension(self, connection):
+        """Ensure DuckDB's spatial extension is available on ``connection``.
+
+        INSTALL runs at most once per process (the extension persists on disk);
+        LOAD runs on every call because each export opens a fresh connection.
+        """
+        if not DuckDBQueries._spatial_installed:
+            connection.execute("INSTALL spatial;")
+            DuckDBQueries._spatial_installed = True
+        connection.execute("LOAD spatial;")
 
     @cached_property
     def delimiter(self):
@@ -390,9 +416,9 @@ class DuckDBQueries:
             str: The SQL query to export the table to an Excel file.
         """
         filename = self._escape_sql_literal(self.set_export_filename(default_filename, export_filename))
+        # Spatial DDL is handled separately via load_spatial_extension() so the
+        # extension is INSTALLed at most once per process; this is a pure COPY.
         return f"""
-            INSTALL spatial;
-            LOAD spatial;
             COPY (SELECT * FROM {self.database_table_name})
             TO '{filename}'(FORMAT GDAL, DRIVER 'xlsx')
         """

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -152,6 +152,13 @@ class CSVReader(CSVComponents):
         """
         Queries a CSV file after importing into DuckDB.
 
+        Security:
+            ``sql_query`` is executed verbatim against the in-memory session.
+            This is intentional for analytics, but it means concatenating
+            untrusted input into ``sql_query`` is a SQL-injection vector
+            against that session. Callers that build queries from user input
+            must validate/parameterize and sandbox at the application layer.
+
         Args:
             sql_query (str): Query to run against DuckDB.
             normalize_columns (bool or None): Deprecated per-call override.

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -1,5 +1,6 @@
 """This module contains tests for the engine classes."""
 
+import json
 from pathlib import Path
 
 import polars as pl
@@ -693,3 +694,64 @@ class TestLeadingCommentHandling:
             df = reader.to_dataframe()
             assert df.columns == ["a", "b"]
             assert len(df) == 1
+
+
+class TestPolarsWriterParseOnce:
+    """CSVWriterPolarsEngine must parse the source once across export formats."""
+
+    def test_multi_format_export_reads_once(self, tmp_path, sample_csv, monkeypatch):
+        """write_csv + write_json + write_parquet on one instance read once."""
+        import datagrunt.core.csv_io.engines as engines_mod
+
+        calls = {"count": 0}
+        original = engines_mod.CSVReaderPolarsEngine.to_dataframe
+
+        def counting_to_dataframe(self, normalize_columns=None):
+            calls["count"] += 1
+            return original(self, normalize_columns)
+
+        monkeypatch.setattr(engines_mod.CSVReaderPolarsEngine, "to_dataframe", counting_to_dataframe)
+
+        writer = CSVWriterPolarsEngine(sample_csv)
+        writer.write_csv(str(tmp_path / "o.csv"))
+        writer.write_json(str(tmp_path / "o.json"))
+        writer.write_parquet(str(tmp_path / "o.parquet"))
+
+        assert calls["count"] == 1
+
+    def test_normalize_variants_are_not_cross_contaminated(self, tmp_path):
+        """Caching must key on normalize_columns; raw and normalized differ."""
+        csv = tmp_path / "c.csv"
+        csv.write_text("First Name,Age\nJohn,30\n")
+        writer = CSVWriterPolarsEngine(str(csv))
+
+        raw_path = tmp_path / "raw.csv"
+        norm_path = tmp_path / "norm.csv"
+        writer.write_csv(str(raw_path), normalize_columns=False)
+        writer.write_csv(str(norm_path), normalize_columns=True)
+
+        assert "First Name" in raw_path.read_text()
+        assert "first_name" in norm_path.read_text()
+
+
+class TestPyArrowJsonOutput:
+    """PyArrow JSON/JSONL export content must be preserved by the refactor."""
+
+    def test_write_json_content(self, tmp_path):
+        csv = tmp_path / "d.csv"
+        csv.write_text("name,age\nJohn,30\nJane,25\n")
+        out = tmp_path / "o.json"
+        CSVWriterPyArrowEngine(str(csv)).write_json(str(out))
+        # The PyArrow engine reads all columns as strings; lock that exactly.
+        assert json.loads(out.read_text()) == [
+            {"name": "John", "age": "30"},
+            {"name": "Jane", "age": "25"},
+        ]
+
+    def test_write_jsonl_content(self, tmp_path):
+        csv = tmp_path / "d.csv"
+        csv.write_text("name,age\nJohn,30\nJane,25\n")
+        out = tmp_path / "o.jsonl"
+        CSVWriterPyArrowEngine(str(csv)).write_json_newline_delimited(str(out))
+        lines = [json.loads(line) for line in out.read_text().splitlines()]
+        assert lines == [{"name": "John", "age": "30"}, {"name": "Jane", "age": "25"}]

--- a/tests/core_tests/databases_tests/test_databases.py
+++ b/tests/core_tests/databases_tests/test_databases.py
@@ -251,3 +251,87 @@ class TestDuckDBQueriesContextManager:
         relation = queries.create_table()
         assert relation.fetchall() == [("1", "2"), ("3", "4")]
         queries.close()
+
+
+class TestDuckDBQueriesLazySkipRows:
+    """The leading-line scan must be deferred until ``skip_rows`` is needed."""
+
+    def test_skip_rows_not_scanned_at_construction(self, tmp_path, monkeypatch):
+        """Constructing DuckDBQueries must not scan the file for leading lines.
+
+        ``skip_rows`` is only consumed by the DuckDB import path. Polars/PyArrow
+        engines build a DuckDBQueries (for the table name) but never touch
+        DuckDB, so scanning leading physical lines in __init__ wastes a full
+        leading-block read on every such construction.
+        """
+        import datagrunt.core.databases.databases as dbmod
+
+        calls = {"count": 0}
+        original = dbmod._count_leading_physical_lines_before_header
+
+        def counting(path):
+            calls["count"] += 1
+            return original(path)
+
+        monkeypatch.setattr(dbmod, "_count_leading_physical_lines_before_header", counting)
+
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1,col2\n1,A\n2,B\n")
+        queries = DuckDBQueries(str(csv))
+
+        # Construction must not have triggered the leading-line scan.
+        assert calls["count"] == 0
+
+        # First access computes it once; the result is cached thereafter.
+        first = queries.skip_rows
+        assert calls["count"] == 1
+        assert queries.skip_rows == first
+        assert calls["count"] == 1
+
+    def test_skip_rows_value_matches_leading_blank_lines(self, tmp_path):
+        """Lazy skip_rows must still yield the correct DuckDB skip count."""
+        csv = tmp_path / "leading.csv"
+        # Two leading blank lines before the header; DuckDB skips up to the header.
+        csv.write_text("\n\ncol1,col2\n1,A\n")
+        queries = DuckDBQueries(str(csv))
+        assert queries.skip_rows == 2
+
+
+class TestSpatialExtensionInstallOnce:
+    """Spatial DDL must live outside the export query and INSTALL once/process."""
+
+    def test_export_excel_query_has_no_spatial_ddl(self, tmp_path):
+        csv = tmp_path / "d.csv"
+        csv.write_text("a,b\n1,2\n")
+        queries = DuckDBQueries(str(csv))
+        sql = queries.export_excel_query("output.xlsx").upper()
+        assert "INSTALL" not in sql
+        assert "LOAD" not in sql
+        assert "COPY" in sql
+        queries.close()
+
+    def test_install_runs_once_load_runs_each_call(self, tmp_path):
+        """INSTALL spatial at most once per process; LOAD on every connection."""
+        # Reset the process-level guard so the assertion is deterministic.
+        DuckDBQueries._spatial_installed = False
+
+        executed = []
+
+        class _FakeConn:
+            def execute(self, sql, *args, **kwargs):
+                executed.append(sql.strip())
+                return self
+
+        csv = tmp_path / "d.csv"
+        csv.write_text("a,b\n1,2\n")
+        queries = DuckDBQueries(str(csv))
+        fake = _FakeConn()
+
+        # Two exports in the same process each get a fresh connection.
+        queries.load_spatial_extension(fake)
+        queries.load_spatial_extension(fake)
+
+        installs = [s for s in executed if s.upper().startswith("INSTALL SPATIAL")]
+        loads = [s for s in executed if s.upper().startswith("LOAD SPATIAL")]
+        assert len(installs) == 1
+        assert len(loads) == 2


### PR DESCRIPTION
Closes #185.

Second batch of efficiency findings (first shipped in #184), scoped to the high-confidence, behavior-preserving wins. Each change is covered by behavior-locking (characterization) tests plus efficiency-asserting tests.

## Changes
- **#11 Polars writer re-read** — `CSVWriterPolarsEngine` caches the parsed frame per resolved `normalize_columns`; exporting one instance to several formats now parses the source **once** instead of once per format.
- **#13 spatial on every Excel export** — spatial DDL moved out of `export_excel_query` (now a pure COPY) into `DuckDBQueries.load_spatial_extension()`, which `INSTALL`s at most **once per process** and `LOAD`s per connection. (Payoff is modest: the DuckDB writer closes its connection after each export, so `LOAD` can't be cached across calls — only the redundant `INSTALL` is avoided.)
- **#4 / #14 PyArrow JSON** — `write_json` uses `table.to_pylist()`; JSONL converts per `to_batches()` (C-level) while still streaming one line at a time. Output is **byte-equivalent** to the old per-row Python loop.
- **#15 eager leading-line scan** — `DuckDBQueries.skip_rows` is now a lazy `cached_property`, so Polars/PyArrow engines stop paying a full leading-line scan at construction.
- **#3 SQL passthrough (by design)** — added a Security note to `CSVReader.query_data`'s docstring. No behavior change.

## Not changed
- **#9 row_count full scan** — already mitigated: `row_count_with_header` is a `cached_property` at both layers, so repeat calls never rescan. Documented as a non-issue.

## Verification
- New tests: 4 efficiency-asserting (RED → GREEN) + 4 characterization (GREEN throughout) = 8 passing.
- Full suite: **965 passed** under **both** the Rust native backend and the pure-Python oracle (`DATAGRUNT_DISABLE_RUST=1`) — no Rust core changes, parity intact.
- ruff clean on all changed files.

## Follow-up (next branch, agreed)
- #10 (`SAMPLE_ROWS_BY_QUALITY` 50k read — sampling-quality tradeoff)
- #12 (`_has_midfile_comments` full scan — largely inherent)
- #16 (PDF reader `to_dicts()` twice across `to_dataframe`/`to_arrow_table`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)