### PR TITLE
perf: cache PDF reader parse + PyArrow midfile-comment scan (final efficiency batch)

### DIFF
--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -66,6 +66,12 @@ class CSVStringSample:
     """Base class for creating a string sample of a CSV file."""
 
     SAMPLE_ROWS = 2
+    # Window scanned to pick the SAMPLE_ROWS rows with the fewest nulls. It is a
+    # deliberate quality/cost tradeoff: large enough that early sparse rows do
+    # not dominate the sample, bounded so the read+sort stays cheap. The result
+    # is a cached_property, so this scan happens at most once per instance.
+    # Lowering it would change which rows are selected (an observable change),
+    # so treat this as a tuning constant, not free headroom.
     SAMPLE_ROWS_BY_QUALITY = 50_000
 
     def __init__(self, filepath, delimiter=None):

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -4,6 +4,7 @@
 import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -746,6 +747,15 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
     Class to read CSV files and convert CSV files powered by PyArrow.
     """
 
+    @cached_property
+    def _midfile_comments(self):
+        """Whether the file has a mid-file ``#`` comment, scanned once per instance.
+
+        The scan is O(file) to prove absence, so caching avoids repeating it on
+        every conversion/export performed on the same engine instance.
+        """
+        return _has_midfile_comments(self.filepath)
+
     def _polars_fallback_table(self, columns, normalize_columns, truncate_ragged_lines, n_rows=None):
         """Parse the CSV with Polars and convert it to an Arrow table.
 
@@ -811,7 +821,7 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
             _check_csv_ragged_and_warn(self.filepath, self.delimiter)
             # Fallback to Polars to parse the ragged CSV, then convert to Arrow Table
             return self._polars_fallback_table(columns, normalize_columns, truncate_ragged_lines=True)
-        if _has_midfile_comments(self.filepath):
+        if self._midfile_comments:
             # PyArrow's native reader crashes on comment lines past the leading
             # block; defer to Polars so the rows match the polars reference
             # engine (issue #90).
@@ -868,7 +878,7 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
                 truncate_ragged_lines=True,
                 n_rows=CSVEngineProperties.dataframe_sample_rows,
             )
-        if _has_midfile_comments(self.filepath):
+        if self._midfile_comments:
             # PyArrow's native reader crashes on comment lines past the leading
             # block; defer to Polars so the rows match the polars reference
             # engine (issue #90).
@@ -1017,6 +1027,15 @@ class CSVReaderPyArrowEngine(CSVBaseReaderEngine):
 class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
     """Class to write CSVs to other file formats powered by PyArrow."""
 
+    @cached_property
+    def _midfile_comments(self):
+        """Whether the file has a mid-file ``#`` comment, scanned once per instance.
+
+        Cached so exporting to multiple formats on one writer instance scans
+        the file for mid-file comments only once.
+        """
+        return _has_midfile_comments(self.filepath)
+
     def _create_table(self, normalize_columns=False):
         """Create a PyArrow table for writing operations."""
         # Read with PyArrow with all columns as string to prevent data loss
@@ -1032,7 +1051,7 @@ class CSVWriterPyArrowEngine(CSVBaseWriterEngine):
                 "PyArrow engine does not support legacy Mac OS carriage return (\\r) newlines. "
                 "Please use engine='duckdb' or convert the file to Unix/Windows newlines."
             )
-        if self.lenient or _has_midfile_comments(self.filepath):
+        if self.lenient or self._midfile_comments:
             if self.lenient:
                 _check_csv_ragged_and_warn(self.filepath, self.queries.delimiter)
             # Fallback to Polars: it parses ragged rows and skips mid-file ``#``

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -94,6 +94,19 @@ class PDFBaseReaderEngine(ABC):
         self.workers = workers
         if not self.filepath.exists():
             raise FileNotFoundError
+        self._parsed_cache = {}
+
+    def _parse_to_dicts(self, drop_layout_tables: bool = False) -> dict:
+        """Parse once per drop_layout_tables value, shared by the conversions.
+
+        ``to_dataframe`` and ``to_arrow_table`` both need the parsed document
+        and only read it (via ``flatten``), so they reuse a single parse on the
+        same instance. The public ``to_dicts`` stays uncached so its return
+        value is never an unexpectedly shared/mutable object.
+        """
+        if drop_layout_tables not in self._parsed_cache:
+            self._parsed_cache[drop_layout_tables] = self.to_dicts(drop_layout_tables=drop_layout_tables)
+        return self._parsed_cache[drop_layout_tables]
 
     @abstractmethod
     def get_sample(self) -> dict:
@@ -161,14 +174,16 @@ class PDFReaderPyMuPDFEngine(PDFBaseReaderEngine):
 
     def to_dataframe(self, drop_layout_tables: bool = False) -> pl.DataFrame:
         """Flatten parsed elements into a Polars DataFrame (one row/element)."""
-        records = pdfcomponents.ParsedDocument(self.to_dicts(drop_layout_tables=drop_layout_tables)).flatten()
+        document = self._parse_to_dicts(drop_layout_tables=drop_layout_tables)
+        records = pdfcomponents.ParsedDocument(document).flatten()
         if not records:
             return pl.DataFrame()
         return pl.DataFrame(records)
 
     def to_arrow_table(self, drop_layout_tables: bool = False) -> pa.Table:
         """Flatten parsed elements into a PyArrow table (one row/element)."""
-        records = pdfcomponents.ParsedDocument(self.to_dicts(drop_layout_tables=drop_layout_tables)).flatten()
+        document = self._parse_to_dicts(drop_layout_tables=drop_layout_tables)
+        records = pdfcomponents.ParsedDocument(document).flatten()
         if not records:
             return pa.Table.from_pydict({})
         return pa.Table.from_pylist(records)
@@ -290,9 +305,10 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
     def to_dataframe(self, drop_layout_tables: bool = False) -> pl.DataFrame:
         """Flatten parsed elements into a Polars DataFrame (one row/element)."""
         if self.structured:
-            records = pdfcomponents.ParsedDocument(self.to_dicts(drop_layout_tables=drop_layout_tables)).flatten()
+            document = self._parse_to_dicts(drop_layout_tables=drop_layout_tables)
+            records = pdfcomponents.ParsedDocument(document).flatten()
         else:
-            records = PdfiumNativeReader.flatten(self.to_dicts())
+            records = PdfiumNativeReader.flatten(self._parse_to_dicts())
         if not records:
             return pl.DataFrame()
         return pl.DataFrame(records)
@@ -300,9 +316,10 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
     def to_arrow_table(self, drop_layout_tables: bool = False) -> pa.Table:
         """Flatten parsed elements into a PyArrow table (one row/element)."""
         if self.structured:
-            records = pdfcomponents.ParsedDocument(self.to_dicts(drop_layout_tables=drop_layout_tables)).flatten()
+            document = self._parse_to_dicts(drop_layout_tables=drop_layout_tables)
+            records = pdfcomponents.ParsedDocument(document).flatten()
         else:
-            records = PdfiumNativeReader.flatten(self.to_dicts())
+            records = PdfiumNativeReader.flatten(self._parse_to_dicts())
         if not records:
             return pa.Table.from_pydict({})
         return pa.Table.from_pylist(records)

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -734,6 +734,44 @@ class TestPolarsWriterParseOnce:
         assert "first_name" in norm_path.read_text()
 
 
+class TestPyArrowMidfileCommentScanCached:
+    """_has_midfile_comments must be scanned once per PyArrow engine instance."""
+
+    def test_reader_scans_once_across_conversions(self, sample_csv, monkeypatch):
+        import datagrunt.core.csv_io.engines as engines_mod
+
+        calls = {"count": 0}
+        original = engines_mod._has_midfile_comments
+
+        def counting(filepath):
+            calls["count"] += 1
+            return original(filepath)
+
+        monkeypatch.setattr(engines_mod, "_has_midfile_comments", counting)
+
+        engine = CSVReaderPyArrowEngine(sample_csv)
+        engine.to_arrow_table()
+        engine.to_arrow_table()
+        assert calls["count"] == 1
+
+    def test_writer_scans_once_across_exports(self, sample_csv, tmp_path, monkeypatch):
+        import datagrunt.core.csv_io.engines as engines_mod
+
+        calls = {"count": 0}
+        original = engines_mod._has_midfile_comments
+
+        def counting(filepath):
+            calls["count"] += 1
+            return original(filepath)
+
+        monkeypatch.setattr(engines_mod, "_has_midfile_comments", counting)
+
+        writer = CSVWriterPyArrowEngine(sample_csv)
+        writer.write_json(str(tmp_path / "o.json"))
+        writer.write_parquet(str(tmp_path / "o.parquet"))
+        assert calls["count"] == 1
+
+
 class TestPyArrowJsonOutput:
     """PyArrow JSON/JSONL export content must be preserved by the refactor."""
 

--- a/tests/core_tests/pdf_io_tests/test_engines.py
+++ b/tests/core_tests/pdf_io_tests/test_engines.py
@@ -441,3 +441,36 @@ class TestPDFWriterPdfiumStructured:
         paths = PDFWriterPdfiumEngine(sample_pdf, structured=True).extract_images(output_dir=str(tmp_path))
         assert len(paths) >= 1
         assert all(os.path.isfile(p) for p in paths)
+
+
+class TestPDFReaderParseSharedAcrossConversions:
+    """to_dataframe + to_arrow_table on one reader must parse the PDF once."""
+
+    @staticmethod
+    def _spy_parse(monkeypatch):
+        import datagrunt.core.pdf_io.pdfcomponents as pdfc
+
+        calls = {"count": 0}
+        original = pdfc.DocumentAssembler.parse_document
+
+        def counting(self, *args, **kwargs):
+            calls["count"] += 1
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(pdfc.DocumentAssembler, "parse_document", counting)
+        return calls
+
+    def test_dataframe_and_arrow_share_one_parse(self, sample_pdf, monkeypatch):
+        calls = self._spy_parse(monkeypatch)
+        engine = PDFReaderPyMuPDFEngine(sample_pdf)
+        engine.to_dataframe()
+        engine.to_arrow_table()
+        assert calls["count"] == 1
+
+    def test_public_to_dicts_still_reparses(self, sample_pdf, monkeypatch):
+        """Public to_dicts must keep its uncached contract (fresh dict per call)."""
+        calls = self._spy_parse(monkeypatch)
+        engine = PDFReaderPyMuPDFEngine(sample_pdf)
+        engine.to_dicts()
+        engine.to_dicts()
+        assert calls["count"] == 2


### PR DESCRIPTION
Closes #187.

Final batch of efficiency findings (after #184 and #185). The two lower-value items deferred earlier, plus a documentation-only change.

## Changes
- **#16 PDF reader double-parse** — `to_dataframe` and `to_arrow_table` each called `to_dicts()`, so calling both on one reader instance parsed the PDF twice. Added a private memoized `_parse_to_dicts` on `PDFBaseReaderEngine`, shared by both conversions (PyMuPDF + Pdfium). The public `to_dicts` stays **uncached** so its contract (a fresh dict per call) is preserved — guarded by a test.
- **#12 `_has_midfile_comments` full scan** — re-ran on every PyArrow read/export. The scan is inherently O(file) to *prove* no mid-file comment exists, so it's now cached per instance via `cached_property` on both `CSVReaderPyArrowEngine` and `CSVWriterPyArrowEngine`; repeated operations scan once.
- **#10 `SAMPLE_ROWS_BY_QUALITY = 50_000`** — **no behavior change**. Already a `cached_property`, and shrinking the window would change which rows are sampled. Added a comment documenting the tradeoff (per agreed decision).

## Verification
- New tests: 3 efficiency-asserting (RED → GREEN) + 1 contract-preservation (public `to_dicts` still re-parses) = 4 passing.
- Full suite: **969 passed** under **both** Rust native and the pure-Python oracle — no Rust core changes, parity intact.
- Blocking ruff scope (`src/datagrunt/core/csv_io`) clean. Pre-existing `pdf_io/engines.py` lint (unused `time`, worker import order, long log strings) left untouched — out of scope and non-blocking.

## Status
This completes the efficiency-finding remediation across three PRs (#184, #185, #186 → now this). All security findings were already addressed or are by-design/info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)