### PR TITLE
perf(csv): cache table in sql_query_to_dataframe (#189) + dedupe is_structured (#190)

### DIFF
--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -588,13 +588,12 @@ class DuckDBQueries:
         Returns:
             polars.DataFrame: The resulting DataFrame.
         """
-        if self.lenient:
-            _check_csv_ragged_and_warn(self.filepath, self.delimiter)
-        # Ensure the table is created with original column names for querying
-        self.connection.sql(self.import_csv_query())
-        # The raw import above replaced the table with original column names;
-        # record that so create_table cannot wrongly reuse a "normalized" table.
-        self._imported_normalize_columns = False
+        # Create (or reuse) the table with ORIGINAL column names so the user's
+        # SQL can reference them. create_table caches per connection, so running
+        # several queries against the same instance imports the file once
+        # instead of re-importing on every call (issue #189); it also handles
+        # the lenient ragged-row warning on actual import.
+        self.create_table(normalize_columns=False)
 
         # Execute the user's query
         result_df = self.connection.sql(sql_query).pl()

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -111,14 +111,12 @@ class PDFWriter(PDFComponents):
         if self._parsed_dict is not None:
             filename = export_filename if export_filename else "output.jsonl"
             document = self._parsed_dict
+            is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
             if image_output_dir and dedupe_images:
-                is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
                 if is_structured:
                     pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
                 else:
                     PdfiumNativeReader.dedupe_images(document, image_output_dir=image_output_dir)
-            
-            is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
             if is_structured:
                 records = pdfcomponents.ParsedDocument(document).flatten()
             else:
@@ -155,14 +153,12 @@ class PDFWriter(PDFComponents):
         if self._parsed_dict is not None:
             filename = export_filename if export_filename else "output.md"
             document = self._parsed_dict
+            is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
             if image_output_dir and dedupe_images:
-                is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
                 if is_structured:
                     pdfcomponents.ParsedDocument(document).dedupe_images(image_output_dir=image_output_dir)
                 else:
                     PdfiumNativeReader.dedupe_images(document, image_output_dir=image_output_dir)
-            
-            is_structured = any("elements" in pg for pg in document.get("document", {}).get("pages", []))
             if is_structured:
                 markdown_text = pdfcomponents.ParsedDocument(document).to_markdown(export_filename=filename)
             else:

--- a/tests/core_tests/databases_tests/test_databases.py
+++ b/tests/core_tests/databases_tests/test_databases.py
@@ -158,6 +158,54 @@ class TestCreateTableIdempotent:
         queries.close()
 
 
+class TestSqlQueryToDataframeReusesImport:
+    """sql_query_to_dataframe must reuse the cached table, not re-import (#189)."""
+
+    def test_repeated_queries_import_once(self, tmp_path, monkeypatch):
+        """Two SQL queries on one instance must import the CSV only once."""
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1,col2\n1,A\n2,B\n")
+        queries = DuckDBQueries(str(csv))
+
+        import_calls = {"count": 0}
+        original_import_query = queries.import_csv_query
+
+        def counting_import_query():
+            import_calls["count"] += 1
+            return original_import_query()
+
+        monkeypatch.setattr(queries, "import_csv_query", counting_import_query)
+
+        sql = f"SELECT col1, col2 FROM {queries.database_table_name} ORDER BY col1"
+        first = queries.sql_query_to_dataframe(sql)
+        second = queries.sql_query_to_dataframe(sql)
+
+        assert import_calls["count"] == 1
+        assert first.rows() == second.rows() == [("1", "A"), ("2", "B")]
+        queries.close()
+
+    def test_reimports_with_original_names_after_normalized_table(self, tmp_path):
+        """A prior normalized import must be rebuilt with original column names.
+
+        sql_query_to_dataframe queries against the original headers, so if the
+        cached table was last imported normalized, it must re-import (not reuse
+        the normalized table) so the user's SQL can reference original names.
+        """
+        csv = tmp_path / "data.csv"
+        csv.write_text("First Name,Age\nJohn,30\n")
+        queries = DuckDBQueries(str(csv))
+
+        # Prime the cache with a NORMALIZED table (columns: first_name, age).
+        queries.create_table(normalize_columns=True)
+
+        # Querying original names must still work (forces a fresh import).
+        sql = f'SELECT "First Name", "Age" FROM {queries.database_table_name}'
+        result = queries.sql_query_to_dataframe(sql)
+        assert result.columns == ["First Name", "Age"]
+        assert result.rows() == [("John", "30")]
+        queries.close()
+
+
 class TestNumericLeadingFilename:
     """Numeric-leading filenames must yield a valid unquoted table name (#149).
 

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -298,3 +298,44 @@ class TestPDFWriterJsonAndDictInputs:
         assert "# Header Text" in content
         assert "Hello body" in content
 
+    @pytest.fixture
+    def dummy_native_dict(self):
+        """A native-schema (non-"elements") document, exercising is_structured=False."""
+        return {
+            "document": {
+                "source": "dummy.pdf",
+                "total_pages": 1,
+                "pages": [
+                    {
+                        "page_number": 1,
+                        "text": "Hello native body",
+                        "text_objects": [
+                            {
+                                "text": "Hello native body",
+                                "font_size": 12,
+                                "position": {"x": 1, "y": 1, "w": 1, "h": 1},
+                                "bbox": [0, 0, 1, 1],
+                            }
+                        ],
+                        "images": [],
+                    }
+                ],
+            }
+        }
+
+    def test_writer_with_native_dict(self, dummy_native_dict, tmp_path, monkeypatch):
+        """Native-schema dict must flatten/render via the non-structured branch."""
+        monkeypatch.chdir(tmp_path)
+        writer = PDFWriter(dummy_native_dict)
+
+        jlpath = writer.write_json_newline_delimited("native_out.jsonl")
+        with open(jlpath) as f:
+            lines = [json.loads(line) for line in f]
+        assert len(lines) == 1
+        assert lines[0]["type"] == "text"
+        assert lines[0]["text"] == "Hello native body"
+
+        mdpath = writer.write_markdown("native_out.md")
+        with open(mdpath) as f:
+            assert "Hello native body" in f.read()
+


### PR DESCRIPTION
Closes #189. Closes #190.

Two findings from an external (Gemini) performance review that I verified as genuine (the rest of that report was overstated, already-solved, or technically off, so this branch covers only the actionable ones).

## #189 — `sql_query_to_dataframe` re-imported on every call
`DuckDBQueries.sql_query_to_dataframe` unconditionally ran `import_csv_query()`, bypassing the `_table_is_current` cache. The Polars and PyArrow engines route `query_data` through it, so N SQL queries on one reader = N full re-imports. The **DuckDB engine** already used `create_table` correctly, so this was an inconsistency.

Fix: use `create_table(normalize_columns=False)` — imports once per connection, re-imports only on a normalize-mode flip. The lenient ragged-row warning now fires on actual import (via `create_table`) instead of once per query.

## #190 — duplicate `is_structured` in PDF writers
`write_json_newline_delimited` and `write_markdown` computed `is_structured` twice in the parsed-dict path. Hoisted to one computation. (Minor: `any(...)` short-circuits, so this is a DRY cleanup, not a meaningful speedup.)

## Verification
- New tests: import-once + normalize mode-flip correctness for the SQL path (RED→GREEN); a native (non-structured) dict characterization test for the PDF writers (previously uncovered branch).
- Full suite: **972 passed** under **both** Rust native and the pure-Python oracle — no Rust core changes.
- Blocking ruff scope (`src/datagrunt/core/csv_io`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)