### PR TITLE
test(parity): legacy-mac quoted-CR corpus case; drop tautological rowcount test

### DIFF
--- a/tests/parity/corpus.py
+++ b/tests/parity/corpus.py
@@ -58,4 +58,9 @@ CORPUS: dict[str, bytes] = {
     # decoder chunk boundary (io.rs CHUNK_SIZE). Exercises row counting across
     # the chunk split for both backends.
     "chunk_boundary_quoted_newline.csv": b"a,b\n" + b"x" * 65_528 + b',"line1\nline2"\n',
+    # Legacy-Mac (\r) line endings WITH a quoted field that itself contains a
+    # \r. Python reads these via newline=None (universal translation), so the
+    # quoted \r must stay part of one record rather than splitting the row.
+    # Exercises the legacy-mac branch and quoting together for both backends.
+    "legacy_mac_quoted_cr.csv": b'id,note\r1,"line one\rline two"\r2,plain\r',
 }

--- a/tests/parity/test_parity_rowcount.py
+++ b/tests/parity/test_parity_rowcount.py
@@ -13,8 +13,7 @@ def test_row_count_with_header(corpus_file):
     ) == py.row_count_with_header(str(corpus_file), delimiter)
 
 
-def test_row_count_without_header_is_count_minus_one(corpus_file):
-    delimiter = py.infer_delimiter(str(corpus_file))
-    rust_count = datagrunt_rs.row_count_with_header(str(corpus_file), delimiter)
-    py_count = py.row_count_with_header(str(corpus_file), delimiter)
-    assert rust_count - 1 == py_count - 1, "row_count_without_header parity"
+# Note: there is intentionally no separate ``row_count_without_header`` parity
+# test. Both backends expose only ``row_count_with_header``; the without-header
+# count is ``with_header - 1`` at the CSVRows layer (covered in the core tests),
+# so a backend-level ``(x-1) == (y-1)`` assertion is just the test above.


### PR DESCRIPTION
Closes #179. Two test-quality nits from the 4.0.0 test-review backlog. Test-only — no source changes.

- **Add legacy-Mac quoted-`\r` corpus case.** New `legacy_mac_quoted_cr.csv` (`\r` line endings with a quoted field that itself contains a `\r`). Python reads legacy-mac via `newline=None` (universal translation), so the quoted `\r` must stay part of one record rather than splitting the row — this exercises the legacy-mac branch and quoting together. Every parity test now runs over it; row-count parity (Rust == Python) holds, confirming no edge-case divergence.
- **Drop the tautological rowcount test.** `test_row_count_without_header_is_count_minus_one` asserted `(x-1) == (y-1)` — algebraically identical to the `test_row_count_with_header` parity assertion above it. Both backends expose only `row_count_with_header`; the without-header count is `with_header - 1` at the `CSVRows` layer (covered in core tests), so there was nothing extra to assert at the backend level.

## Verification
- Parity suite green; the new corpus entry passes row-count parity.
- Full suite **936 passed** (the count drops because the removed redundant test ran across the whole corpus — no real coverage lost). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)