### PR TITLE
docs(csv): note CSV/formula-injection risk on spreadsheet export

### DIFF
--- a/src/datagrunt/csv_api/csvwriter.py
+++ b/src/datagrunt/csv_api/csvwriter.py
@@ -18,6 +18,17 @@ class CSVWriter(CSVComponents):
     """
     Class to unify the interface for converting CSV files to various other
     supported file types.
+
+    Security:
+        Cell values are written verbatim — datagrunt preserves data, it does
+        not transform or sanitize it. For the spreadsheet-interpreted formats
+        (``write_csv`` and ``write_excel``), a value beginning with ``=``,
+        ``+``, ``-``, ``@`` (or a leading tab/carriage return) is treated as a
+        FORMULA by Excel / LibreOffice / Google Sheets when the file is opened
+        — the classic CSV/formula-injection vector (CWE-1236). If your source
+        data is untrusted and the output may be opened in a spreadsheet
+        application, sanitize at the application layer before export; datagrunt
+        will not silently mutate the values for you.
     """
 
     def __init__(self, filepath, engine="duckdb", lenient=False, normalize_columns=False):


### PR DESCRIPTION
Documents the CSV/formula-injection (CWE-1236) risk on `write_csv`/`write_excel` and **declines** the opt-in sanitization proposed in #173.

## Rationale
datagrunt's design is to **preserve** data, not transform it. Formula-injection sanitization (prefixing `'` to cells starting with `=+-@`) is inherently lossy — it would corrupt legitimate values like negative numbers (`-5`) — and adopting "mutate the data because it could be risky" puts the project on an endless treadmill of defensive transformations. The trust boundary belongs at the application layer (same disposition as the `query_data` SQL passthrough).

So: a `Security:` note on the `CSVWriter` class docstring explaining that cell values are written verbatim and that a value beginning with `=`, `+`, `-`, `@` (or a leading tab/CR) is interpreted as a formula by spreadsheet apps when the exported file is opened — callers exporting untrusted data should sanitize at their layer.

## Scope
- Docstring-only. No behavior change. ruff clean; import sanity verified.
- #173 closed as not-planned (feature declined by design); this PR is the documentation half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)