### PR TITLE
Add seeded PDF backend parity harness for CI

### DIFF
--- a/tests/parity/pdf_corpus.py
+++ b/tests/parity/pdf_corpus.py
@@ -1,0 +1,72 @@
+"""Seeded PDF builders for cross-backend parity tests.
+
+Each builder writes one PDF under a shared corpus directory. Builders mirror
+real-world shapes (text, images, multipage markers) without relying on the
+git-ignored ``data/pdfs/`` corpus used by ``test_engine_comparison.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pymupdf
+
+Builder = Callable[[Path], None]
+
+
+def build_text_and_image(dest: Path) -> None:
+    """One page: header, body lines, and an embedded image."""
+    doc = pymupdf.open()
+    page = doc.new_page(width=612, height=792)
+    page.insert_text((72, 72), "Quarterly Report", fontsize=24)
+    page.insert_text((72, 120), "This is body text for testing.", fontsize=11)
+    page.insert_text((72, 140), "Body line two for the report.", fontsize=11)
+    page.insert_text((72, 160), "Body line three with details.", fontsize=11)
+    page.insert_text((72, 180), "Body line four wraps up the text.", fontsize=11)
+
+    pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 100, 100))
+    pix.set_rect(pix.irect, (255, 0, 0))
+    page.insert_image(pymupdf.Rect(72, 200, 172, 300), stream=pix.tobytes("png"))
+
+    doc.save(str(dest))
+    doc.close()
+
+
+def build_multipage_markers(dest: Path) -> None:
+    """Three pages with distinct marker strings."""
+    doc = pymupdf.open()
+    for n in range(1, 4):
+        page = doc.new_page(width=612, height=792)
+        page.insert_text((72, 72), f"Page Marker {n}", fontsize=18)
+        page.insert_text((72, 110), f"Body content for page {n}.", fontsize=11)
+    doc.save(str(dest))
+    doc.close()
+
+
+def build_body_text_only(dest: Path) -> None:
+    """One page with only body text (no images)."""
+    doc = pymupdf.open()
+    page = doc.new_page(width=612, height=792)
+    page.insert_text((72, 72), "Simple paragraph for parity.", fontsize=12)
+    page.insert_text((72, 96), "Second line of plain text.", fontsize=12)
+    doc.save(str(dest))
+    doc.close()
+
+
+BUILDERS: dict[str, Builder] = {
+    "text_and_image.pdf": build_text_and_image,
+    "multipage_markers.pdf": build_multipage_markers,
+    "body_text_only.pdf": build_body_text_only,
+}
+
+
+def write_corpus(root: Path) -> dict[str, Path]:
+    """Materialize every seeded PDF under ``root`` and return name -> path."""
+    root.mkdir(parents=True, exist_ok=True)
+    paths: dict[str, Path] = {}
+    for name, builder in BUILDERS.items():
+        path = root / name
+        builder(path)
+        paths[name] = path
+    return paths

--- a/tests/parity/pdf_helpers.py
+++ b/tests/parity/pdf_helpers.py
@@ -1,0 +1,50 @@
+"""Shared helpers for PDF backend parity assertions."""
+
+from __future__ import annotations
+
+ELEMENT_SCHEMA_KEYS = frozenset({"id", "type", "content", "position", "metadata"})
+
+TEXT_FLOOR_RATIO = 0.5
+
+
+def elements_by_type(doc: dict) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for page in doc.get("document", {}).get("pages", []):
+        for element in page.get("elements", []):
+            element_type = element["type"]
+            counts[element_type] = counts.get(element_type, 0) + 1
+    return counts
+
+
+def table_cells(doc: dict) -> list:
+    cells = []
+    for page in doc.get("document", {}).get("pages", []):
+        for element in page.get("elements", []):
+            if element.get("type") == "table":
+                cells.append(element.get("content"))
+    return cells
+
+
+def text_chars(doc: dict) -> int:
+    total = 0
+    for page in doc.get("document", {}).get("pages", []):
+        for element in page.get("elements", []):
+            content = element.get("content")
+            if isinstance(content, str):
+                total += len(content)
+    return total
+
+
+def collect_schema_violations(doc: dict) -> list[str]:
+    violations = []
+    for page in doc.get("document", {}).get("pages", []):
+        for element in page.get("elements", []):
+            missing = ELEMENT_SCHEMA_KEYS - element.keys()
+            if missing:
+                violations.append(f"page {page.get('page_number')}: missing {sorted(missing)}")
+    return violations
+
+
+def text_within_floor(left: int, right: int, floor: float = TEXT_FLOOR_RATIO) -> bool:
+    lo, hi = sorted((left, right))
+    return lo >= floor * hi

--- a/tests/parity/test_pdf_backend_parity.py
+++ b/tests/parity/test_pdf_backend_parity.py
@@ -1,0 +1,90 @@
+"""Cross-backend structural parity for PDFium vs PyMuPDF (unified schema).
+
+Unlike ``test_engine_comparison.py`` (local ``data/pdfs/`` corpus, deselected
+by default), these tests use a small seeded builder corpus and run in CI.
+"""
+
+import pytest
+from pdf_corpus import BUILDERS, write_corpus
+from pdf_helpers import (
+    collect_schema_violations,
+    elements_by_type,
+    table_cells,
+    text_chars,
+    text_within_floor,
+)
+
+from datagrunt import PDFReader
+
+pytestmark = pytest.mark.usefixtures("pdf_parity_corpus")
+
+
+@pytest.fixture(scope="session")
+def pdf_parity_corpus(tmp_path_factory):
+    """Write the seeded PDF corpus once per session."""
+    return write_corpus(tmp_path_factory.mktemp("pdf_parity_corpus"))
+
+
+@pytest.fixture(params=sorted(BUILDERS), ids=lambda name: name)
+def structured_pair(request, pdf_parity_corpus):
+    """Parse one corpus PDF with both engines in structured (unified) mode."""
+    path = pdf_parity_corpus[request.param]
+    pymupdf_doc = PDFReader(path, engine="pymupdf").to_dicts()
+    pdfium_doc = PDFReader(path, engine="pdfium").to_dicts()
+    return request.param, pymupdf_doc, pdfium_doc
+
+
+class TestStructuredBackendParity:
+    """PDFium structured output must stay aligned with PyMuPDF on seeded docs."""
+
+    def test_page_count_matches(self, structured_pair):
+        _, pymupdf_doc, pdfium_doc = structured_pair
+        assert pymupdf_doc["document"]["total_pages"] == pdfium_doc["document"]["total_pages"]
+
+    def test_unified_element_schema(self, structured_pair):
+        _, pymupdf_doc, pdfium_doc = structured_pair
+        assert collect_schema_violations(pymupdf_doc) == []
+        assert collect_schema_violations(pdfium_doc) == []
+
+    def test_table_cells_identical(self, structured_pair):
+        """Tables come from the shared pdfplumber path and must match exactly."""
+        _, pymupdf_doc, pdfium_doc = structured_pair
+        assert table_cells(pdfium_doc) == table_cells(pymupdf_doc)
+
+    def test_image_count_at_least_pymupdf(self, structured_pair):
+        _, pymupdf_doc, pdfium_doc = structured_pair
+        pdfium_images = elements_by_type(pdfium_doc).get("image", 0)
+        pymupdf_images = elements_by_type(pymupdf_doc).get("image", 0)
+        assert pdfium_images >= pymupdf_images
+
+    def test_text_volume_within_floor(self, structured_pair):
+        name, pymupdf_doc, pdfium_doc = structured_pair
+        mu_chars = text_chars(pymupdf_doc)
+        pdf_chars = text_chars(pdfium_doc)
+        assert text_within_floor(mu_chars, pdf_chars), (
+            f"{name}: text extraction diverges drastically "
+            f"(pymupdf={mu_chars}, pdfium={pdf_chars})"
+        )
+
+    def test_both_engines_extract_text(self, structured_pair):
+        name, pymupdf_doc, pdfium_doc = structured_pair
+        assert text_chars(pymupdf_doc) > 0, f"pymupdf extracted no text from {name}"
+        assert text_chars(pdfium_doc) > 0, f"pdfium extracted no text from {name}"
+
+
+class TestMultipageMarkerParity:
+    """Multipage corpus: every page marker must appear on both engines."""
+
+    def test_all_page_markers_present(self, pdf_parity_corpus):
+        path = pdf_parity_corpus["multipage_markers.pdf"]
+        for engine in ("pymupdf", "pdfium"):
+            doc = PDFReader(path, engine=engine).to_dicts()
+            pages = doc["document"]["pages"]
+            assert len(pages) == 3
+            for n, page in enumerate(pages, start=1):
+                page_text = " ".join(
+                    el["content"]
+                    for el in page.get("elements", [])
+                    if isinstance(el.get("content"), str)
+                )
+                assert f"Page Marker {n}" in page_text, f"{engine} missing marker on page {n}"

--- a/tests/parity/test_pdf_helpers.py
+++ b/tests/parity/test_pdf_helpers.py
@@ -1,0 +1,104 @@
+"""Unit tests for PDF parity helper functions."""
+
+from pdf_helpers import (
+    ELEMENT_SCHEMA_KEYS,
+    collect_schema_violations,
+    elements_by_type,
+    table_cells,
+    text_chars,
+    text_within_floor,
+)
+
+
+def test_elements_by_type_counts_each_type():
+    doc = {
+        "document": {
+            "pages": [
+                {
+                    "elements": [
+                        {"type": "text", "content": "a"},
+                        {"type": "image", "content": None},
+                        {"type": "text", "content": "b"},
+                    ]
+                }
+            ]
+        }
+    }
+    assert elements_by_type(doc) == {"text": 2, "image": 1}
+
+
+def test_table_cells_collects_only_tables():
+    doc = {
+        "document": {
+            "pages": [
+                {
+                    "elements": [
+                        {"type": "text", "content": "skip"},
+                        {"type": "table", "content": [["a", "b"]]},
+                    ]
+                }
+            ]
+        }
+    }
+    assert table_cells(doc) == [[["a", "b"]]]
+
+
+def test_text_chars_sums_string_content_only():
+    doc = {
+        "document": {
+            "pages": [
+                {
+                    "elements": [
+                        {"type": "text", "content": "hello"},
+                        {"type": "image", "content": None},
+                        {"type": "text", "content": "world"},
+                    ]
+                }
+            ]
+        }
+    }
+    assert text_chars(doc) == 10
+
+
+def test_collect_schema_violations_flags_missing_keys():
+    doc = {
+        "document": {
+            "pages": [
+                {
+                    "page_number": 1,
+                    "elements": [{"type": "text", "content": "only partial schema"}],
+                }
+            ]
+        }
+    }
+    violations = collect_schema_violations(doc)
+    assert len(violations) == 1
+    for key in ELEMENT_SCHEMA_KEYS - {"type", "content"}:
+        assert key in violations[0]
+
+
+def test_collect_schema_violations_empty_for_valid_element():
+    doc = {
+        "document": {
+            "pages": [
+                {
+                    "page_number": 1,
+                    "elements": [
+                        {
+                            "id": "elem_01_001",
+                            "type": "text",
+                            "content": "ok",
+                            "position": {"x": 0, "y": 0, "w": 1, "h": 1},
+                            "metadata": {},
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    assert collect_schema_violations(doc) == []
+
+
+def test_text_within_floor_accepts_similar_volumes():
+    assert text_within_floor(100, 120) is True
+    assert text_within_floor(10, 100) is False


### PR DESCRIPTION
## Summary
- Add a seeded PDF parity corpus under `tests/parity/` that runs in CI (unlike the git-ignored `data/pdfs/` corpus).
- Compare PDFium vs PyMuPDF on unified-schema output: page count, element schema, table cells, image count, and text volume floor.

Depends on #200 (CSV engine protocol).

## Test plan
- [x] `pytest tests/parity/test_pdf_helpers.py tests/parity/test_pdf_backend_parity.py`
- [x] Full suite: `pytest tests/` (982 passed)