### PR TITLE
Extract CSV engine protocol and shared reader helpers

### DIFF
--- a/src/datagrunt/core/csv_io/__init__.py
+++ b/src/datagrunt/core/csv_io/__init__.py
@@ -22,6 +22,7 @@ from datagrunt.core.csv_io.engines import (
     CSVWriterPyArrowEngine,
 )
 from datagrunt.core.csv_io.factories import CSVEngineFactory
+from datagrunt.core.csv_io.protocol import CSVReaderEngineProtocol, CSVWriterEngineProtocol
 
 __all__ = [
     "CSVDelimiter",
@@ -39,6 +40,8 @@ __all__ = [
     "CSVWriterPolarsEngine",
     "CSVWriterPyArrowEngine",
     "CSVEngineFactory",
+    "CSVReaderEngineProtocol",
+    "CSVWriterEngineProtocol",
     "_count_leading_comments",
     "_count_leading_physical_lines_before_header",
     "_check_csv_ragged_and_warn",

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -24,6 +24,15 @@ from datagrunt.core.csv_io.csvcomponents import (
     _count_leading_physical_lines_before_header,
     _is_legacy_mac_newlines,
 )
+from datagrunt.core.csv_io.protocol import (
+    DataFrameDerivedReaderMixin,
+)
+from datagrunt.core.csv_io.protocol import (
+    arrow_to_polars as _arrow_to_polars,
+)
+from datagrunt.core.csv_io.protocol import (
+    resolve_normalize_columns as _resolve_normalize_columns,
+)
 from datagrunt.core.databases import DuckDBQueries
 
 
@@ -48,30 +57,6 @@ def _has_midfile_comments(filepath):
             elif stripped.startswith("#"):
                 return True
     return False
-
-
-def _resolve_normalize_columns(instance_default, per_call_value):
-    """Resolve a per-call normalize flag against the engine's instance default.
-
-    Args:
-        instance_default (bool): The engine's constructor-level setting.
-        per_call_value (bool or None): The per-call argument; ``None`` means
-        "inherit the instance-level setting".
-
-    Returns:
-        bool: The effective normalization mode.
-    """
-    return instance_default if per_call_value is None else per_call_value
-
-
-def _arrow_to_polars(table: pa.Table) -> pl.DataFrame:
-    """Convert a PyArrow table to a Polars DataFrame, never a bare Series.
-
-    ``pl.from_arrow`` yields a Series for a single-column table; the CSV engines
-    always present a DataFrame, so collapse that case here in one place.
-    """
-    df = pl.from_arrow(table)
-    return df.to_frame() if isinstance(df, pl.Series) else df
 
 
 @dataclass
@@ -409,7 +394,7 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         return result_relation
 
 
-class CSVReaderPolarsEngine(CSVBaseReaderEngine):
+class CSVReaderPolarsEngine(DataFrameDerivedReaderMixin, CSVBaseReaderEngine):
     """
     Class to read CSV files and convert CSV files powered by Polars.
     """
@@ -472,32 +457,6 @@ class CSVReaderPolarsEngine(CSVBaseReaderEngine):
             A Polars dataframe.
         """
         return self._create_dataframe(_resolve_normalize_columns(self.normalize_columns, normalize_columns))
-
-    def to_arrow_table(self, normalize_columns=None):
-        """
-        Converts CSV to a PyArrow table.
-
-        Args:
-            normalize_columns (bool or None): Whether to normalize column
-            names. ``None`` (default) inherits the instance-level setting.
-
-        Returns:
-            A PyArrow table.
-        """
-        return self._create_dataframe(_resolve_normalize_columns(self.normalize_columns, normalize_columns)).to_arrow()
-
-    def to_dicts(self, normalize_columns=None):
-        """
-        Converts CSV to a list of Python dictionaries.
-
-        Args:
-            normalize_columns (bool or None): Whether to normalize column
-            names. ``None`` (default) inherits the instance-level setting.
-
-        Returns:
-            A list of dictionaries.
-        """
-        return self._create_dataframe(_resolve_normalize_columns(self.normalize_columns, normalize_columns)).to_dicts()
 
     def query_data(self, sql_query, normalize_columns=None):
         """

--- a/src/datagrunt/core/csv_io/protocol.py
+++ b/src/datagrunt/core/csv_io/protocol.py
@@ -1,0 +1,108 @@
+"""Structural protocols and shared helpers for CSV reader/writer engines."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional, Protocol, Union, runtime_checkable
+
+import polars as pl
+import pyarrow as pa
+from duckdb import DuckDBPyRelation
+
+
+def resolve_normalize_columns(instance_default: bool, per_call_value: Optional[bool]) -> bool:
+    """Resolve a per-call normalize flag against the engine's instance default."""
+    return instance_default if per_call_value is None else per_call_value
+
+
+def arrow_to_polars(table: pa.Table) -> pl.DataFrame:
+    """Convert a PyArrow table to a Polars DataFrame, never a bare Series."""
+    df = pl.from_arrow(table)
+    return df.to_frame() if isinstance(df, pl.Series) else df
+
+
+@runtime_checkable
+class CSVReaderEngineProtocol(Protocol):
+    """Structural interface every CSV reader engine must satisfy."""
+
+    filepath: Path
+    lenient: bool
+    normalize_columns: bool
+    db_table: str
+    delimiter: str
+
+    @property
+    def queries(self):
+        """DuckDB query helper bound to this reader's source file."""
+        ...
+
+    def close(self) -> None:
+        """Release engine-held resources."""
+        ...
+
+    def get_sample(self, normalize_columns: Optional[bool] = None) -> pl.DataFrame:
+        """Return a sample of the data as a Polars DataFrame."""
+        ...
+
+    def to_dataframe(self, normalize_columns: Optional[bool] = None) -> pl.DataFrame:
+        """Convert the full CSV to a Polars DataFrame."""
+        ...
+
+    def to_arrow_table(self, normalize_columns: Optional[bool] = None) -> pa.Table:
+        """Convert the full CSV to a PyArrow table."""
+        ...
+
+    def to_dicts(self, normalize_columns: Optional[bool] = None) -> List[Dict]:
+        """Convert the full CSV to a list of row dicts."""
+        ...
+
+    def query_data(
+        self, sql_query: str, normalize_columns: Optional[bool] = None
+    ) -> Union[DuckDBPyRelation, pl.DataFrame]:
+        """Run SQL against the imported CSV."""
+        ...
+
+
+@runtime_checkable
+class CSVWriterEngineProtocol(Protocol):
+    """Structural interface every CSV writer engine must satisfy."""
+
+    filepath: Path
+    lenient: bool
+    normalize_columns: bool
+    db_table: str
+
+    @property
+    def queries(self):
+        """DuckDB query helper bound to this writer's source file."""
+        ...
+
+    def write_csv(self, export_filename=None, normalize_columns=None) -> None:
+        """Export to CSV."""
+        ...
+
+    def write_excel(self, export_filename=None, normalize_columns=None) -> None:
+        """Export to Excel."""
+        ...
+
+    def write_json(self, export_filename=None, normalize_columns=None) -> None:
+        """Export to JSON."""
+        ...
+
+    def write_json_newline_delimited(self, export_filename=None, normalize_columns=None) -> None:
+        """Export to JSON Lines."""
+        ...
+
+    def write_parquet(self, export_filename=None, normalize_columns=None) -> None:
+        """Export to Parquet."""
+        ...
+
+
+class DataFrameDerivedReaderMixin:
+    """Default Arrow/dict conversions for engines centered on Polars DataFrames."""
+
+    def to_arrow_table(self, normalize_columns=None):
+        return self.to_dataframe(normalize_columns).to_arrow()
+
+    def to_dicts(self, normalize_columns=None):
+        return self.to_dataframe(normalize_columns).to_dicts()

--- a/tests/core_tests/csv_io_tests/test_protocol.py
+++ b/tests/core_tests/csv_io_tests/test_protocol.py
@@ -1,0 +1,88 @@
+"""Tests that CSV engines satisfy the shared reader/writer protocol."""
+
+import polars as pl
+import pyarrow as pa
+import pytest
+
+from datagrunt.core.csv_io.factories import CSVEngineFactory
+from datagrunt.core.csv_io.protocol import (
+    CSVReaderEngineProtocol,
+    CSVWriterEngineProtocol,
+    arrow_to_polars,
+    resolve_normalize_columns,
+)
+
+ALL_ENGINES = ("duckdb", "polars", "pyarrow")
+
+READER_METHODS = (
+    "get_sample",
+    "to_dataframe",
+    "to_arrow_table",
+    "to_dicts",
+    "query_data",
+    "close",
+)
+
+WRITER_METHODS = (
+    "write_csv",
+    "write_excel",
+    "write_json",
+    "write_json_newline_delimited",
+    "write_parquet",
+)
+
+READER_ATTRIBUTES = ("filepath", "lenient", "normalize_columns", "queries", "db_table", "delimiter")
+
+
+class TestNormalizeColumnHelpers:
+    def test_resolve_inherits_instance_default(self):
+        assert resolve_normalize_columns(True, None) is True
+        assert resolve_normalize_columns(False, None) is False
+
+    def test_resolve_per_call_overrides_instance_default(self):
+        assert resolve_normalize_columns(False, True) is True
+        assert resolve_normalize_columns(True, False) is False
+
+    def test_arrow_to_polars_single_column_returns_dataframe(self):
+        table = pa.table({"value": ["42"]})
+        df = arrow_to_polars(table)
+        assert isinstance(df, pl.DataFrame)
+        assert df.shape == (1, 1)
+
+
+class TestReaderEngineProtocol:
+    @pytest.mark.parametrize("engine", ALL_ENGINES)
+    def test_factory_reader_is_protocol_instance(self, sample_csv, engine):
+        reader = CSVEngineFactory(sample_csv, engine).create_reader()
+        assert isinstance(reader, CSVReaderEngineProtocol)
+
+    @pytest.mark.parametrize("engine", ALL_ENGINES)
+    def test_reader_exposes_required_attributes(self, sample_csv, engine):
+        reader = CSVEngineFactory(sample_csv, engine).create_reader()
+        for attr in READER_ATTRIBUTES:
+            assert hasattr(reader, attr), f"{engine} missing {attr}"
+
+    @pytest.mark.parametrize("engine", ALL_ENGINES)
+    def test_reader_exposes_required_methods(self, sample_csv, engine):
+        reader = CSVEngineFactory(sample_csv, engine).create_reader()
+        for method in READER_METHODS:
+            assert callable(getattr(reader, method)), f"{engine} missing {method}"
+
+
+class TestWriterEngineProtocol:
+    @pytest.mark.parametrize("engine", ALL_ENGINES)
+    def test_factory_writer_is_protocol_instance(self, sample_csv, engine):
+        writer = CSVEngineFactory(sample_csv, engine).create_writer()
+        assert isinstance(writer, CSVWriterEngineProtocol)
+
+    @pytest.mark.parametrize("engine", ALL_ENGINES)
+    def test_writer_exposes_required_attributes(self, sample_csv, engine):
+        writer = CSVEngineFactory(sample_csv, engine).create_writer()
+        for attr in ("filepath", "lenient", "normalize_columns", "queries", "db_table"):
+            assert hasattr(writer, attr), f"{engine} missing {attr}"
+
+    @pytest.mark.parametrize("engine", ALL_ENGINES)
+    def test_writer_exposes_required_methods(self, sample_csv, engine):
+        writer = CSVEngineFactory(sample_csv, engine).create_writer()
+        for method in WRITER_METHODS:
+            assert callable(getattr(writer, method)), f"{engine} missing {method}"


### PR DESCRIPTION
## Summary
- Add `CSVReaderEngineProtocol` and `CSVWriterEngineProtocol` in `csv_io/protocol.py`, with shared helpers and a `DataFrameDerivedReaderMixin` for Polars reader conversions.
- Refactor `engines.py` to use the protocol module and deduplicate Polars `to_dicts` / `to_arrow_table` via the mixin.

## Test plan
- [x] `pytest tests/core_tests/csv_io_tests/test_protocol.py`
- [x] `pytest tests/core_tests/csv_io_tests/` (137 passed)
- [x] Full suite: `pytest tests/` (982 passed)


Made with [Cursor](https://cursor.com)