### PR TITLE
perf: precompute PDF page median and cache PyArrow writer table

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -899,6 +899,21 @@ class CSVReaderPyArrowEngine(_PyArrowEngineMixin, CSVBaseReaderEngine):
 class CSVWriterPyArrowEngine(_PyArrowEngineMixin, CSVBaseWriterEngine):
     """Class to write CSVs to other file formats powered by PyArrow."""
 
+    def __init__(self, filepath, lenient=False, normalize_columns=False):
+        super().__init__(filepath, lenient=lenient, normalize_columns=normalize_columns)
+        # Cache the parsed table per resolved normalize_columns value so that
+        # exporting one instance to several formats parses the source once.
+        # PyArrow tables are immutable and writes never mutate them, so the same
+        # table is safely shared across export formats (mirrors the Polars
+        # writer's _frame_cache).
+        self._table_cache = {}
+
+    def _table(self, normalize_columns):
+        """Return the parsed PyArrow table, reading the source once per mode."""
+        if normalize_columns not in self._table_cache:
+            self._table_cache[normalize_columns] = self._create_table(normalize_columns)
+        return self._table_cache[normalize_columns]
+
     def _create_table(self, normalize_columns=False):
         """Create a PyArrow table for writing operations (all columns as string)."""
         columns = CSVColumns(self.filepath, delimiter=self.queries.delimiter).columns
@@ -946,7 +961,7 @@ class CSVWriterPyArrowEngine(_PyArrowEngineMixin, CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.csv_export_filename, export_filename)
-        table = self._create_table(normalize_columns)
+        table = self._table(normalize_columns)
         # Use native PyArrow CSV writer - no dataframe conversion needed
         pacsv.write_csv(table, filename)
 
@@ -961,7 +976,7 @@ class CSVWriterPyArrowEngine(_PyArrowEngineMixin, CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.excel_export_filename, export_filename)
-        table = self._create_table(normalize_columns)
+        table = self._table(normalize_columns)
         _arrow_to_polars(table).write_excel(filename)
 
     def write_json(self, export_filename=None, normalize_columns=None):
@@ -975,7 +990,7 @@ class CSVWriterPyArrowEngine(_PyArrowEngineMixin, CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_export_filename, export_filename)
-        table = self._create_table(normalize_columns)
+        table = self._table(normalize_columns)
         # to_pylist does the Arrow->Python conversion in C, producing the same
         # list-of-dicts the per-row loop built, without the Python-level scan.
         with open(filename, "w") as f:
@@ -992,7 +1007,7 @@ class CSVWriterPyArrowEngine(_PyArrowEngineMixin, CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_newline_export_filename, export_filename)
-        table = self._create_table(normalize_columns)
+        table = self._table(normalize_columns)
         # Convert per record batch (C-level) instead of cell-by-cell in Python,
         # while still streaming one line at a time to keep memory bounded.
         with open(filename, "w") as f:
@@ -1011,6 +1026,6 @@ class CSVWriterPyArrowEngine(_PyArrowEngineMixin, CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.parquet_export_filename, export_filename)
-        table = self._create_table(normalize_columns)
+        table = self._table(normalize_columns)
         # Use native PyArrow Parquet writer - no dataframe conversion needed
         pq.write_table(table, filename)

--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -6,7 +6,7 @@ from datagrunt.core.pdf_io.extraction.base import ExtractionBackend
 from datagrunt.core.pdf_io.extraction.ocr import ocr_data_to_blocks
 from datagrunt.core.pdf_io.extraction.pdfium_document import ENCRYPTED_PDF_MESSAGE
 from datagrunt.core.pdf_io.extraction.shapes import BBox, ImageBlock, PageAnalysis, TextBlock
-from datagrunt.core.pdf_io.extraction.text_block_builder import classify_font_size
+from datagrunt.core.pdf_io.extraction.text_block_builder import classify_by_median, page_median_size
 
 logger = logging.getLogger(__name__)
 
@@ -118,9 +118,10 @@ class PyMuPDFBackend(ExtractionBackend):
                 for span in line.get("spans", [])
                 if span["text"].strip()
             ]
+            median_size = page_median_size(all_sizes)
             blocks = []
             for order, block in enumerate(raw_blocks):
-                tb = self._build_block(block, all_sizes, order)
+                tb = self._build_block(block, median_size, order)
                 if tb is not None:
                     blocks.append(tb)
             return blocks
@@ -128,7 +129,7 @@ class PyMuPDFBackend(ExtractionBackend):
             if should_close:
                 doc.close()
 
-    def _build_block(self, block: dict, all_sizes: list, order: int):
+    def _build_block(self, block: dict, median_size, order: int):
         """Reduce one pymupdf block dict to a TextBlock (or None if empty)."""
         texts, fonts, sizes, bolds, italics = [], [], [], [], []
         for line in block.get("lines", []):
@@ -153,7 +154,7 @@ class PyMuPDFBackend(ExtractionBackend):
             font_size=round(dominant_size, 1),
             is_bold=is_bold,
             is_italic=any(italics),
-            classification=classify_font_size(round(dominant_size, 1), is_bold, all_sizes),
+            classification=classify_by_median(round(dominant_size, 1), median_size),
             reading_order=order,
         )
 

--- a/src/datagrunt/core/pdf_io/extraction/text_block_builder.py
+++ b/src/datagrunt/core/pdf_io/extraction/text_block_builder.py
@@ -18,10 +18,10 @@ LIST_MARKER_REGEX = re.compile(
 )
 
 
-def page_median_size(all_sizes: list):
+def page_median_size(all_sizes: list) -> float | None:
     """Median font size for a page (legacy formula), or None if no sizes.
 
-    Uses ``sorted(all_sizes)[len // 2]`` rather than ``statistics.median`` to
+    Uses ``sorted(all_sizes)[len(all_sizes) // 2]`` rather than ``statistics.median`` to
     preserve exact parity with the original classifier (and the Rust port):
     for even-length inputs this picks the upper-middle element, it does NOT
     average the two middle values.

--- a/src/datagrunt/core/pdf_io/extraction/text_block_builder.py
+++ b/src/datagrunt/core/pdf_io/extraction/text_block_builder.py
@@ -18,14 +18,26 @@ LIST_MARKER_REGEX = re.compile(
 )
 
 
-def classify_font_size(font_size: float, is_bold: bool, all_sizes: list) -> str:
-    """Classify a block by font size relative to the page's size distribution.
+def page_median_size(all_sizes: list):
+    """Median font size for a page (legacy formula), or None if no sizes.
+
+    Uses ``sorted(all_sizes)[len // 2]`` rather than ``statistics.median`` to
+    preserve exact parity with the original classifier (and the Rust port):
+    for even-length inputs this picks the upper-middle element, it does NOT
+    average the two middle values.
+    """
+    if not all_sizes:
+        return None
+    return sorted(all_sizes)[len(all_sizes) // 2]
+
+
+def classify_by_median(font_size: float, median_size) -> str:
+    """Classify a block by font size relative to a precomputed page median.
 
     Ported from the original ``extractors._classify_block`` (identical thresholds).
     """
-    if not all_sizes:
+    if median_size is None:
         return "body_text"
-    median_size = sorted(all_sizes)[len(all_sizes) // 2]
     if font_size >= median_size * 1.6:
         return "header"
     if font_size >= median_size * 1.2:
@@ -33,6 +45,17 @@ def classify_font_size(font_size: float, is_bold: bool, all_sizes: list) -> str:
     if font_size < median_size * 0.85:
         return "caption"
     return "body_text"
+
+
+def classify_font_size(font_size: float, is_bold: bool, all_sizes: list) -> str:
+    """Classify a block by font size relative to the page's size distribution.
+
+    Back-compat wrapper retained for callers that pass the raw size list; the
+    hot extraction paths precompute the median once via ``page_median_size``
+    and call ``classify_by_median`` directly. ``is_bold`` is accepted for
+    signature compatibility and not used in the thresholds.
+    """
+    return classify_by_median(font_size, page_median_size(all_sizes))
 
 
 class TextBlockBuilder:
@@ -48,29 +71,30 @@ class TextBlockBuilder:
 
     def build(self, items: list) -> list:
         """Return a list of classified ``TextBlock`` from raw ``TextItem`` list.
-        
+
         Processes the items in reading order, identifying column layouts to prevent bleed-over.
         """
         if not items:
             return []
-            
+
         sorter = PageLayoutSorter(TextItemAdapter())
         segments = sorter.partition(items)
         all_blocks = []
         all_sizes = [it.size for it in items if it.text]
-        
+        median_size = page_median_size(all_sizes)
+
         order = 0
         for seg_items in segments:
             if not seg_items:
                 continue
             lines = self._cluster_into_lines(seg_items)
             merged = self._merge_lines(lines)
-            blocks = self._finalize(merged, all_sizes)
+            blocks = self._finalize(merged, median_size)
             for b in blocks:
                 b.reading_order = order
                 order += 1
             all_blocks.extend(blocks)
-            
+
         return all_blocks
 
     def _cluster_into_lines(self, items: list) -> list:
@@ -159,7 +183,7 @@ class TextBlockBuilder:
         prev["bold"] = prev["bold"] or ln["bold"]
         prev["italic"] = prev["italic"] or ln["italic"]
 
-    def _finalize(self, merged: list, all_sizes: list) -> list:
+    def _finalize(self, merged: list, median_size) -> list:
         """Convert merged line records into classified ``TextBlock`` objects."""
         blocks = []
         order = 0
@@ -174,7 +198,7 @@ class TextBlockBuilder:
                     font_size=round(b["size"], 1),
                     is_bold=b["bold"],
                     is_italic=b["italic"],
-                    classification=classify_font_size(round(b["size"], 1), b["bold"], all_sizes),
+                    classification=classify_by_median(round(b["size"], 1), median_size),
                     reading_order=order,
                 )
             )

--- a/tests/core_tests/csv_io_tests/test_pyarrow_writer_cache.py
+++ b/tests/core_tests/csv_io_tests/test_pyarrow_writer_cache.py
@@ -1,0 +1,46 @@
+"""The PyArrow writer parses the source once across multiple exports."""
+
+from datagrunt.core.csv_io.engines import CSVWriterPyArrowEngine
+
+
+def test_pyarrow_writer_parses_once_across_formats(tmp_path, monkeypatch):
+    src = tmp_path / "in.csv"
+    src.write_text("a,b\n1,2\n3,4\n")
+
+    engine = CSVWriterPyArrowEngine(str(src))
+
+    calls = {"n": 0}
+    original = engine._create_table
+
+    def counting_create_table(normalize_columns=False):
+        calls["n"] += 1
+        return original(normalize_columns)
+
+    monkeypatch.setattr(engine, "_create_table", counting_create_table)
+
+    engine.write_csv(str(tmp_path / "out.csv"))
+    engine.write_json(str(tmp_path / "out.json"))
+    engine.write_parquet(str(tmp_path / "out.parquet"))
+
+    assert calls["n"] == 1  # source parsed once, not once per format
+
+
+def test_pyarrow_writer_caches_per_normalize_mode(tmp_path, monkeypatch):
+    src = tmp_path / "in.csv"
+    src.write_text("A B,C\n1,2\n")
+    engine = CSVWriterPyArrowEngine(str(src))
+
+    calls = {"n": 0}
+    original = engine._create_table
+
+    def counting_create_table(normalize_columns=False):
+        calls["n"] += 1
+        return original(normalize_columns)
+
+    monkeypatch.setattr(engine, "_create_table", counting_create_table)
+
+    engine.write_csv(str(tmp_path / "raw.csv"), normalize_columns=False)
+    engine.write_csv(str(tmp_path / "norm.csv"), normalize_columns=True)
+    engine.write_json(str(tmp_path / "norm.json"), normalize_columns=True)
+
+    assert calls["n"] == 2  # one build per distinct normalize_columns value

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_text_block_builder.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_text_block_builder.py
@@ -1,7 +1,12 @@
 """Tests for TextBlockBuilder."""
 
 from datagrunt.core.pdf_io.extraction.shapes import TextItem
-from datagrunt.core.pdf_io.extraction.text_block_builder import TextBlockBuilder, classify_font_size
+from datagrunt.core.pdf_io.extraction.text_block_builder import (
+    TextBlockBuilder,
+    classify_font_size,
+    classify_by_median,
+    page_median_size,
+)
 
 
 def _item(text, y, size, x0=10.0):
@@ -37,19 +42,37 @@ def test_builder_column_extraction():
     # Right column items (y=100 and y=120)
     right1 = TextItem(text="right 1", x0=350, x1=450, y_top=100, y_bot=111, size=11.0, font="Arial", is_bold=False, is_italic=False)
     right2 = TextItem(text="right 2", x0=350, x1=450, y_top=120, y_bot=131, size=11.0, font="Arial", is_bold=False, is_italic=False)
-    
+
     # Pass them in non-sequential order
     items = [left2, right1, title, left1, right2]
-    
+
     blocks = TextBlockBuilder().build(items)
-    
+
     # We expect 3 blocks in exact reading order: Title -> Left Column (merged) -> Right Column (merged)
     assert len(blocks) == 3
     assert blocks[0].text == "Spanning Title"
     assert blocks[1].text == "left 1 left 2"
     assert blocks[2].text == "right 1 right 2"
-    
+
     # Check reading order indices
     assert blocks[0].reading_order == 0
     assert blocks[1].reading_order == 1
     assert blocks[2].reading_order == 2
+
+
+def test_page_median_size_matches_legacy_formula():
+    sizes = [10.0, 11.0, 12.0, 24.0]
+    # Legacy behavior: sorted(all_sizes)[len // 2] (NOT statistics.median).
+    assert page_median_size(sizes) == 12.0
+    assert page_median_size([]) is None
+
+
+def test_classify_by_median_equivalent_to_classify_font_size():
+    sizes = [10.0, 11.0, 11.0, 12.0, 24.0]
+    median = page_median_size(sizes)
+    for fs in (8.0, 11.0, 14.0, 24.0):
+        assert classify_by_median(fs, median) == classify_font_size(fs, False, sizes)
+
+
+def test_classify_by_median_empty_is_body_text():
+    assert classify_by_median(24.0, None) == "body_text"


### PR DESCRIPTION
Two pure-internal performance optimizations from an optimization review. No public-API or output change; behavior identical before/after.

## Changes

**1. PDF: precompute page median font size once per page** (`eed5add`)
`classify_font_size` re-sorted the page's font-size list on every text block (O(blocks × n log n) for a page-constant value). Now the median is computed once and threaded into classification at both call sites (`TextBlockBuilder._finalize`, `PyMuPDFBackend._build_block`). The public `classify_font_size(font_size, is_bold, all_sizes)` is retained as a thin back-compat wrapper. The median formula is preserved byte-for-byte (`sorted(all_sizes)[len(all_sizes) // 2]`, **not** `statistics.median`) to keep Rust parity intact.

**2. CSV: cache parsed table in PyArrow writer across exports** (`86ca012`)
`CSVWriterPyArrowEngine` re-ran `_create_table` on every `write_*`, re-parsing the source once per format. Added a `_table_cache` keyed on resolved `normalize_columns`, mirroring `CSVWriterPolarsEngine._frame_cache`, so multi-format export from one instance parses the source once. PyArrow tables are immutable and no `write_*` path mutates the table, so the shared cache is safe.

**3. Style follow-up** (`4bf8143`)
Added `-> float | None` return annotation and corrected a docstring formula snippet on the now-public `page_median_size`.

## Testing
- 355 CSV + PDF tests passing (incl. seeded backend parity tests).
- New: `test_text_block_builder.py` median/equivalence tests; `test_pyarrow_writer_cache.py` parse-once + per-normalize-mode tests.

## Review
Implemented via subagent-driven development with per-task spec+quality reviews and a final whole-branch review (verdict: ready to merge, no Critical/Important findings).

Closes #202
(Supersedes #203, which auto-closed when the branch was renamed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)