### PR TITLE
perf(pdf): single-pass per-page extraction (extract_page)

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/base.py
+++ b/src/datagrunt/core/pdf_io/extraction/base.py
@@ -51,3 +51,22 @@ class ExtractionBackend(ABC):
     @abstractmethod
     def ocr_page(self, page_number: int, dpi: int = 300) -> list[OcrBlock]:
         """Return OCR-recovered text lines for the page."""
+
+    def extract_page(
+        self, page_number: int, output_dir: str = None, name_prefix: str = "page"
+    ) -> tuple:
+        """Single-pass extraction: ``(PageAnalysis, list[TextBlock], list[ImageBlock])``.
+
+        Default implementation calls the three primitives separately; concrete
+        backends may override to parse the page once. The skip logic mirrors the
+        assembly pipeline: text blocks only when a text layer exists, images only
+        when the page reports embedded images. OCR is never performed here.
+        """
+        analysis = self.analyze_page(page_number)
+        text_blocks = self.extract_text_blocks(page_number) if analysis.has_text_layer else []
+        images = (
+            self.extract_images(page_number, output_dir=output_dir, name_prefix=name_prefix)
+            if analysis.image_count > 0
+            else []
+        )
+        return analysis, text_blocks, images

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
@@ -60,6 +60,44 @@ class PdfiumBackend(ExtractionBackend):
             if should_close:
                 doc.close()
 
+    def extract_page(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> tuple:
+        """Parse the page once (single pdfium page/textpage open), returning
+        analysis + text blocks + images, instead of opening the page three times.
+        """
+        doc, should_close = self._get_doc()
+        try:
+            with doc.page(page_number) as page:
+                width, height = page.size()
+                text = page.full_text().strip()
+                text_objs, image_objs = page.count_objects()
+                has_text = len(text) > 0
+                analysis = PageAnalysis(
+                    width=float(width),
+                    height=float(height),
+                    rotation=page.rotation(),
+                    has_text_layer=has_text,
+                    is_scanned=(not has_text and image_objs > 0),
+                    text_block_count=text_objs,
+                    image_count=image_objs,
+                    image_block_count=image_objs,
+                    has_line_drawings=page.has_paths(),
+                    text_length=len(text),
+                )
+                text_blocks = []
+                if has_text:
+                    text_blocks = TextBlockBuilder().build(list(page.text_items()))
+                images = []
+                if image_objs > 0:
+                    images = list(
+                        page.image_items(
+                            output_dir=output_dir, name_prefix=name_prefix, page_number=page_number
+                        )
+                    )
+                return analysis, text_blocks, images
+        finally:
+            if should_close:
+                doc.close()
+
     def extract_text_blocks(self, page_number: int) -> list:
         """Return classified text blocks built from pdfium text objects."""
         doc, should_close = self._get_doc()

--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -158,36 +158,104 @@ class PyMuPDFBackend(ExtractionBackend):
             reading_order=order,
         )
 
+    def extract_page(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> tuple:
+        """Parse the page once, returning analysis + text blocks + images.
+
+        Shares a single ``get_text("dict", sort=True)`` and a single
+        ``get_images()`` between analysis and extraction. Block/image counts are
+        sort-order independent, so the sorted dict yields the same counts the
+        unsorted ``analyze_page`` produced. ``get_text("text")`` is retained for
+        ``has_text_layer``/``text_length`` to keep parity byte-identical.
+        """
+        doc, should_close = self._get_doc()
+        try:
+            if page_number < 0 or page_number >= doc.page_count:
+                raise ValueError(f"Page {page_number} out of range")
+            page = doc[page_number]
+            data = page.get_text("dict", sort=True)
+            raw_blocks = data["blocks"]
+            text_block_dicts = [b for b in raw_blocks if b.get("type") == 0]
+            image_block_dicts = [b for b in raw_blocks if b.get("type") == 1]
+            text = page.get_text("text").strip()
+            has_text = len(text) > 0
+            image_list = page.get_images()
+            drawings = page.get_drawings()
+            has_lines = any(item[0] in ("l", "re") for d in drawings for item in d.get("items", []))
+            analysis = PageAnalysis(
+                width=page.rect.width,
+                height=page.rect.height,
+                rotation=page.rotation,
+                has_text_layer=has_text,
+                is_scanned=(not has_text and len(image_list) > 0),
+                text_block_count=len(text_block_dicts),
+                image_count=len(image_list),
+                image_block_count=len(image_block_dicts),
+                has_line_drawings=has_lines,
+                text_length=len(text),
+            )
+            text_blocks = []
+            if has_text:
+                all_sizes = [
+                    span["size"]
+                    for block in text_block_dicts
+                    for line in block.get("lines", [])
+                    for span in line.get("spans", [])
+                    if span["text"].strip()
+                ]
+                median_size = page_median_size(all_sizes)
+                for order, block in enumerate(text_block_dicts):
+                    tb = self._build_block(block, median_size, order)
+                    if tb is not None:
+                        text_blocks.append(tb)
+            images = []
+            if analysis.image_count > 0:
+                images = self._images_from_page(
+                    doc, page, image_list, output_dir, name_prefix, page_number
+                )
+            return analysis, text_blocks, images
+        finally:
+            if should_close:
+                doc.close()
+
     def extract_images(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> list:
         """Return embedded images (ported from extractors.extract_images)."""
-        import os
-
         doc, should_close = self._get_doc()
         try:
             if page_number < 0 or page_number >= doc.page_count:
                 return []
-            if output_dir:
-                os.makedirs(output_dir, exist_ok=True)
             page = doc[page_number]
-            image_list = page.get_images()
-            results = []
-            # ``get_images()`` lists images in resource (xref) order, which can
-            # differ from the content/display order. Resolve each image's bbox by
-            # its xref so positions never get swapped; track per-xref occurrences
-            # so an image drawn multiple times maps to the correct rect each time.
-            xref_occurrence = {}
-            for idx, img_info in enumerate(image_list):
-                xref = img_info[0]
-                occurrence = xref_occurrence.get(xref, 0)
-                xref_occurrence[xref] = occurrence + 1
-                bbox = self._resolve_image_bbox(page, xref, occurrence)
-                block = self._image_block(doc, img_info, idx, bbox, output_dir, name_prefix, page_number)
-                if block is not None:
-                    results.append(block)
-            return results
+            return self._images_from_page(
+                doc, page, page.get_images(), output_dir, name_prefix, page_number
+            )
         finally:
             if should_close:
                 doc.close()
+
+    def _images_from_page(self, doc, page, image_list, output_dir, name_prefix, page_number) -> list:
+        """Build ImageBlocks from an already-fetched ``page.get_images()`` list.
+
+        Shared by ``extract_images`` and ``extract_page`` so the image list is
+        enumerated once per page.
+        """
+        import os
+
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+        results = []
+        # ``get_images()`` lists images in resource (xref) order, which can
+        # differ from the content/display order. Resolve each image's bbox by
+        # its xref so positions never get swapped; track per-xref occurrences
+        # so an image drawn multiple times maps to the correct rect each time.
+        xref_occurrence = {}
+        for idx, img_info in enumerate(image_list):
+            xref = img_info[0]
+            occurrence = xref_occurrence.get(xref, 0)
+            xref_occurrence[xref] = occurrence + 1
+            bbox = self._resolve_image_bbox(page, xref, occurrence)
+            block = self._image_block(doc, img_info, idx, bbox, output_dir, name_prefix, page_number)
+            if block is not None:
+                results.append(block)
+        return results
 
     @staticmethod
     def _resolve_image_bbox(page, xref, occurrence) -> BBox:

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -46,7 +46,9 @@ class DocumentAssembler:
     def parse_page(self, page_index, image_output_dir=None) -> dict:
         """Parse a single page into the unified element schema."""
         with self.backend, self.table_extractor:
-            analysis = self.backend.analyze_page(page_index)
+            analysis, text_blocks, images = self.backend.extract_page(
+                page_index, output_dir=image_output_dir, name_prefix=self.filepath.stem
+            )
             elements = []
             counter = {"n": 1}
 
@@ -72,7 +74,7 @@ class DocumentAssembler:
 
             warnings = []
             if analysis.has_text_layer:
-                for block in self.backend.extract_text_blocks(page_index):
+                for block in text_blocks:
                     if not is_inside_table(block.bbox):
                         elements.append(self._text_element(block, gen_elem_id(), page_index))
             elif analysis.is_scanned:
@@ -93,11 +95,8 @@ class DocumentAssembler:
             for table in tables:
                 elements.append(self._table_element(table, gen_elem_id(), page_index))
 
-            if analysis.image_count > 0:
-                for img in self.backend.extract_images(
-                    page_index, output_dir=image_output_dir, name_prefix=self.filepath.stem
-                ):
-                    elements.append(self._image_element(img, gen_elem_id(), page_index))
+            for img in images:
+                elements.append(self._image_element(img, gen_elem_id(), page_index))
 
             classification = "mixed"
             if analysis.is_scanned:

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_base.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_base.py
@@ -19,3 +19,25 @@ def test_missing_file_raises(tmp_path):
 
     with pytest.raises(FileNotFoundError):
         Dummy(tmp_path / "nope.pdf")
+
+
+def test_extract_page_default_delegates_and_honors_skip_logic(sample_pdf):
+    """The base default extract_page returns the same triple parse_page assembled
+    from the three primitives, skipping text when no text layer and images when none."""
+    from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
+
+    backend = PyMuPDFBackend(sample_pdf)
+    with backend:
+        analysis, text_blocks, images = ExtractionBackend.extract_page(backend, 0)
+        # Compare against the primitives called directly.
+        expected_analysis = backend.analyze_page(0)
+        expected_text = backend.extract_text_blocks(0) if expected_analysis.has_text_layer else []
+        expected_images = (
+            backend.extract_images(0) if expected_analysis.image_count > 0 else []
+        )
+
+    assert analysis == expected_analysis
+    assert text_blocks == expected_text
+    assert images == expected_images
+    assert text_blocks  # sample_pdf has a text layer
+    assert images       # sample_pdf has an embedded image

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_backend.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_backend.py
@@ -33,3 +33,33 @@ class TestPdfiumBackend:
     def test_missing_file_raises(self):
         with pytest.raises(FileNotFoundError):
             PdfiumBackend("nope.pdf")
+
+    def test_pdfium_extract_page_matches_primitives(self, sample_pdf):
+        """Single-pass extract_page returns the same analysis/text/images as the
+        three primitives called separately."""
+        backend = PdfiumBackend(sample_pdf)
+        with backend:
+            analysis, text_blocks, images = backend.extract_page(0)
+            assert analysis == backend.analyze_page(0)
+            assert text_blocks == backend.extract_text_blocks(0)
+            assert images == backend.extract_images(0)
+        assert text_blocks  # sample_pdf has a text layer
+
+    def test_pdfium_extract_page_opens_page_once(self, sample_pdf, monkeypatch):
+        """extract_page must open the pdfium page (and textpage) once, not three times."""
+        from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
+
+        count = {"n": 0}
+        orig_page = PdfiumDocument.page
+
+        def spy_page(self, page_number):
+            count["n"] += 1
+            return orig_page(self, page_number)
+
+        monkeypatch.setattr(PdfiumDocument, "page", spy_page)
+
+        backend = PdfiumBackend(sample_pdf)
+        with backend:
+            backend.extract_page(0)
+
+        assert count["n"] == 1

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pymupdf_backend.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pymupdf_backend.py
@@ -90,3 +90,45 @@ class TestPyMuPDFBackend:
         assert (round(blue.bbox.x, 1), round(blue.bbox.y, 1)) == blue_corner
         assert (round(green.bbox.x, 1), round(green.bbox.y, 1)) == green_corner
         assert all(im.bbox.w > 0 and im.bbox.h > 0 for im in images)
+
+
+def test_pymupdf_extract_page_matches_primitives(sample_pdf):
+    """Single-pass extract_page returns the same analysis/text/images as the
+    three primitives called separately."""
+    from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
+
+    backend = PyMuPDFBackend(sample_pdf)
+    with backend:
+        analysis, text_blocks, images = backend.extract_page(0)
+        assert analysis == backend.analyze_page(0)
+        assert text_blocks == backend.extract_text_blocks(0)
+        assert images == backend.extract_images(0)
+    assert text_blocks and images  # sanity: sample_pdf has both
+
+
+def test_pymupdf_extract_page_parses_page_once(sample_pdf, monkeypatch):
+    """extract_page must not re-parse: at most two get_text calls (dict + text)
+    and exactly one get_images call, versus three/two in the old path."""
+    import pymupdf
+    from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
+
+    counts = {"get_text": 0, "get_images": 0}
+    orig_text, orig_images = pymupdf.Page.get_text, pymupdf.Page.get_images
+
+    def spy_text(self, *a, **k):
+        counts["get_text"] += 1
+        return orig_text(self, *a, **k)
+
+    def spy_images(self, *a, **k):
+        counts["get_images"] += 1
+        return orig_images(self, *a, **k)
+
+    monkeypatch.setattr(pymupdf.Page, "get_text", spy_text)
+    monkeypatch.setattr(pymupdf.Page, "get_images", spy_images)
+
+    backend = PyMuPDFBackend(sample_pdf)
+    with backend:
+        backend.extract_page(0)
+
+    assert counts["get_text"] <= 2
+    assert counts["get_images"] == 1


### PR DESCRIPTION
Removes redundant per-page backend parsing by introducing a single-pass `extract_page()` that returns `(PageAnalysis, list[TextBlock], list[ImageBlock])` in one page scope. Output is byte-for-byte identical to the previous three-call path; the seeded backend parity harness and full PDF suite stay green.

## Changes

**1. `extract_page` seam** (`b867a8b`)
Add a concrete `ExtractionBackend.extract_page` whose default delegates to the three primitives (`analyze_page` / `extract_text_blocks` / `extract_images`) using parse_page's exact skip logic (text only if `has_text_layer`, images only if `image_count > 0`, never OCR). `DocumentAssembler.parse_page` now calls it. Behavior identical — the seam enables the per-backend overrides below. The three primitives remain as the wrappers tests and the parity oracle use.

**2. PyMuPDF single-pass override** (`17a3c5b`)
Share one `get_text("dict", sort=True)` and one `get_images()` across analysis and extraction (counts are sort-order independent; `get_text("text")` retained for `has_text_layer`/`text_length` so parity stays byte-identical). Eliminates the duplicate dict parse and image enumeration per page. `extract_images` now shares a new `_images_from_page` helper.

**3. PDFium single-pass override** (`ea13ecd`)
Open the pdfium page (and its textpage) once and run analysis + text-item + image-item extraction in one scope, instead of three separate page opens per page.

## Testing
- 689 PDF + parity tests passing.
- Each backend has an equivalence test (`extract_page` output `==` the three primitives, via dataclass `__eq__`) and a call-count regression guard (`parses_page_once` / `opens_page_once`).

## Review
Implemented via subagent-driven development: per-task spec+quality reviews and a final whole-branch review on Opus (verdict: ready to merge, no Critical/Important findings).

Possible non-blocking follow-ups (noted by review): a small typing sweep (`-> tuple[...]`, `Optional[str]`) and a direct skip-branch assertion on `extract_page`.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)