### PR TITLE
perf(csv): DuckDB connection reuse for reads and multi-format writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,18 +96,22 @@ df = dg.query_data(query).pl()
 print(df)
 ```
 
-With the DuckDB engine, repeated `query_data()` calls on the same reader reuse
-a single import: the CSV is loaded into DuckDB once per reader instance, so
-follow-up queries skip the file import entirely and run dramatically faster.
+With the DuckDB engine, datagrunt imports the CSV once per reader or writer and
+reuses it: repeated reads (`to_dataframe`, `to_arrow_table`, `get_sample`),
+`query_data` calls, and multi-format exports (`write_csv` + `write_excel` +
+`write_json` + `write_parquet`) all skip re-importing the file, so follow-up
+operations run dramatically faster.
 
-Because that reuse keeps a DuckDB connection open, hold the reader in a `with`
-block (or call `reader.close()`) to release it deterministically when you are
-done. The reader stays usable afterward — a later call transparently reopens:
+You never have to manage this — the connection is released automatically when the
+reader or writer is garbage-collected. If you want to release it *early* (for
+example, to free memory deterministically in a long-running process), use the
+reader as a context manager or call `close()`; this is optional and the object
+stays usable afterward:
 
 ```python
 with CSVReader('vehicles.csv', engine='duckdb') as dg:
     df = dg.query_data(f"SELECT city, COUNT(*) FROM {dg.db_table} GROUP BY 1").pl()
-# connection is closed here, even if the block raises
+# connection released here, even if the block raises
 ```
 
 ### Consistent Column Names with `normalize_columns`

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ reuses it: repeated reads (`to_dataframe`, `to_arrow_table`, `get_sample`),
 operations run dramatically faster.
 
 You never have to manage this — the connection is released automatically when the
-reader or writer is garbage-collected. If you want to release it *early* (for
+reader or writer goes out of scope (its connection is reference-counted). If you
+want to release it *early* (for
 example, to free memory deterministically in a long-running process), use the
 reader as a context manager or call `close()`; this is optional and the object
 stays usable afterward:

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -266,8 +266,9 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         # The engine is cached on the CSVReader, so the streaming-sample
-        # connection is reused by later reads and released when the reader is
-        # collected (or via the optional close()/`with`). datagrunt manages this.
+        # connection is reused by later reads and released when the reader goes
+        # out of scope (its connection is reference-counted), or earlier via the
+        # optional close()/`with`. datagrunt manages this; callers never must.
         return self.queries.sample_dataframe(
             CSVEngineProperties.dataframe_sample_rows,
             normalize_columns,
@@ -286,7 +287,8 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         # Keep the import alive on the cached engine so a follow-up read/query
-        # reuses it; released on GC (or the optional close()).
+        # reuses it; released when the reader goes out of scope (reference-counted),
+        # or earlier via the optional close().
         return self.queries.create_table(normalize_columns).pl()
 
     def to_arrow_table(self, normalize_columns=None):
@@ -302,7 +304,8 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         # Keep the import alive on the cached engine for follow-up reads/queries;
-        # released on GC (or the optional close()).
+        # released when the reader goes out of scope (reference-counted), or
+        # earlier via the optional close().
         result = self.queries.create_table(normalize_columns).arrow()
         if isinstance(result, pa.Table):
             return result
@@ -319,7 +322,8 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
         Returns:
             A list of dictionaries.
         """
-        # to_dataframe already materializes and closes; this is a thin wrapper.
+        # to_dataframe materializes the frame and keeps the import alive for
+        # reuse; this is a thin wrapper.
         return self.to_dataframe(normalize_columns).to_dicts()
 
     def _normalize_relation_columns(self, relation):

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -254,28 +254,14 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
     """
 
     def get_sample(self, normalize_columns=None):
-        """
-        Return a sample of the CSV file.
-
-        Args:
-            normalize_columns (bool or None): Whether to normalize column
-            names. ``None`` (default) inherits the instance-level setting.
-
-        Returns:
-            A Polars DataFrame containing the sample rows.
-        """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
-        # sample_dataframe streams the first rows (no full-table import) and
-        # returns a materialized Polars frame, so the per-call connection can
-        # be released deterministically rather than waiting on garbage
-        # collection.
-        try:
-            return self.queries.sample_dataframe(
-                CSVEngineProperties.dataframe_sample_rows,
-                normalize_columns,
-            )
-        finally:
-            self.queries.close()
+        # The engine is cached on the CSVReader, so the streaming-sample
+        # connection is reused by later reads and released when the reader is
+        # collected (or via the optional close()/`with`). datagrunt manages this.
+        return self.queries.sample_dataframe(
+            CSVEngineProperties.dataframe_sample_rows,
+            normalize_columns,
+        )
 
     def to_dataframe(self, normalize_columns=None):
         """
@@ -289,11 +275,9 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
             A Polars dataframe.
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
-        # Materialize fully (.pl()) before closing the per-call connection.
-        try:
-            return self.queries.create_table(normalize_columns).pl()
-        finally:
-            self.queries.close()
+        # Keep the import alive on the cached engine so a follow-up read/query
+        # reuses it; released on GC (or the optional close()).
+        return self.queries.create_table(normalize_columns).pl()
 
     def to_arrow_table(self, normalize_columns=None):
         """
@@ -307,14 +291,12 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
             A PyArrow table.
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
-        # Materialize into an in-memory pa.Table before closing the connection.
-        try:
-            result = self.queries.create_table(normalize_columns).arrow()
-            if isinstance(result, pa.Table):
-                return result
-            return result.read_all()
-        finally:
-            self.queries.close()
+        # Keep the import alive on the cached engine for follow-up reads/queries;
+        # released on GC (or the optional close()).
+        result = self.queries.create_table(normalize_columns).arrow()
+        if isinstance(result, pa.Table):
+            return result
+        return result.read_all()
 
     def to_dicts(self, normalize_columns=None):
         """

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -495,13 +495,10 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.csv_export_filename, export_filename)
-        # COPY executes eagerly on .sql(), so the file is written before close()
-        # releases the per-call connection.
-        try:
-            self.queries.create_table(normalize_columns)
-            self.queries.connection.sql(self.queries.export_csv_query(filename))
-        finally:
-            self.queries.close()
+        # COPY executes eagerly on .sql(); the import stays on the cached engine
+        # so multi-format export reuses it (released on GC, not per call).
+        self.queries.create_table(normalize_columns)
+        self.queries.connection.sql(self.queries.export_csv_query(filename))
 
     def write_excel(self, export_filename=None, normalize_columns=None):
         """
@@ -514,12 +511,9 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.excel_export_filename, export_filename)
-        try:
-            self.queries.create_table(normalize_columns)
-            self.queries.load_spatial_extension(self.queries.connection)
-            self.queries.connection.sql(self.queries.export_excel_query(filename))
-        finally:
-            self.queries.close()
+        self.queries.create_table(normalize_columns)
+        self.queries.load_spatial_extension(self.queries.connection)
+        self.queries.connection.sql(self.queries.export_excel_query(filename))
 
     def write_json(self, export_filename=None, normalize_columns=None):
         """
@@ -532,11 +526,8 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_export_filename, export_filename)
-        try:
-            self.queries.create_table(normalize_columns)
-            self.queries.connection.sql(self.queries.export_json_query(filename))
-        finally:
-            self.queries.close()
+        self.queries.create_table(normalize_columns)
+        self.queries.connection.sql(self.queries.export_json_query(filename))
 
     def write_json_newline_delimited(self, export_filename=None, normalize_columns=None):
         """
@@ -549,11 +540,8 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.json_newline_export_filename, export_filename)
-        try:
-            self.queries.create_table(normalize_columns)
-            self.queries.connection.sql(self.queries.export_json_newline_delimited_query(filename))
-        finally:
-            self.queries.close()
+        self.queries.create_table(normalize_columns)
+        self.queries.connection.sql(self.queries.export_json_newline_delimited_query(filename))
 
     def write_parquet(self, export_filename=None, normalize_columns=None):
         """
@@ -566,11 +554,8 @@ class CSVWriterDuckDBEngine(CSVBaseWriterEngine):
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         filename = self.queries.set_export_filename(CSVEngineProperties.parquet_export_filename, export_filename)
-        try:
-            self.queries.create_table(normalize_columns)
-            self.queries.connection.sql(self.queries.export_parquet_query(filename))
-        finally:
-            self.queries.close()
+        self.queries.create_table(normalize_columns)
+        self.queries.connection.sql(self.queries.export_parquet_query(filename))
 
 
 class CSVWriterPolarsEngine(CSVBaseWriterEngine):

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -254,6 +254,16 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
     """
 
     def get_sample(self, normalize_columns=None):
+        """
+        Return a sample of the CSV as a Polars DataFrame.
+
+        Args:
+            normalize_columns (bool or None): Whether to normalize column
+            names. ``None`` (default) inherits the instance-level setting.
+
+        Returns:
+            A Polars DataFrame containing the sample rows.
+        """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         # The engine is cached on the CSVReader, so the streaming-sample
         # connection is reused by later reads and released when the reader is

--- a/src/datagrunt/csv_api/csvwriter.py
+++ b/src/datagrunt/csv_api/csvwriter.py
@@ -1,6 +1,7 @@
 """Module for writing CSV files and converting to different file formats."""
 
 # standard library
+from functools import cached_property
 from pathlib import Path
 
 # third party libraries
@@ -52,14 +53,26 @@ class CSVWriter(CSVComponents):
         self.engine = engine.lower().replace(" ", "")
         CSVEngineFactory.validate_engine(self.engine)
 
-    def _create_writer(self):
-        """Create a writer object."""
+    @cached_property
+    def _writer(self):
+        """Return this writer's engine, built once and reused.
+
+        Caching it means exporting one ``CSVWriter`` to several formats reuses a
+        single import instead of rebuilding the engine and re-importing the
+        source for every format. The engine owns the DuckDB connection; it is
+        released when the writer is garbage-collected. (Parallels
+        ``CSVReader._reader``; the two are unified in issue #209.)
+        """
         return CSVEngineFactory(
             self.filepath,
             self.engine,
             lenient=self.lenient,
             normalize_columns=self.normalize_columns,
         ).create_writer()
+
+    def _create_writer(self):
+        """Return this writer's cached engine (back-compat delegator)."""
+        return self._writer
 
     def _write_empty_output(self, default_filename, out_filename=None):
         """Write a truly empty output file for an empty/blank source.

--- a/src/datagrunt/csv_api/csvwriter.py
+++ b/src/datagrunt/csv_api/csvwriter.py
@@ -60,7 +60,8 @@ class CSVWriter(CSVComponents):
         Caching it means exporting one ``CSVWriter`` to several formats reuses a
         single import instead of rebuilding the engine and re-importing the
         source for every format. The engine owns the DuckDB connection; it is
-        released when the writer is garbage-collected. (Parallels
+        released when the writer goes out of scope (its connection is
+        reference-counted), or earlier via an explicit teardown. (Parallels
         ``CSVReader._reader``; the two are unified in issue #209.)
         """
         return CSVEngineFactory(

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -469,3 +469,25 @@ class TestCSVReaderContextManager:
             with CSVReader(self._csv(tmp_path), engine=engine) as reader:
                 df = reader.to_dataframe()
             assert len(df) == 2
+
+    def test_duckdb_mixed_reads_import_file_once(self, sample_csv, monkeypatch):
+        """to_dataframe + to_arrow_table + query_data on one DuckDB reader import once."""
+        from datagrunt.core.databases import DuckDBQueries
+
+        calls = {"n": 0}
+        original = DuckDBQueries.import_csv_query
+
+        def spy(self, *args, **kwargs):
+            calls["n"] += 1
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(DuckDBQueries, "import_csv_query", spy)
+
+        reader = CSVReader(sample_csv, engine="duckdb")
+        reader.to_dataframe()
+        # Connection stays open after a materializing read (no per-call close).
+        assert reader.__dict__["_reader"].queries._connection is not None
+        reader.to_arrow_table()
+        reader.query_data(f"SELECT * FROM {reader.db_table} LIMIT 1")
+
+        assert calls["n"] == 1

--- a/tests/csv_api_tests/test_csvwriter.py
+++ b/tests/csv_api_tests/test_csvwriter.py
@@ -195,3 +195,26 @@ class TestCSVWriter:
         new_timestamp = Path(out_file).stat().st_mtime
 
         assert new_timestamp > original_timestamp
+
+    def test_duckdb_writer_imports_once_across_formats(self, sample_csv, tmp_path, monkeypatch):
+        """Exporting one DuckDB CSVWriter to several formats imports the source once."""
+        from datagrunt.core import DuckDBQueries
+
+        calls = {"n": 0}
+        original = DuckDBQueries.import_csv_query
+
+        def spy(self, *args, **kwargs):
+            calls["n"] += 1
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(DuckDBQueries, "import_csv_query", spy)
+
+        writer = CSVWriter(sample_csv, engine="duckdb")
+        writer.write_csv(str(tmp_path / "out.csv"))
+        writer.write_json(str(tmp_path / "out.json"))
+        writer.write_parquet(str(tmp_path / "out.parquet"))
+
+        assert calls["n"] == 1
+        assert (tmp_path / "out.csv").exists()
+        assert (tmp_path / "out.json").exists()
+        assert (tmp_path / "out.parquet").exists()


### PR DESCRIPTION
Stops re-importing the CSV on every DuckDB operation. Multi-format exports from one `CSVWriter` and mixed materializing reads on one `CSVReader` now import the source **once** — with no user action required. Output is unchanged.

## Changes

**Reader (#208)** — `db044f7`
`CSVReaderDuckDBEngine.get_sample`/`to_dataframe`/`to_arrow_table` no longer close the connection in a per-call `finally`. The engine is already cached on `CSVReader` (issue #104), so `to_dataframe()` → `to_arrow_table()` → `query_data()` import once instead of three times.

**Writer (#207)** — `924d5a6`
`CSVWriter` now caches its engine (`cached_property _writer`, mirroring `CSVReader._reader`) and the five `CSVWriterDuckDBEngine.write_*` drop their per-call `close()`. Exporting one writer to CSV+Excel+JSON+Parquet imports once instead of four times.

**Docs** — `2caf149`, `a18dc62`
README documents that reuse covers reads, `query_data`, and multi-format writes. Lifecycle wording is precise: the connection is released when the reader/writer **goes out of scope (reference-counted)** — not via the cyclic GC — reconciled with the `DuckDBQueries.close()` docstring.

## Lifecycle principle
The user **never** has to call `.close()`. Reuse and cleanup are automatic. `close()` / `with` remain optional power-user tools for *early* deterministic release (reader has them today).

## Scope
Deliberately minimal. The engine-lifecycle DRY unification across `CSVReader`/`CSVWriter` (and the parallel PDF API) is tracked separately in **#209** and intentionally not done here — the writer's `_writer`/`_create_writer` parallels the reader's for now so #209 can collapse them cleanly.

## Testing
- 233 CSV / engine / database tests passing.
- New behavioral spies on `DuckDBQueries.import_csv_query` assert exactly one import across mixed reads and across multi-format writes.
- Dispose paths untouched: polars/pyarrow `query_data` still dispose; DuckDB `query_data` still returns a live relation. `test_query_data_disposes_connection_on_materializing_engines` unaffected.

## Review
Subagent-driven: per-task spec+quality reviews and a final whole-branch review on Opus (one Important doc-contradiction finding, fixed in `a18dc62`).

Closes #207
Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)