### PR TITLE
refactor(csv): DRY engine-lifecycle within the CSV domain

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -78,24 +78,20 @@ class CSVEngineProperties:
     missing_file_message: str = "File '{filepath}'. No such file or directory."
 
 
-class CSVBaseReaderEngine(ABC):
-    """Abstract base class defining the interface for reader engines."""
+class _DuckDBBackedEngine(ABC):
+    """Shared DuckDB-connection ownership for the CSV reader/writer engines.
+
+    Holds the per-engine ``DuckDBQueries`` (and the derived table name) plus the
+    idempotent ``close()`` both engine families need, so neither base duplicates
+    connection setup/teardown.
+    """
 
     def __init__(self, filepath, lenient=False, normalize_columns=False):
-        """Initialize the CSVReader class.
-
-        Args:
-            filepath (str or Path): Path to the file to read.
-            lenient (bool): Whether to run in lenient mode.
-            normalize_columns (bool): Whether to normalize column names for
-            every operation on this engine. A per-call argument overrides it.
-        """
         self.filepath = Path(filepath)
         self.lenient = lenient
         self.normalize_columns = normalize_columns
         self.queries = DuckDBQueries(self.filepath, lenient=self.lenient)
         self.db_table = self.queries.database_table_name
-        self.delimiter = self.queries.delimiter
         if not self.filepath.exists():
             raise FileNotFoundError
 
@@ -107,6 +103,22 @@ class CSVBaseReaderEngine(ABC):
         this resets already-clean state. The engine stays usable afterward.
         """
         self.queries.close()
+
+
+class CSVBaseReaderEngine(_DuckDBBackedEngine):
+    """Abstract base class defining the interface for reader engines."""
+
+    def __init__(self, filepath, lenient=False, normalize_columns=False):
+        """Initialize the reader engine (adds the sniffed delimiter).
+
+        Args:
+            filepath (str or Path): Path to the file to read.
+            lenient (bool): Whether to run in lenient mode.
+            normalize_columns (bool): Whether to normalize column names for
+            every operation on this engine. A per-call argument overrides it.
+        """
+        super().__init__(filepath, lenient=lenient, normalize_columns=normalize_columns)
+        self.delimiter = self.queries.delimiter
 
     @abstractmethod
     def get_sample(self, normalize_columns: Optional[bool] = None) -> pl.DataFrame:
@@ -168,26 +180,8 @@ class CSVBaseReaderEngine(ABC):
         pass
 
 
-class CSVBaseWriterEngine(ABC):
+class CSVBaseWriterEngine(_DuckDBBackedEngine):
     """Abstract base class defining the interface for writer engines."""
-
-    def __init__(self, filepath, lenient=False, normalize_columns=False):
-        """
-        Initialize the CSV Writer DuckDB Engine class.
-
-        Args:
-            filepath (str or Path): Path to the file to write.
-            lenient (bool): Whether to run in lenient mode.
-            normalize_columns (bool): Whether to normalize column names for
-            every operation on this engine. A per-call argument overrides it.
-        """
-        self.filepath = Path(filepath)
-        self.lenient = lenient
-        self.normalize_columns = normalize_columns
-        self.queries = DuckDBQueries(self.filepath, lenient=self.lenient)
-        self.db_table = self.queries.database_table_name
-        if not self.filepath.exists():
-            raise FileNotFoundError
 
     @abstractmethod
     def write_csv(self, export_filename, normalize_columns=None):

--- a/src/datagrunt/csv_api/_engine_backed.py
+++ b/src/datagrunt/csv_api/_engine_backed.py
@@ -1,0 +1,63 @@
+"""Shared engine lifecycle for the CSV public API (CSVReader/CSVWriter)."""
+
+from functools import cached_property
+
+from datagrunt.core import CSVComponents, CSVEngineFactory
+
+
+class _CSVEngineBacked(CSVComponents):
+    """Engine ownership + lifecycle shared by CSVReader and CSVWriter.
+
+    Owns the single cached engine (which holds the DuckDB connection and import)
+    plus the optional ``close()``/context-manager semantics, so neither subclass
+    duplicates resource handling. Subclasses set ``_engine_role`` to choose the
+    factory builder and add any role-specific state in their own ``__init__``.
+    """
+
+    _engine_role = None  # "reader" or "writer"
+
+    def __init__(self, filepath, engine, lenient=False, normalize_columns=False):
+        self.lenient = lenient
+        self.normalize_columns = normalize_columns
+        super().__init__(filepath)
+        self.engine = engine.lower().replace(" ", "")
+        CSVEngineFactory.validate_engine(self.engine)
+
+    @cached_property
+    def _engine(self):
+        """Build this object's engine once and reuse it.
+
+        The engine owns the DuckDB connection (and, for the duckdb engine, the
+        imported table), so caching it means repeated operations reuse a single
+        import. Released when this object goes out of scope (reference-counted),
+        or earlier via the optional ``close()``/``with``.
+        """
+        factory = CSVEngineFactory(
+            self.filepath,
+            self.engine,
+            lenient=self.lenient,
+            normalize_columns=self.normalize_columns,
+        )
+        if self._engine_role == "reader":
+            return factory.create_reader()
+        return factory.create_writer()
+
+    def close(self):
+        """Release the engine's DuckDB connection, if one was built.
+
+        Idempotent; never forces the engine into existence (so a reader/writer
+        that has run nothing has nothing to close); the object stays usable
+        afterward — a later call transparently rebuilds. Optional: datagrunt
+        also releases on scope exit.
+        """
+        engine = self.__dict__.get("_engine")
+        if engine is not None:
+            engine.close()
+
+    def __enter__(self):
+        """Enter a ``with`` block, returning this object."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Release the engine on leaving the block; lets exceptions propagate."""
+        self.close()

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -3,9 +3,6 @@ Module for reading CSV files and converting to different in memory python
 objects.
 """
 
-# standard library
-from pathlib import Path
-
 # third party libraries
 import polars as pl
 import pyarrow as pa

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -4,7 +4,6 @@ objects.
 """
 
 # standard library
-from functools import cached_property
 from pathlib import Path
 
 # third party libraries
@@ -12,12 +11,15 @@ import polars as pl
 import pyarrow as pa
 
 # local libraries
-from datagrunt.core import CSVComponents, CSVEngineFactory, DuckDBQueries
+from datagrunt.core import DuckDBQueries
+from datagrunt.csv_api._engine_backed import _CSVEngineBacked
 from datagrunt.csv_api._compat import warn_per_call_normalize
 
 
-class CSVReader(CSVComponents):
+class CSVReader(_CSVEngineBacked):
     """Class to unify the interface for reading CSV files."""
+
+    _engine_role = "reader"
 
     def __init__(self, filepath, engine="polars", lenient=False, normalize_columns=False):
         """
@@ -32,65 +34,12 @@ class CSVReader(CSVComponents):
             every operation on this reader. With the DuckDB engine, queries
             are then written against the normalized names.
         """
-        filepath = Path(filepath)
-        self.lenient = lenient
-        self.normalize_columns = normalize_columns
-        super().__init__(filepath)
+        super().__init__(filepath, engine, lenient=lenient, normalize_columns=normalize_columns)
         self.db_table = DuckDBQueries(self.filepath, lenient=self.lenient).database_table_name
-        self.engine = engine.lower().replace(" ", "")
-        CSVEngineFactory.validate_engine(self.engine)
 
     def _return_empty_file_object(self, object):
         """Return an empty object of the specified type."""
         return object
-
-    def close(self):
-        """Close the DuckDB connection held by this reader's engine, if any.
-
-        Only the DuckDB engine holds a live connection, and only once an
-        operation has built the cached engine; if no operation has run yet there
-        is nothing to close, so this never forces the engine (and its import)
-        into existence. ``close()`` is idempotent and the reader stays usable
-        afterward - a later call transparently rebuilds/reopens (issue #150).
-        """
-        reader = self.__dict__.get("_reader")
-        if reader is not None:
-            reader.close()
-
-    def __enter__(self):
-        """Enter a ``with`` block, returning this reader."""
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Close the engine's connection on leaving the ``with`` block.
-
-        Returns ``None`` so any in-flight exception propagates.
-        """
-        self.close()
-
-    @cached_property
-    def _reader(self):
-        """Return this reader's engine, built once and reused.
-
-        The engine owns the DuckDB connection (and, for the DuckDB engine, the
-        imported table). Caching it here means repeated calls - notably
-        ``query_data`` - reuse a single import instead of rebuilding a fresh
-        engine and re-importing the file on every call (issue #104).
-        """
-        return CSVEngineFactory(
-            self.filepath,
-            self.engine,
-            lenient=self.lenient,
-            normalize_columns=self.normalize_columns,
-        ).create_reader()
-
-    def _create_reader(self):
-        """Return this reader's cached engine.
-
-        Retained for backward compatibility; delegates to the cached ``_reader``
-        so callers share a single engine and a single CSV import.
-        """
-        return self._reader
 
     def get_sample(self, normalize_columns=None):
         """Return a sample of the CSV file.
@@ -104,7 +53,7 @@ class CSVReader(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pl.DataFrame())
-        return self._create_reader().get_sample(warn_per_call_normalize(normalize_columns))
+        return self._engine.get_sample(warn_per_call_normalize(normalize_columns))
 
     def to_dataframe(self, normalize_columns=None):
         """Converts CSV to a Polars dataframe.
@@ -118,7 +67,7 @@ class CSVReader(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pl.DataFrame())
-        return self._create_reader().to_dataframe(warn_per_call_normalize(normalize_columns))
+        return self._engine.to_dataframe(warn_per_call_normalize(normalize_columns))
 
     def to_arrow_table(self, normalize_columns=None):
         """Converts CSV to a PyArrow table.
@@ -132,7 +81,7 @@ class CSVReader(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pa.Table.from_pydict({}))
-        return self._create_reader().to_arrow_table(warn_per_call_normalize(normalize_columns))
+        return self._engine.to_arrow_table(warn_per_call_normalize(normalize_columns))
 
     def to_dicts(self, normalize_columns=None):
         """Converts CSV to a list of dictionaries.
@@ -146,7 +95,7 @@ class CSVReader(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(list())
-        return self._create_reader().to_dicts(warn_per_call_normalize(normalize_columns))
+        return self._engine.to_dicts(warn_per_call_normalize(normalize_columns))
 
     def query_data(self, sql_query, normalize_columns=None):
         """
@@ -184,4 +133,4 @@ class CSVReader(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(list())
-        return self._create_reader().query_data(sql_query, warn_per_call_normalize(normalize_columns))
+        return self._engine.query_data(sql_query, warn_per_call_normalize(normalize_columns))

--- a/src/datagrunt/csv_api/csvwriter.py
+++ b/src/datagrunt/csv_api/csvwriter.py
@@ -1,21 +1,16 @@
 """Module for writing CSV files and converting to different file formats."""
 
 # standard library
-from functools import cached_property
 from pathlib import Path
 
 # third party libraries
 # local libraries
-from datagrunt.core import (
-    CSVComponents,
-    CSVEngineFactory,
-    CSVEngineProperties,
-    DuckDBQueries,
-)
+from datagrunt.core import CSVEngineProperties, DuckDBQueries
+from datagrunt.csv_api._engine_backed import _CSVEngineBacked
 from datagrunt.csv_api._compat import warn_per_call_normalize
 
 
-class CSVWriter(CSVComponents):
+class CSVWriter(_CSVEngineBacked):
     """
     Class to unify the interface for converting CSV files to various other
     supported file types.
@@ -32,6 +27,8 @@ class CSVWriter(CSVComponents):
         will not silently mutate the values for you.
     """
 
+    _engine_role = "writer"
+
     def __init__(self, filepath, engine="duckdb", lenient=False, normalize_columns=False):
         """
         Initialize the CSV Writer class.
@@ -44,36 +41,9 @@ class CSVWriter(CSVComponents):
             normalize_columns (bool): Whether to normalize column names in
             every file this writer exports.
         """
-        filepath = Path(filepath)
-        self.lenient = lenient
-        self.normalize_columns = normalize_columns
-        super().__init__(filepath)
+        super().__init__(filepath, engine, lenient=lenient, normalize_columns=normalize_columns)
         self.queries = DuckDBQueries(self.filepath, lenient=self.lenient)
         self.db_table = self.queries.database_table_name
-        self.engine = engine.lower().replace(" ", "")
-        CSVEngineFactory.validate_engine(self.engine)
-
-    @cached_property
-    def _writer(self):
-        """Return this writer's engine, built once and reused.
-
-        Caching it means exporting one ``CSVWriter`` to several formats reuses a
-        single import instead of rebuilding the engine and re-importing the
-        source for every format. The engine owns the DuckDB connection; it is
-        released when the writer goes out of scope (its connection is
-        reference-counted), or earlier via an explicit teardown. (Parallels
-        ``CSVReader._reader``; the two are unified in issue #209.)
-        """
-        return CSVEngineFactory(
-            self.filepath,
-            self.engine,
-            lenient=self.lenient,
-            normalize_columns=self.normalize_columns,
-        ).create_writer()
-
-    def _create_writer(self):
-        """Return this writer's cached engine (back-compat delegator)."""
-        return self._writer
 
     def _write_empty_output(self, default_filename, out_filename=None):
         """Write a truly empty output file for an empty/blank source.
@@ -97,7 +67,7 @@ class CSVWriter(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(CSVEngineProperties.csv_export_filename, out_filename)
-        return self._create_writer().write_csv(out_filename, warn_per_call_normalize(normalize_columns))
+        return self._engine.write_csv(out_filename, warn_per_call_normalize(normalize_columns))
 
     def write_excel(self, out_filename=None, normalize_columns=None):
         """
@@ -110,7 +80,7 @@ class CSVWriter(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(CSVEngineProperties.excel_export_filename, out_filename)
-        return self._create_writer().write_excel(out_filename, warn_per_call_normalize(normalize_columns))
+        return self._engine.write_excel(out_filename, warn_per_call_normalize(normalize_columns))
 
     def write_json(self, out_filename=None, normalize_columns=None):
         """
@@ -123,7 +93,7 @@ class CSVWriter(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(CSVEngineProperties.json_export_filename, out_filename)
-        return self._create_writer().write_json(out_filename, warn_per_call_normalize(normalize_columns))
+        return self._engine.write_json(out_filename, warn_per_call_normalize(normalize_columns))
 
     def write_json_newline_delimited(self, out_filename=None, normalize_columns=None):
         """
@@ -136,7 +106,7 @@ class CSVWriter(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(CSVEngineProperties.json_newline_export_filename, out_filename)
-        return self._create_writer().write_json_newline_delimited(
+        return self._engine.write_json_newline_delimited(
             out_filename, warn_per_call_normalize(normalize_columns)
         )
 
@@ -151,4 +121,4 @@ class CSVWriter(CSVComponents):
         """
         if self.is_empty or self.is_blank:
             return self._write_empty_output(CSVEngineProperties.parquet_export_filename, out_filename)
-        return self._create_writer().write_parquet(out_filename, warn_per_call_normalize(normalize_columns))
+        return self._engine.write_parquet(out_filename, warn_per_call_normalize(normalize_columns))

--- a/tests/core_tests/csv_io_tests/test_engines.py
+++ b/tests/core_tests/csv_io_tests/test_engines.py
@@ -772,6 +772,24 @@ class TestPyArrowMidfileCommentScanCached:
         assert calls["count"] == 1
 
 
+class TestDuckDBBackedEngineBase:
+    """_DuckDBBackedEngine base class: shared init + close() for reader/writer."""
+
+    def test_writer_engine_has_close(self, sample_csv):
+        """All CSV writer engines expose close() (shared with reader via base)."""
+        for engine in ("duckdb", "polars", "pyarrow"):
+            writer = CSVEngineFactory(sample_csv, engine).create_writer()
+            assert hasattr(writer, "close")
+            writer.close()  # idempotent, must not raise
+            writer.close()
+
+    def test_reader_engine_attrs_preserved(self, sample_csv):
+        """The base refactor preserves the reader engine's attributes."""
+        reader = CSVEngineFactory(sample_csv, "duckdb").create_reader()
+        assert reader.filepath and reader.db_table and reader.delimiter
+        assert reader.queries is not None
+
+
 class TestPyArrowJsonOutput:
     """PyArrow JSON/JSONL export content must be preserved by the refactor."""
 

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -435,7 +435,7 @@ class TestCSVReaderContextManager:
         reader = CSVReader(self._csv(tmp_path), engine="duckdb")
         with reader:
             reader.query_data(f"SELECT * FROM {reader.db_table}")
-            engine = reader.__dict__["_reader"]
+            engine = reader.__dict__["_engine"]
             assert engine.queries._connection is not None
         assert engine.queries._connection is None
 
@@ -446,13 +446,13 @@ class TestCSVReaderContextManager:
             with reader:
                 reader.query_data(f"SELECT * FROM {reader.db_table}")
                 raise ValueError("boom")
-        assert reader.__dict__["_reader"].queries._connection is None
+        assert reader.__dict__["_engine"].queries._connection is None
 
     def test_close_does_not_build_engine_when_unused(self, tmp_path):
         """close() on a reader that ran no operation must not create the engine."""
         reader = CSVReader(self._csv(tmp_path), engine="duckdb")
         reader.close()
-        assert "_reader" not in reader.__dict__
+        assert "_engine" not in reader.__dict__
 
     def test_reader_usable_after_close(self, tmp_path):
         """The reader stays usable after the block: a later query reopens."""
@@ -486,7 +486,7 @@ class TestCSVReaderContextManager:
         reader = CSVReader(sample_csv, engine="duckdb")
         reader.to_dataframe()
         # Connection stays open after a materializing read (no per-call close).
-        assert reader.__dict__["_reader"].queries._connection is not None
+        assert reader.__dict__["_engine"].queries._connection is not None
         reader.to_arrow_table()
         reader.query_data(f"SELECT * FROM {reader.db_table} LIMIT 1")
 

--- a/tests/csv_api_tests/test_csvwriter.py
+++ b/tests/csv_api_tests/test_csvwriter.py
@@ -218,3 +218,25 @@ class TestCSVWriter:
         assert (tmp_path / "out.csv").exists()
         assert (tmp_path / "out.json").exists()
         assert (tmp_path / "out.parquet").exists()
+
+    def test_csvwriter_close_and_context_manager(self, sample_csv, tmp_path):
+        """CSVWriter supports optional close()/with for early release; stays usable."""
+        writer = CSVWriter(sample_csv, engine="duckdb")
+        writer.write_csv(str(tmp_path / "a.csv"))
+        assert writer.__dict__.get("_engine") is not None
+        writer.close()                      # optional early release
+        assert writer.__dict__["_engine"].queries._connection is None
+        # Still usable afterward (engine transparently rebuilds).
+        writer.write_json(str(tmp_path / "b.json"))
+        assert (tmp_path / "b.json").exists()
+
+        with CSVWriter(sample_csv, engine="duckdb") as w:
+            w.write_parquet(str(tmp_path / "c.parquet"))
+        assert (tmp_path / "c.parquet").exists()
+
+
+    def test_csvwriter_close_does_not_build_engine_when_unused(self, sample_csv):
+        """close() never forces the engine (and its import) into existence."""
+        writer = CSVWriter(sample_csv, engine="duckdb")
+        writer.close()
+        assert "_engine" not in writer.__dict__


### PR DESCRIPTION
Removes duplicated engine-lifecycle code **within the CSV domain** by extracting two shared bases. Pure refactor — no behavior change; `CSVWriter` gains an *optional* `close()`/`with` (never required).

## Changes

**Engine layer** — `4e3f543`
New `_DuckDBBackedEngine(ABC)` holds the `__init__` that `CSVBaseReaderEngine`/`CSVBaseWriterEngine` each duplicated (filepath, lenient, normalize_columns, queries, db_table, file-exists check) plus `close()`. The reader base adds `self.delimiter`; writer engines now inherit `close()`.

**Public API** — `3b56f73`
New `_CSVEngineBacked(CSVComponents)` holds the cached engine (`cached_property _engine`, built via `CSVEngineFactory` per `_engine_role`), idempotent `close()`, and `__enter__`/`__exit__`. `CSVReader`/`CSVWriter` extend it and supply only role-specific `__init__` state. The cached attribute is standardized to **`_engine`**; the old `_reader`/`_writer`/`_create_reader`/`_create_writer` indirections are removed; public methods call `self._engine`. `CSVWriter` gains an optional `close()`/`with` for early release (symmetry with `CSVReader`).

**Cleanup** — `8f0ac60`
Drop the now-unused `Path` import from `csvreader.py`.

## Scope (per "DRY within each domain")
CSV domain **only**. No PDF changes, no CSV/PDF shared base. The PDF-domain DRY (and the `PDFReader` no-cache perf bug) is tracked separately in **#211**.

## Lifecycle principle (unchanged)
The user is never required to call `.close()`. Reuse-by-default; released on scope exit (reference-counted); `close()`/`with` are optional. `CSVWriter`'s new `close()`/`with` is additive and optional.

## Testing
- Full suite **998 passed**; focused CSV/engine/database suite **237 passed**.
- New tests: writer-engine `close()` parity; reader engine attribute preservation; `CSVWriter` optional `close()`/context-manager + lazy-close; the 4 reader context-manager tests updated to `_engine`.
- No behavior change: constructor attributes preserved across all four engine families; missing-file still raises `FileNotFoundError`; #207/#208 reuse + empty/blank + `warn_per_call_normalize` guards intact.

## Review
Subagent-driven: per-task spec+quality reviews + a final whole-branch review on Opus (verdict: ready to merge, no Critical/Important).

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)