### PR TITLE
perf(pdf): cache PDFReader engine + DRY PDF engine-lifecycle

### DIFF
--- a/src/datagrunt/pdf_api/_engine_backed.py
+++ b/src/datagrunt/pdf_api/_engine_backed.py
@@ -1,0 +1,56 @@
+"""Shared engine lifecycle for the PDF public API (PDFReader/PDFWriter)."""
+
+from functools import cached_property
+from pathlib import Path
+
+from datagrunt.core import PDFComponents, PDFEngineFactory
+
+
+class _PDFEngineBacked(PDFComponents):
+    """Engine ownership shared by PDFReader and PDFWriter.
+
+    Holds the identical PDF constructor and the single cached engine (built via
+    ``PDFEngineFactory`` by role), so both classes parse the source once per
+    instance and neither duplicates the factory wiring. PDF engines hold no
+    external connection (only in-memory parse caches), so there is no
+    ``close()``/context-manager here.
+    """
+
+    _engine_role = None  # "reader" or "writer"
+
+    def __init__(self, filepath, engine="pdfium", workers=1, native=False):
+        """Initialize a PDF reader/writer.
+
+        Args:
+            filepath (str, Path, or dict): Path to the PDF/JSON file, or a
+                parsed document dict.
+            engine (str, default 'pdfium'): Parsing engine to instantiate. One of
+                'pdfium' (default -- permissive license; emits the unified element
+                schema by default, or the lean native schema when ``native=True``)
+                or 'pymupdf' (unified element schema, tables + OCR).
+            workers (int, default 1): Number of concurrent per-page workers.
+            native (bool, default False): pdfium only -- when True, emit the lean
+                native schema instead of the unified element schema. Ignored by
+                the pymupdf engine.
+        """
+        if not isinstance(filepath, dict):
+            filepath = Path(filepath)
+        super().__init__(filepath)
+        self.engine = engine.lower().replace(" ", "")
+        self.workers = workers
+        self.native = native
+
+    @cached_property
+    def _engine(self):
+        """Build this object's engine once and reuse it across calls.
+
+        Caching means repeated/mixed conversions reuse a single parse (the engine
+        memoizes internally) instead of re-parsing the PDF on every call.
+        Released when this object goes out of scope.
+        """
+        factory = PDFEngineFactory(
+            self.filepath, self.engine, self.workers, structured=not self.native
+        )
+        if self._engine_role == "reader":
+            return factory.create_reader()
+        return factory.create_writer()

--- a/src/datagrunt/pdf_api/_engine_backed.py
+++ b/src/datagrunt/pdf_api/_engine_backed.py
@@ -53,4 +53,8 @@ class _PDFEngineBacked(PDFComponents):
         )
         if self._engine_role == "reader":
             return factory.create_reader()
-        return factory.create_writer()
+        if self._engine_role == "writer":
+            return factory.create_writer()
+        raise NotImplementedError(
+            f"Subclass must set _engine_role to 'reader' or 'writer', got {self._engine_role!r}"
+        )

--- a/src/datagrunt/pdf_api/pdfreader.py
+++ b/src/datagrunt/pdf_api/pdfreader.py
@@ -1,50 +1,22 @@
 """Module for reading PDF files and converting to in-memory Python objects."""
 
-# standard library
-from pathlib import Path
-
 # third party libraries
 import polars as pl
 import pyarrow as pa
 
 # local libraries
-from datagrunt.core import PDFComponents, PDFEngineFactory
 from datagrunt.core.pdf_io import pdfcomponents
+from datagrunt.pdf_api._engine_backed import _PDFEngineBacked
 
 
-class PDFReader(PDFComponents):
+class PDFReader(_PDFEngineBacked):
     """Class to unify the interface for reading and parsing PDF files."""
 
-    def __init__(self, filepath, engine="pdfium", workers=1, native=False):
-        """Initialize the PDF Reader class.
-
-        Args:
-            filepath (str, Path, or dict): Path to the PDF/JSON file to read, or parsed document dict.
-            engine (str, default 'pdfium'): Parsing engine to instantiate.
-                One of 'pdfium' (default -- permissive license; emits the unified
-                element schema by default, or the lean native schema when
-                ``native=True``) or 'pymupdf' (unified element schema, tables +
-                OCR).
-            workers (int, default 1): Number of concurrent per-page workers.
-            native (bool, default False): pdfium only -- when True, emit the lean
-                native schema (text, positioned text objects, images; no table
-                detection) instead of the default unified element schema. Ignored
-                by the pymupdf engine.
-        """
-        if not isinstance(filepath, dict):
-            filepath = Path(filepath)
-        super().__init__(filepath)
-        self.engine = engine.lower().replace(" ", "")
-        self.workers = workers
-        self.native = native
+    _engine_role = "reader"
 
     def _return_empty_file_object(self, object):
         """Return an empty object of the specified type."""
         return object
-
-    def _create_reader(self):
-        """Create a reader engine instance."""
-        return PDFEngineFactory(self.filepath, self.engine, self.workers, structured=not self.native).create_reader()
 
     def get_sample(self):
         """Parse and return the first page of the PDF."""
@@ -53,7 +25,7 @@ class PDFReader(PDFComponents):
             return pages[0] if pages else {}
         if self.is_empty:
             return self._return_empty_file_object({})
-        return self._create_reader().get_sample()
+        return self._engine.get_sample()
 
     def to_dicts(self, image_output_dir=None, drop_layout_tables=False):
         """Parse the PDF into the unified document dict.
@@ -72,7 +44,7 @@ class PDFReader(PDFComponents):
             return self._parsed_dict
         if self.is_empty:
             return self._return_empty_file_object({})
-        return self._create_reader().to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
+        return self._engine.to_dicts(image_output_dir=image_output_dir, drop_layout_tables=drop_layout_tables)
 
     def to_dataframe(self, drop_layout_tables=False):
         """Parse the PDF and flatten elements into a Polars DataFrame.
@@ -89,7 +61,7 @@ class PDFReader(PDFComponents):
             return pl.DataFrame(records) if records else pl.DataFrame()
         if self.is_empty:
             return self._return_empty_file_object(pl.DataFrame())
-        return self._create_reader().to_dataframe(drop_layout_tables=drop_layout_tables)
+        return self._engine.to_dataframe(drop_layout_tables=drop_layout_tables)
 
     def to_arrow_table(self, drop_layout_tables=False):
         """Parse the PDF and flatten elements into a PyArrow table.
@@ -106,4 +78,4 @@ class PDFReader(PDFComponents):
             return pa.Table.from_pylist(records) if records else pa.Table.from_pydict({})
         if self.is_empty:
             return self._return_empty_file_object(pa.Table.from_pydict({}))
-        return self._create_reader().to_arrow_table(drop_layout_tables=drop_layout_tables)
+        return self._engine.to_arrow_table(drop_layout_tables=drop_layout_tables)

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -2,49 +2,17 @@
 
 # standard library
 import json
-from functools import cached_property
-from pathlib import Path
 
 # local libraries
-from datagrunt.core import PDFComponents, PDFEngineFactory
 from datagrunt.core.pdf_io import pdfcomponents
 from datagrunt.core.pdf_io.extraction import PdfiumNativeReader
+from datagrunt.pdf_api._engine_backed import _PDFEngineBacked
 
 
-class PDFWriter(PDFComponents):
+class PDFWriter(_PDFEngineBacked):
     """Class to unify the interface for writing parsed PDF output."""
 
-    def __init__(self, filepath, engine="pdfium", workers=1, native=False):
-        """Initialize the PDF Writer class.
-
-        Args:
-            filepath (str, Path, or dict): Path to the PDF/JSON file to parse, or parsed document dict.
-            engine (str, default 'pdfium'): Parsing engine to instantiate.
-                One of 'pdfium' (default -- permissive license; emits the unified
-                element schema by default, or the lean native schema when
-                ``native=True``) or 'pymupdf' (unified element schema, tables +
-                OCR).
-            workers (int, default 1): Number of concurrent per-page workers.
-            native (bool, default False): pdfium only -- when True, emit the lean
-                native schema (text, positioned text objects, images; no table
-                detection) instead of the default unified element schema. Ignored
-                by the pymupdf engine.
-        """
-        if not isinstance(filepath, dict):
-            filepath = Path(filepath)
-        super().__init__(filepath)
-        self.engine = engine.lower().replace(" ", "")
-        self.workers = workers
-        self.native = native
-
-    def _create_writer(self):
-        """Create a writer engine instance."""
-        return PDFEngineFactory(self.filepath, self.engine, self.workers, structured=not self.native).create_writer()
-
-    @cached_property
-    def _writer(self):
-        """Cached writer engine; reused across write_* calls on this instance."""
-        return self._create_writer()
+    _engine_role = "writer"
 
     @staticmethod
     def _write_empty_file(filename, content=""):
@@ -85,7 +53,7 @@ class PDFWriter(PDFComponents):
         # document ({}) rather than a raw PdfiumError from loading the file.
         if self.is_empty:
             return self._write_empty_file(export_filename or "output.json", json.dumps({}))
-        return self._writer.write_json(export_filename, image_output_dir, dedupe_images, drop_layout_tables)
+        return self._engine.write_json(export_filename, image_output_dir, dedupe_images, drop_layout_tables)
 
     def write_json_newline_delimited(
         self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False
@@ -118,7 +86,7 @@ class PDFWriter(PDFComponents):
         # the JSONL output is an empty file rather than a raw PdfiumError.
         if self.is_empty:
             return self._write_empty_file(export_filename or "output.jsonl")
-        return self._writer.write_json_newline_delimited(
+        return self._engine.write_json_newline_delimited(
             export_filename, image_output_dir, dedupe_images, drop_layout_tables
         )
 
@@ -155,7 +123,7 @@ class PDFWriter(PDFComponents):
         # the Markdown output is an empty file rather than a raw PdfiumError.
         if self.is_empty:
             return self._write_empty_file(export_filename or "output.md")
-        return self._writer.write_markdown(
+        return self._engine.write_markdown(
             export_filename, image_output_dir, dedupe_images, drop_layout_tables
         )
 
@@ -180,4 +148,4 @@ class PDFWriter(PDFComponents):
         # Mirror PDFReader's is_empty handling: a 0-byte PDF has no images.
         if self.is_empty:
             return []
-        return self._writer.extract_images(output_dir, dedupe)
+        return self._engine.extract_images(output_dir, dedupe)

--- a/tests/pdf_api_tests/test_pdfreader.py
+++ b/tests/pdf_api_tests/test_pdfreader.py
@@ -286,6 +286,14 @@ class TestPDFReaderEngineCache:
         assert calls["n"] == 1  # engine cached: one create_reader, not three
         assert "_engine" in reader.__dict__
 
+    def test_engine_backed_requires_engine_role(self, sample_pdf):
+        """The shared base raises if a subclass omits _engine_role (no silent fallback)."""
+        from datagrunt.pdf_api._engine_backed import _PDFEngineBacked
+
+        obj = _PDFEngineBacked(sample_pdf)  # _engine_role defaults to None
+        with pytest.raises(NotImplementedError):
+            _ = obj._engine
+
 
 class TestPDFReaderJsonAndDictInputs:
     """Tests for initializing PDFReader with JSON files or dictionaries."""

--- a/tests/pdf_api_tests/test_pdfreader.py
+++ b/tests/pdf_api_tests/test_pdfreader.py
@@ -262,6 +262,31 @@ class TestPDFReaderPyMuPDFSequential:
             assert f"Sequential Marker {n}" in text
 
 
+class TestPDFReaderEngineCache:
+    """Engine lifecycle: PDFReader builds its engine once per instance."""
+
+    def test_pdfreader_caches_engine_across_calls(self, sample_pdf, monkeypatch):
+        """PDFReader builds its engine once and reuses it across calls (one parse)."""
+        from datagrunt.core import PDFEngineFactory
+
+        calls = {"n": 0}
+        original = PDFEngineFactory.create_reader
+
+        def spy(self):
+            calls["n"] += 1
+            return original(self)
+
+        monkeypatch.setattr(PDFEngineFactory, "create_reader", spy)
+
+        reader = PDFReader(sample_pdf, engine="pymupdf")
+        reader.to_dataframe()
+        reader.to_arrow_table()
+        reader.to_dataframe()
+
+        assert calls["n"] == 1  # engine cached: one create_reader, not three
+        assert "_engine" in reader.__dict__
+
+
 class TestPDFReaderJsonAndDictInputs:
     """Tests for initializing PDFReader with JSON files or dictionaries."""
 

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -171,6 +171,27 @@ class TestPDFWriter:
             content = f.read()
         assert len(content) > 0
 
+    def test_pdfwriter_caches_engine_across_calls(self, sample_pdf, tmp_path, monkeypatch):
+        """PDFWriter builds its engine once and reuses it across write_* calls."""
+        from datagrunt.core import PDFEngineFactory
+
+        calls = {"n": 0}
+        original = PDFEngineFactory.create_writer
+
+        def spy(self):
+            calls["n"] += 1
+            return original(self)
+
+        monkeypatch.setattr(PDFEngineFactory, "create_writer", spy)
+
+        writer = PDFWriter(sample_pdf, engine="pymupdf")
+        writer.write_json(str(tmp_path / "a.json"))
+        writer.write_markdown(str(tmp_path / "b.md"))
+
+        assert calls["n"] == 1  # engine cached under the standardized _engine name
+        assert "_engine" in writer.__dict__
+        assert (tmp_path / "a.json").exists() and (tmp_path / "b.md").exists()
+
 
 class TestPDFWriterEmptyPdf:
     """Empty (0-byte) PDFs must not surface a raw PdfiumError.


### PR DESCRIPTION
DRYs the engine-lifecycle **within the PDF domain** and fixes a `PDFReader` perf/consistency bug. Pure refactor + the caching fix; output byte-for-byte identical.

## Changes

**`_PDFEngineBacked` base + PDFReader caching** — `25814ae`
`PDFReader` rebuilt its engine on **every** public call, re-parsing the PDF each time (`PDFWriter` already cached). New `_PDFEngineBacked(PDFComponents)` holds the identical PDF constructor and a `cached_property _engine` (built via `PDFEngineFactory` by role). `PDFReader` now reuses one engine — and its internal parse memoization — across calls.

**Role guard** — `e0f04c6`, `4fd615a`
`_engine` raises `NotImplementedError` for an unset/unknown `_engine_role` instead of silently building a writer (removes a latent footgun); covered by a test.

**PDFWriter onto the base** — `93471b2`
`PDFWriter` now inherits the shared constructor + cached engine, dropping its duplicate `__init__`/`_create_writer`/`_writer`. Cached attribute standardized to `_engine` across both PDF classes.

## Caching safety
The reader engine memoizes `to_dataframe`/`to_arrow_table` by `drop_layout_tables`; `to_dicts`/`get_sample` stay uncached and re-parse each call. So caching the `PDFReader` engine reuses parses correctly and never returns stale results for differing `image_output_dir`/`drop_layout_tables`. Verified against the engine source in the final review.

## Scope (DRY within each domain)
PDF domain **only** — no CSV changes, no CSV/PDF shared base. PDF engines hold no connection, so (unlike the CSV base) there is intentionally **no** `close()`/context-manager.

## Testing
- Full suite **1000 passed** (CSV API and all other domains unaffected).
- New behavioral spies assert the engine is built once across mixed calls (reader + writer); plus role-guard coverage.

## Review
Subagent-driven: per-task spec+quality reviews + a final whole-branch review on Opus (verdict: ready to merge, no Critical/Important; the one minor — untested role guard — was then covered in `4fd615a`).

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)