### PR TITLE
perf(csv): single-pass header probe for delimiter/dialect inference (Python-first, then Rust)

### DIFF
--- a/rust/datagrunt-core/src/delimiter.rs
+++ b/rust/datagrunt-core/src/delimiter.rs
@@ -7,7 +7,6 @@ const SAFE_DELIMITERS: [char; 4] = [',', ';', '|', '\t'];
 const SPACE_DELIMITER: char = ' ';
 const DEFAULT_DELIMITER: &str = ",";
 const DEFAULT_TAB_DELIMITER: &str = "\t";
-const CANDIDATE_SAMPLE_ROWS: usize = 5;
 const MIN_CONSISTENT_FIELDS: usize = 3;
 
 /// Python DELIMITER_REGEX_PATTERN [^0-9a-zA-Z_ "-]: candidate = any char that
@@ -62,27 +61,31 @@ fn splits_rows_consistently(sample: &[String], c: char) -> bool {
 /// punctuation candidate that splits the sampled rows consistently; then
 /// space if consistent; else comma. Returns a 1-char String (str in Python).
 /// Errs only on file IO (e.g. missing file), like the Python original.
+///
+/// Uses a single `probe_csv_header` call (1 file open) instead of the
+/// previous separate `is_empty` / `is_blank` / `first_row` / `leading_rows`
+/// calls (3 opens), matching the Python refactor in `_compute_python`.
 pub fn infer_delimiter(path: &Path) -> std::io::Result<String> {
+    // .tsv extension wins immediately — no file content needed.
     if io::is_tsv(path) {
         return Ok(DEFAULT_TAB_DELIMITER.to_string());
     }
-    if io::is_empty(path)? || io::is_blank(path) {
+    let probe = rows::probe_csv_header(path)?;
+    if probe.empty || probe.blank {
         return Ok(DEFAULT_DELIMITER.to_string());
     }
-    let first = rows::first_row(path)?;
-    let candidates = candidates_most_common_first(&first);
+    let candidates = candidates_most_common_first(&probe.first_row);
     for c in &candidates {
         if SAFE_DELIMITERS.contains(c) {
             return Ok(c.to_string());
         }
     }
-    let sample = rows::leading_rows(path, CANDIDATE_SAMPLE_ROWS)?;
     for c in &candidates {
-        if splits_rows_consistently(&sample, *c) {
+        if splits_rows_consistently(&probe.sample_rows, *c) {
             return Ok(c.to_string());
         }
     }
-    if splits_rows_consistently(&sample, SPACE_DELIMITER) {
+    if splits_rows_consistently(&probe.sample_rows, SPACE_DELIMITER) {
         return Ok(SPACE_DELIMITER.to_string());
     }
     Ok(DEFAULT_DELIMITER.to_string())

--- a/rust/datagrunt-core/src/dialect.rs
+++ b/rust/datagrunt-core/src/dialect.rs
@@ -16,48 +16,8 @@
 //! `quoting` (QUOTE_MINIMAL) and the absence of `escapechar` are constants the
 //! binding layer applies (Task 10); they are not part of this core struct.
 
-use crate::io::DecodedReader;
 use fancy_regex::Regex;
-use std::io::{BufRead, BufReader};
-use std::path::Path;
 use std::sync::LazyLock;
-
-const SNIFF_SAMPLE_ROWS: usize = 5;
-
-/// CSVDialect sample: first 5 lines whose stripped form doesn't start with
-/// '#' (blank lines included), keeping each line's trailing `\n` so the result
-/// matches Python's `"".join(lines)` over text-mode iteration.
-///
-/// Streams the file via [`DecodedReader`] with universal-newline translation
-/// (Python text mode), reading line-by-line and STOPPING once 5 lines survive
-/// the comment filter — so an 88 MB file costs only the first few KiB. Line
-/// endings in the sample are universal-translated to `\n`, exactly as Python's
-/// text mode delivers them (not the file's original endings).
-pub fn sniff_sample(path: &Path) -> std::io::Result<String> {
-    let mut reader = BufReader::new(DecodedReader::open(path, true)?);
-    let mut sample = String::new();
-    let mut taken = 0usize;
-    let mut segment = Vec::new();
-    loop {
-        segment.clear();
-        let n = reader.read_until(b'\n', &mut segment)?;
-        if n == 0 {
-            break; // EOF
-        }
-        // DecodedReader already dropped invalid UTF-8, so this is valid UTF-8.
-        let text = String::from_utf8(std::mem::take(&mut segment))
-            .expect("DecodedReader yields valid UTF-8");
-        if text.trim().starts_with('#') {
-            continue;
-        }
-        sample.push_str(&text);
-        taken += 1;
-        if taken >= SNIFF_SAMPLE_ROWS {
-            break; // The whole point: stop after 5 surviving lines.
-        }
-    }
-    Ok(sample)
-}
 
 /// The four data-driven facts `csv.Sniffer().sniff` derives from a sample.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -1,8 +1,96 @@
 //! Ports of CSVRows probes and the leading-line counters.
 
-use crate::io::{is_legacy_mac_newlines, universal_lines, DecodedReader};
-use std::io;
+use crate::io::{is_empty, is_legacy_mac_newlines, universal_lines, DecodedReader};
+use std::io::{self, BufRead, BufReader};
 use std::path::Path;
+
+// ---- probe_csv_header constants ----
+/// Python CANDIDATE_SAMPLE_ROWS = 5.
+const CANDIDATE_SAMPLE_ROWS: usize = 5;
+/// Python CSV_SNIFF_SAMPLE_ROWS = 5.
+const SNIFF_SAMPLE_ROWS: usize = 5;
+
+/// Result of a single-pass header probe: the five values both delimiter
+/// and dialect inference need.
+pub struct HeaderProbe {
+    pub empty: bool,
+    pub blank: bool,
+    pub first_row: String,
+    pub sample_rows: Vec<String>,
+    pub sample_lines: Vec<String>,
+}
+
+/// Single-pass header probe — mirrors `_compute_python.probe_csv_header` exactly.
+///
+/// `sample_rows` = stripped non-blank non-comment rows, capped at
+/// `CANDIDATE_SAMPLE_ROWS` (== Python `leading_rows(CANDIDATE_SAMPLE_ROWS)`).
+///
+/// `sample_lines` = raw non-comment lines with their original line terminator
+/// preserved (blanks kept), capped at `SNIFF_SAMPLE_ROWS`.  Uses
+/// `BufReader::read_until(b'\n')` over a `DecodedReader` (universal-newline
+/// translation on, matching Python text mode) so the trailing `\n` is included
+/// when present and omitted on the final line of a file with no trailing
+/// newline — exactly mirroring Python's `for line in f:`.
+///
+/// `first_row` = `sample_rows[0]` or `""`.
+/// `blank`     = no non-whitespace byte seen (single-pass `saw_nonblank`).
+/// `empty`     = `io::is_empty` fast-path; returns `blank: false` to match Python.
+pub fn probe_csv_header(path: &Path) -> std::io::Result<HeaderProbe> {
+    if is_empty(path)? {
+        return Ok(HeaderProbe {
+            empty: true,
+            blank: false,
+            first_row: String::new(),
+            sample_rows: Vec::new(),
+            sample_lines: Vec::new(),
+        });
+    }
+    // Universal-newline translation on (translate=true) matches Python text mode.
+    let mut reader = BufReader::new(DecodedReader::open(path, true)?);
+    let mut sample_lines: Vec<String> = Vec::new();
+    let mut sample_rows: Vec<String> = Vec::new();
+    let mut saw_nonblank = false;
+    let mut segment: Vec<u8> = Vec::new();
+    loop {
+        segment.clear();
+        let n = reader.read_until(b'\n', &mut segment)?;
+        if n == 0 {
+            break; // EOF
+        }
+        // DecodedReader yields valid UTF-8 only.
+        let text =
+            String::from_utf8(std::mem::take(&mut segment)).expect("DecodedReader yields UTF-8");
+        // `stripped` mirrors Python's `line.strip()`.
+        let stripped = text.trim();
+        if !stripped.is_empty() {
+            saw_nonblank = true;
+        }
+        let is_comment = stripped.starts_with('#');
+        // sample_lines: raw text (including its \n if present), blanks kept,
+        // comments skipped — matches Python's `sample_lines.append(line)`.
+        if !is_comment && sample_lines.len() < SNIFF_SAMPLE_ROWS {
+            sample_lines.push(text.clone());
+        }
+        // sample_rows: stripped non-blank non-comment rows.
+        if !stripped.is_empty() && !is_comment && sample_rows.len() < CANDIDATE_SAMPLE_ROWS {
+            sample_rows.push(stripped.to_string());
+        }
+        if saw_nonblank
+            && sample_lines.len() >= SNIFF_SAMPLE_ROWS
+            && sample_rows.len() >= CANDIDATE_SAMPLE_ROWS
+        {
+            break;
+        }
+    }
+    let first_row = sample_rows.first().cloned().unwrap_or_default();
+    Ok(HeaderProbe {
+        empty: false,
+        blank: !saw_nonblank,
+        first_row,
+        sample_rows,
+        sample_lines,
+    })
+}
 
 /// CSVRows.leading_rows: up to `limit` leading non-blank, non-comment rows,
 /// each stripped. Streams the file and stops once `limit` rows are found.
@@ -120,4 +208,66 @@ pub fn row_count_with_header(path: &Path, delimiter: u8) -> std::io::Result<u64>
         }
     }
     Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tmp(content: &[u8]) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+        f.write_all(content).unwrap();
+        f
+    }
+
+    #[test]
+    fn probe_empty_file() {
+        let f = tmp(b"");
+        let p = probe_csv_header(f.path()).unwrap();
+        assert!(p.empty);
+        assert!(!p.blank);
+        assert!(p.first_row.is_empty());
+        assert!(p.sample_rows.is_empty());
+        assert!(p.sample_lines.is_empty());
+    }
+
+    #[test]
+    fn probe_blank_file() {
+        let f = tmp(b"  \n\t\n  \n");
+        let p = probe_csv_header(f.path()).unwrap();
+        assert!(!p.empty);
+        assert!(p.blank);
+        assert!(p.first_row.is_empty());
+        assert!(p.sample_rows.is_empty());
+        // blank lines are not comments, so they go into sample_lines
+        assert!(!p.sample_lines.is_empty());
+    }
+
+    #[test]
+    fn probe_normal_file() {
+        let f = tmp(b"name,age\nAlice,30\nBob,25\n");
+        let p = probe_csv_header(f.path()).unwrap();
+        assert!(!p.empty);
+        assert!(!p.blank);
+        assert_eq!(p.first_row, "name,age");
+        assert_eq!(p.sample_rows[0], "name,age");
+        // sample_lines include trailing \n to match Python text-mode
+        assert_eq!(p.sample_lines[0], "name,age\n");
+    }
+
+    #[test]
+    fn probe_comment_and_blank_mix() {
+        // Comments skipped in both lists; blanks kept in sample_lines, skipped in sample_rows.
+        let f = tmp(b"# comment\n\nname,age\nAlice,30\n");
+        let p = probe_csv_header(f.path()).unwrap();
+        assert!(!p.empty);
+        assert!(!p.blank);
+        // sample_rows: skips comment AND blank
+        assert_eq!(p.sample_rows, vec!["name,age", "Alice,30"]);
+        // sample_lines: skips comment, keeps blank line
+        assert_eq!(p.sample_lines[0], "\n"); // the blank line
+        assert_eq!(p.sample_lines[1], "name,age\n");
+        assert_eq!(p.sample_lines[2], "Alice,30\n");
+    }
 }

--- a/rust/datagrunt-python/src/lib.rs
+++ b/rust/datagrunt-python/src/lib.rs
@@ -71,6 +71,10 @@ fn check_ragged(path: PathBuf, delimiter: &str) -> PyResult<bool> {
 /// CSVDialect equivalent: None for empty/blank files or an undeterminable
 /// sample; otherwise the raw sniffed dialect fields. lineterminator and
 /// quoting are constants in csv.Sniffer.sniff; escapechar is never set.
+///
+/// Routes through a single `probe_csv_header` call (1 file open) — the probe's
+/// `sample_lines` joined gives the dialect sample, matching the Python refactor
+/// in `_compute_python.sniff_dialect`.
 #[pyfunction]
 #[pyo3(signature = (path, delimiter=None))]
 fn sniff_dialect(
@@ -78,10 +82,11 @@ fn sniff_dialect(
     path: PathBuf,
     delimiter: Option<String>,
 ) -> PyResult<Option<Py<PyDict>>> {
-    if datagrunt_core::io::is_empty(&path).map_err(oserr)? || datagrunt_core::io::is_blank(&path) {
+    let probe = datagrunt_core::rows::probe_csv_header(&path).map_err(oserr)?;
+    if probe.empty || probe.blank {
         return Ok(None);
     }
-    let sample = datagrunt_core::dialect::sniff_sample(&path).map_err(oserr)?;
+    let sample = probe.sample_lines.join("");
     // An empty delimiter string is Python-falsy (`if delimiter:`), meaning "no
     // restriction" — normalize it to None so it doesn't reject every candidate
     // (Some("") would make the substring guard `"".contains(x)` reject all).
@@ -100,6 +105,23 @@ fn sniff_dialect(
     Ok(Some(dict.into()))
 }
 
+/// `probe_csv_header(path) -> dict` — single-pass header probe.
+///
+/// Returns a dict with keys: `empty`, `blank`, `first_row`, `sample_rows`,
+/// `sample_lines`.  Identical values to `_compute_python.probe_csv_header`
+/// for all corpus files (enforced by the parity test suite).
+#[pyfunction]
+fn probe_csv_header(py: Python<'_>, path: PathBuf) -> PyResult<Py<PyDict>> {
+    let probe = datagrunt_core::rows::probe_csv_header(&path).map_err(oserr)?;
+    let d = PyDict::new(py);
+    d.set_item("empty", probe.empty)?;
+    d.set_item("blank", probe.blank)?;
+    d.set_item("first_row", probe.first_row)?;
+    d.set_item("sample_rows", probe.sample_rows)?;
+    d.set_item("sample_lines", probe.sample_lines)?;
+    Ok(d.into())
+}
+
 #[pymodule]
 #[pyo3(name = "_native")]
 fn datagrunt_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -113,5 +135,6 @@ fn datagrunt_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(row_count_with_header, m)?)?;
     m.add_function(wrap_pyfunction!(check_ragged, m)?)?;
     m.add_function(wrap_pyfunction!(sniff_dialect, m)?)?;
+    m.add_function(wrap_pyfunction!(probe_csv_header, m)?)?;
     Ok(())
 }

--- a/src/datagrunt/core/csv_io/_compute_python.py
+++ b/src/datagrunt/core/csv_io/_compute_python.py
@@ -196,7 +196,11 @@ def probe_csv_header(filepath):
                 sample_lines.append(line)
             if stripped and not is_comment and len(sample_rows) < CANDIDATE_SAMPLE_ROWS:
                 sample_rows.append(stripped)
-            if saw_nonblank and len(sample_lines) >= CSV_SNIFF_SAMPLE_ROWS and len(sample_rows) >= CANDIDATE_SAMPLE_ROWS:
+            if (
+                saw_nonblank
+                and len(sample_lines) >= CSV_SNIFF_SAMPLE_ROWS
+                and len(sample_rows) >= CANDIDATE_SAMPLE_ROWS
+            ):
                 break
 
     return {

--- a/src/datagrunt/core/csv_io/_compute_python.py
+++ b/src/datagrunt/core/csv_io/_compute_python.py
@@ -164,18 +164,63 @@ def _splits_rows_consistently(sample_rows, char):
     return len(field_counts) == 1 and field_counts.pop() >= MIN_CONSISTENT_FIELDS
 
 
+def probe_csv_header(filepath):
+    """Single-pass header probe shared by delimiter + dialect inference.
+
+    One read captures everything both inference paths need, replacing the
+    separate ``is_blank`` / ``first_row`` / ``leading_rows`` / sniff-sample reads.
+
+    Returns a dict:
+      - ``empty``: file has zero bytes.
+      - ``blank``: file has no non-whitespace content.
+      - ``first_row``: first stripped, non-blank, non-comment row ("" if none).
+      - ``sample_rows``: up to ``CANDIDATE_SAMPLE_ROWS`` stripped non-blank
+        non-comment rows (reproduces ``leading_rows(CANDIDATE_SAMPLE_ROWS)``).
+      - ``sample_lines``: up to ``CSV_SNIFF_SAMPLE_ROWS`` raw non-comment lines,
+        blanks kept (reproduces ``sniff_dialect``'s sample).
+    """
+    props = FileProperties(filepath)
+    if props.is_empty:
+        return {"empty": True, "blank": False, "first_row": "", "sample_rows": [], "sample_lines": []}
+
+    sample_lines = []
+    sample_rows = []
+    saw_nonblank = False
+    with open(filepath, "r", encoding=props.DEFAULT_ENCODING, errors="ignore") as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped:
+                saw_nonblank = True
+            is_comment = stripped.startswith("#")
+            if not is_comment and len(sample_lines) < CSV_SNIFF_SAMPLE_ROWS:
+                sample_lines.append(line)
+            if stripped and not is_comment and len(sample_rows) < CANDIDATE_SAMPLE_ROWS:
+                sample_rows.append(stripped)
+            if saw_nonblank and len(sample_lines) >= CSV_SNIFF_SAMPLE_ROWS and len(sample_rows) >= CANDIDATE_SAMPLE_ROWS:
+                break
+
+    return {
+        "empty": False,
+        "blank": not saw_nonblank,
+        "first_row": sample_rows[0] if sample_rows else "",
+        "sample_rows": sample_rows,
+        "sample_lines": sample_lines,
+    }
+
+
 def infer_delimiter(filepath):
     """Infer the delimiter (safe > consistent punctuation > space > comma)."""
     props = FileProperties(filepath)
     if props.is_tsv:
         return DEFAULT_TAB_DELIMITER
-    if props.is_empty or props.is_blank:
+    probe = probe_csv_header(filepath)
+    if probe["empty"] or probe["blank"]:
         return DEFAULT_DELIMITER
-    candidates = _candidates_most_common(first_row(filepath))
+    candidates = _candidates_most_common(probe["first_row"])
     for char in candidates:
         if char in SAFE_DELIMITERS:
             return char
-    sample = leading_rows(filepath, CANDIDATE_SAMPLE_ROWS)
+    sample = probe["sample_rows"]
     for char in candidates:
         if _splits_rows_consistently(sample, char):
             return char
@@ -191,18 +236,10 @@ def sniff_dialect(filepath, delimiter=None):
     (``escapechar`` None, ``lineterminator`` "\\r\\n", ``quoting`` 0) mirror what
     ``csv.Sniffer().sniff`` and ``datagrunt._native.sniff_dialect`` produce.
     """
-    props = FileProperties(filepath)
-    if props.is_empty or props.is_blank:
+    probe = probe_csv_header(filepath)
+    if probe["empty"] or probe["blank"]:
         return None
-    lines = []
-    with open(filepath, "r", encoding=props.DEFAULT_ENCODING, errors="ignore") as f:
-        for line in f:
-            if line.strip().startswith("#"):
-                continue
-            lines.append(line)
-            if len(lines) >= CSV_SNIFF_SAMPLE_ROWS:
-                break
-    sample = "".join(lines)
+    sample = "".join(probe["sample_lines"])
     try:
         if delimiter:
             dialect = csv.Sniffer().sniff(sample, delimiters=delimiter)

--- a/tests/core_tests/csv_io_tests/test_probe_csv_header.py
+++ b/tests/core_tests/csv_io_tests/test_probe_csv_header.py
@@ -1,0 +1,51 @@
+"""Unit tests for the single-pass CSV header probe (Python reference)."""
+
+from datagrunt.core.csv_io import _compute_python as py
+
+
+def _write(tmp_path, name, content):
+    p = tmp_path / name
+    p.write_bytes(content)
+    return str(p)
+
+
+def test_probe_normal_csv(tmp_path):
+    path = _write(tmp_path, "a.csv", b"a,b,c\n1,2,3\n4,5,6\n")
+    probe = py.probe_csv_header(path)
+    assert probe["empty"] is False
+    assert probe["blank"] is False
+    assert probe["first_row"] == "a,b,c"
+    assert probe["sample_rows"][0] == "a,b,c"
+    assert probe["sample_lines"][0] == "a,b,c\n"
+
+
+def test_probe_empty(tmp_path):
+    path = _write(tmp_path, "e.csv", b"")
+    probe = py.probe_csv_header(path)
+    assert probe["empty"] is True
+    assert probe["first_row"] == "" and probe["sample_rows"] == [] and probe["sample_lines"] == []
+
+
+def test_probe_blank(tmp_path):
+    path = _write(tmp_path, "b.csv", b"   \n\n\t\n")
+    probe = py.probe_csv_header(path)
+    assert probe["empty"] is False
+    assert probe["blank"] is True
+    assert probe["first_row"] == ""
+
+
+def test_probe_skips_comments_for_rows_but_keeps_blanks_in_lines(tmp_path):
+    path = _write(tmp_path, "c.csv", b"# comment\n\na,b\n1,2\n")
+    probe = py.probe_csv_header(path)
+    # sample_rows: stripped, non-blank, non-comment
+    assert probe["sample_rows"][0] == "a,b"
+    # sample_lines: raw non-comment lines incl the blank line
+    assert probe["sample_lines"][0] == "\n"
+    assert probe["first_row"] == "a,b"
+
+
+def test_probe_matches_legacy_helpers(tmp_path):
+    path = _write(tmp_path, "d.csv", b"x;y;z\n1;2;3\n#c\n4;5;6\n")
+    probe = py.probe_csv_header(path)
+    assert probe["first_row"] == py.first_row(path)
+    assert probe["sample_rows"] == py.leading_rows(path, py.CANDIDATE_SAMPLE_ROWS)

--- a/tests/core_tests/csv_io_tests/test_probe_csv_header.py
+++ b/tests/core_tests/csv_io_tests/test_probe_csv_header.py
@@ -49,3 +49,13 @@ def test_probe_matches_legacy_helpers(tmp_path):
     probe = py.probe_csv_header(path)
     assert probe["first_row"] == py.first_row(path)
     assert probe["sample_rows"] == py.leading_rows(path, py.CANDIDATE_SAMPLE_ROWS)
+
+
+def test_probe_caps_sample_rows_and_lines_at_five(tmp_path):
+    """Both sample windows cap at their 5-row limits regardless of file size."""
+    rows = b"".join(f"r{i},v\n".encode() for i in range(8))  # 8 non-blank, non-comment rows
+    path = _write(tmp_path, "big.csv", rows)
+    probe = py.probe_csv_header(path)
+    assert len(probe["sample_rows"]) == py.CANDIDATE_SAMPLE_ROWS == 5
+    assert len(probe["sample_lines"]) == py.CSV_SNIFF_SAMPLE_ROWS == 5
+    assert probe["sample_rows"] == py.leading_rows(path, py.CANDIDATE_SAMPLE_ROWS)

--- a/tests/parity/test_parity_probes.py
+++ b/tests/parity/test_parity_probes.py
@@ -29,3 +29,9 @@ def test_leading_rows(corpus_file):
         assert datagrunt_rs.leading_rows(str(corpus_file), limit) == py.leading_rows(
             str(corpus_file), limit
         )
+
+
+def test_probe_csv_header(corpus_file):
+    rust = datagrunt_rs.probe_csv_header(str(corpus_file))
+    python = py.probe_csv_header(str(corpus_file))
+    assert rust == python, corpus_file.name


### PR DESCRIPTION
Collapses the redundant header reads in CSV delimiter/dialect inference into one streaming `probe_csv_header`, implemented **Python-first then ported to Rust**, with byte-identical results proven by the differential-parity suite across all 46 corpus files on both backends.

Closes #214

## Problem
`infer_delimiter` re-opened the header 3× (`is_blank` + `first_row` + `leading_rows`) and `sniff_dialect` 2× (`is_blank` + sample); on first import both run, so the header was opened ~5×.

## Change
New `probe_csv_header(path) -> {empty, blank, first_row, sample_rows, sample_lines}` — one pass capturing both sample windows + blank/empty. `infer_delimiter` and `sniff_dialect` consume it: **3→1** and **2→1** opens, identical results.

- `c7f6b59` — Python reference (`_compute_python.py`) + refactor.
- `ac58c38` — Python cap-at-5 boundary tests.
- `b854199` — Rust port: `_native` core probe + refactor of Rust `infer_delimiter`/`sniff_dialect`, PyO3 binding, Rust unit tests, parity test.
- `239e098` — remove the now-dead `dialect::sniff_sample` (superseded by the probe).

## Principle honored (Python-first)
Python is the leading implementation and the differential-parity oracle; Rust follows. Notably, after the Python commit (Rust still unchanged), the parity suite stayed green — which *proves* the Python refactor changed no behavior. The Rust port then keeps both backends in agreement.

## Design note (intentional deviation from the plan sketch)
The probe reads lines via `BufReader<DecodedReader>::read_until(b'\n')` (the same approach as the former `dialect::sniff_sample`), **not** `io::universal_lines`. Reason: `sample_lines` must preserve each line's raw terminator (and the last line of a no-trailing-newline file must have none) to match Python's `for line in f:` exactly for `csv.Sniffer`. The initial `universal_lines` attempt was caught by parity (3 failures) and corrected.

## Testing (all local gates green)
- `cargo test`: 41 passed (incl. 4 new probe tests)
- differential parity (`tests/parity/`): **512 passed** (Rust == Python, all 46 corpus files)
- full suite, Rust backend: **1051 passed**
- full suite, Python backend (`DATAGRUNT_DISABLE_RUST=1`): **1051 passed**
- `ruff check src/datagrunt/core/csv_io`: clean

## Review
Subagent-driven: per-task spec+quality reviews + a final whole-branch review on Opus (no Critical/Important; the two minor items — dead `sniff_sample`, document the `read_until` choice — are addressed in `239e098` and this description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)