### PR TITLE
docs: add CLAUDE.md playbook + gitignore local .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ FINDINGS.md
 
 # Example notebooks/data live in docs now — never tracked here.
 examples/
+
+# Local Claude Code config (settings, commands, worktrees) — keep local only
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md — the datagrunt playbook
+
+Project-specific guidance for Claude Code (in addition to the global `~/.claude/CLAUDE.md` clean-code standards). This file is the source of truth for **how we work on datagrunt**. When asked to do something "the usual way" / "per the usual" / via `/ship`, follow this.
+
+datagrunt is a CSV/PDF data utility. CSV delimiter/dialect/row inference runs in a **required Rust extension** (`datagrunt._native`, PyO3/maturin) with a pure-Python mirror (`_compute_python.py`) as the parity oracle. PDF parsing is **pure Python** (pymupdf + pdfium + pdfplumber + tesseract OCR).
+
+---
+
+## First principles (non-negotiable)
+
+- **Python-first, then port to Rust.** For CSV compute, change/add logic in `src/datagrunt/core/csv_io/_compute_python.py` first, validate, *then* mirror it in the Rust crate and prove agreement with the differential-parity suite. Python leads; Rust follows. If it's inefficient in Python it's inefficient in Rust — fix Python, then fix Rust. `_compute_python` must keep mirroring the `_native` function API (it is both the toggle target and the parity oracle).
+- **Rust core is the required default (4.0+).** `_compute.backend()` returns `_native` by default; `_compute_python` is the parity oracle + a hidden diagnostics toggle (`DATAGRUNT_DISABLE_RUST` / `rust_disabled()`), **not** an automatic runtime fallback. `_compute.py` hard-imports `_native`. Do **not** add a silent pure-Python fallback.
+- **Automatic resource lifecycle — never require the user to call `.close()`.** Reuse by default (cache the engine per public object); cleanup is automatic via reference-counted release on scope exit. `close()` / `with` are optional power-user tools for *early* release only; the default path must be correct and fast without them.
+- **DRY + single-responsibility, within each domain — never across.** Deduplicate inside the CSV domain and inside the PDF domain; do **not** create a shared CSV/PDF base (they are separate subsystems). Don't over-abstract.
+- **Preserve, not transform.** datagrunt never silently sanitizes/mutates data for hypothetical risks. SQL via `query_data` and CSV/Excel formula-injection (values starting with `=,+,-,@`) are **documented app-layer concerns** — document and defer; do not "fix" by mutating data.
+- **PDF extraction must be 100% complete.** Never propose selective or stage-skipping extraction; preserve per-page error isolation (a bad page is recorded and skipped, never drops a batch).
+
+---
+
+## The workflow ("the usual")
+
+For any substantive change, follow this end-to-end. (Trivial 1–2 line fixes may skip the formal plan doc but still get tests, a PR, and CI.)
+
+1. **Track it as a labeled GitHub issue, up front.** Every enhancement/optimization/bug gets a `gh issue create --label <…>` *before* implementation. Labels: `performance`, `code-quality`, `bug`, `documentation`, `security`, `enhancement`. Apply multiple when it spans categories. If expanded scope is discovered mid-work, log it as its own issue and defer it — don't balloon the current PR.
+2. **Branch as `<type>/<kebab-case>`** — `feature/…`, `refactor/…`, `perf/…`, `fix/…`, `docs/…`. Never date-prefixed snake_case. Never commit straight to `main`.
+3. **Plan** with the `superpowers:writing-plans` skill (save under the gitignored `docs/superpowers/plans/`).
+4. **Implement via `superpowers:subagent-driven-development`:** a fresh implementer subagent per task (TDD — failing test first), then a per-task spec+quality review; fix Critical/Important findings before moving on.
+5. **Final whole-branch review** (most capable model) for non-trivial changes; address findings.
+6. **Open a PR** with a clear body and `Closes #<issue>`. Merge (squash, delete branch) **only after CI is green**, then sync `main`.
+7. **Release/publish needs explicit consent.** Version bumps and real-PyPI publishes require the maintainer's express approval; CI/TestPyPI testing without a version change is fine.
+
+### Test gates — all must pass before merge
+- `uv run pytest tests/ -q` — Rust backend (default)
+- `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` — Python backend
+- When Rust changed: `cd rust && cargo test`, plus the differential parity suite `uv run pytest tests/parity/ -q` (Rust == Python over the corpus)
+- `ruff check src/datagrunt/core/csv_io` (CI gates on this; check the broader tree too)
+- After Rust changes, **rebuild the extension** so tests see it: `uv pip install -e ".[dev,pdf]"` (or `maturin develop`)
+
+### Hygiene
+- Use **`uv`** for all Python package/env work (never plain `pip`/`python`); `maturin`/`cargo` for Rust.
+- **Keep PRs clean:** no dev/test/benchmark/scratch cruft in the repo or diff. Dev scripts go in the gitignored `scripts/`. Never commit non-documentation markdown (code-review/validation/scratch notes).
+- Commit messages end with: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
+- PR bodies end with: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+
+---
+
+## Architecture map (orient fast)
+
+- **CSV compute:** `core/csv_io/_compute.py` dispatches `backend()` → `_native` (Rust) or `_compute_python` (oracle/toggle). Both expose the same function set (`infer_delimiter`, `sniff_dialect`, `probe_csv_header`, `leading_rows`, `first_row`, `count_leading_comments`, `row_count_with_header`, `check_ragged`, `normalize_columns`, …).
+- **CSV API:** `CSVReader`/`CSVWriter` share `csv_api/_engine_backed.py::_CSVEngineBacked` (cached `_engine` + optional `close()`/context-manager). Engines (`core/csv_io/engines.py`) share `_DuckDBBackedEngine`; DuckDB access via `core/databases/databases.py::DuckDBQueries`.
+- **PDF (pure Python):** `PDFReader`/`PDFWriter` share `pdf_api/_engine_backed.py::_PDFEngineBacked` (cached `_engine`). `core/pdf_io/pdfcomponents.py::DocumentAssembler.extract_page` does single-pass per-page extraction; backends under `core/pdf_io/extraction/` (pymupdf, pdfium, OCR, tables, layout). PDFium parallelism uses a process pool (per-page batching was investigated and declined — see issue #216).
+
+---
+
+## Rust crate (`rust/`)
+- `datagrunt-core` = pure-Rust logic (delimiter, dialect, io, normalize, ragged, rows); `datagrunt-python` = the PyO3 `_native` bindings. Unit tests are in-file `#[cfg(test)]` modules.
+- Mirror the existing line-iteration helpers (`io::universal_lines`, `DecodedReader`) for parity; avoid `unwrap()/expect()/panic!` reachable from user input (a panic across the PyO3 boundary is a DoS). Run `cargo clippy` on changes.


### PR DESCRIPTION
Adds a project **`CLAUDE.md`** so the established datagrunt way is loaded automatically every session — no more re-typing the playbook.

## What's in `CLAUDE.md`
- **First principles:** Python-first→Rust port; Rust-required core (no silent Python fallback); automatic resource lifecycle (never require user `.close()`); DRY+SRP within each domain (never cross CSV/PDF); preserve-not-transform; 100% PDF extraction.
- **The workflow ("the usual"):** labeled GitHub issue up front → `<type>/<kebab>` branch → plan → subagent-driven implementation (TDD) → per-task spec+quality review → final whole-branch review → PR `Closes #N` → CI → squash-merge. Plus release-needs-consent and keep-PRs-clean.
- **Test gates:** both pytest backends, `cargo test` + parity suite when Rust changes, ruff, and the extension-rebuild step.
- **Architecture map** + Rust-crate notes for fast orientation.

## `.gitignore`
Adds `.claude/` so local Claude Code config (settings, commands, worktrees) stays **local only**, per maintainer preference. No `.claude/` files were tracked, so this is a clean ignore.

## Note: `/ship` command
A local `/ship <issue#>` slash command was created at `.claude/commands/ship.md` (runs the full `CLAUDE.md` workflow against an issue). Because `.claude/` is now gitignored, it stays local to your machine and is intentionally **not** part of this PR.

Docs/config only — no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)