### PR TITLE
docs: declare Python 3.12 + 3.13 in pyproject classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
The package targets `requires-python = ">=3.10"`, ships an **abi3-py310** wheel (one stable-ABI wheel that runs on CPython 3.10+), and CI/build run on 3.12 — but the PyPI trove `classifiers` stopped at 3.11, under-reporting supported versions to PyPI and dependency resolvers.

Adds:
- `Programming Language :: Python :: 3.12` (CI + sdist build target)
- `Programming Language :: Python :: 3.13` (abi3-py310 compatible; current release)

Validated: `pyproject.toml` parses and the new entries are canonical trove classifiers. Metadata-only — no code/test change, and not under `src/`|`rust/` so it doesn't trigger the version-bump workflow.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)