### PR TITLE
fix(csv): cap per-line buffering to bound memory on malformed input

### DIFF
--- a/rust/datagrunt-core/src/io.rs
+++ b/rust/datagrunt-core/src/io.rs
@@ -8,6 +8,19 @@ use std::path::Path;
 const BOM: &[u8] = b"\xef\xbb\xbf";
 const CHUNK_SIZE: usize = 64 * 1024;
 
+/// Per-physical-line cap (chars), identical to Python _compute_python.MAX_LINE_CHARS.
+pub const MAX_LINE_CHARS: usize = 2 * 1024 * 1024;
+/// Byte read bound: 4x the char cap (UTF-8 is ≤4 bytes/char), so the char cap
+/// is always the binding limit and memory stays bounded.
+const MAX_LINE_READ_BYTES: usize = MAX_LINE_CHARS * 4;
+
+/// Truncate `s` to at most `n` Unicode scalar values (chars).
+///
+/// Unlike a byte slice, this always lands on a valid char boundary.
+pub fn take_chars(s: &str, n: usize) -> String {
+    s.chars().take(n).collect()
+}
+
 /// Python `errors="ignore"`: invalid byte sequences are dropped, not replaced.
 pub fn decode_ignore(bytes: &[u8]) -> String {
     let mut out = String::with_capacity(bytes.len());
@@ -323,8 +336,47 @@ impl UniversalLines {
         Ok(())
     }
 
+    /// Skip bytes in the stream until (and including) the next `\r`, `\n`, or
+    /// `\r\n` terminator. Called after capping a giant line to restore
+    /// line-stream alignment.
+    fn skip_to_next_line(&mut self) -> std::io::Result<()> {
+        loop {
+            let mut i = self.pos;
+            while i < self.buf.len() {
+                match self.buf[i] {
+                    b'\n' => {
+                        self.pos = i + 1;
+                        return Ok(());
+                    }
+                    b'\r' => {
+                        // Need lookahead for \r\n.
+                        if i + 1 == self.buf.len() && !self.eof {
+                            // Keep the \r in the buffer and read more for lookahead.
+                            self.pos = i;
+                            self.fill()?;
+                            // Restart scan; self.pos still points at the \r.
+                            break;
+                        }
+                        let next_is_lf = self.buf.get(i + 1) == Some(&b'\n');
+                        self.pos = i + 1 + usize::from(next_is_lf);
+                        return Ok(());
+                    }
+                    _ => i += 1,
+                }
+            }
+            if self.eof {
+                self.pos = self.buf.len();
+                return Ok(());
+            }
+            // No terminator found yet; drain scanned bytes and read more.
+            self.pos = i;
+            self.fill()?;
+        }
+    }
+
     /// Decode one universal-newline-delimited line (without terminator), or
-    /// `None` at EOF. Errors propagate.
+    /// `None` at EOF. Lines are capped at `MAX_LINE_CHARS` characters so a
+    /// pathological newline-free file cannot force unbounded buffering.
     fn next_line(&mut self) -> std::io::Result<Option<String>> {
         if !self.bom_checked {
             self.check_bom()?;
@@ -335,7 +387,8 @@ impl UniversalLines {
             while i < self.buf.len() {
                 match self.buf[i] {
                     b'\n' => {
-                        let line = decode_ignore(&self.buf[self.pos..i]);
+                        let raw = decode_ignore(&self.buf[self.pos..i]);
+                        let line = take_chars(&raw, MAX_LINE_CHARS);
                         self.pos = i + 1;
                         return Ok(Some(line));
                     }
@@ -345,7 +398,8 @@ impl UniversalLines {
                         if i + 1 == self.buf.len() && !self.eof {
                             break;
                         }
-                        let line = decode_ignore(&self.buf[self.pos..i]);
+                        let raw = decode_ignore(&self.buf[self.pos..i]);
+                        let line = take_chars(&raw, MAX_LINE_CHARS);
                         let next_is_lf = self.buf.get(i + 1) == Some(&b'\n');
                         self.pos = i + 1 + usize::from(next_is_lf);
                         return Ok(Some(line));
@@ -356,13 +410,26 @@ impl UniversalLines {
             // No complete line in the buffer. Read more, or flush the tail.
             if self.eof {
                 if self.pos < self.buf.len() {
-                    let line = decode_ignore(&self.buf[self.pos..]);
+                    let raw = decode_ignore(&self.buf[self.pos..]);
+                    let line = take_chars(&raw, MAX_LINE_CHARS);
                     self.pos = self.buf.len();
                     return Ok(Some(line));
                 }
                 return Ok(None);
             }
             self.fill()?;
+            // Cap: if we've buffered more than MAX_LINE_READ_BYTES without
+            // finding a newline, emit the capped line and stream-skip the rest.
+            // This prevents unbounded allocation on malformed newline-free files.
+            let unread = self.buf.len() - self.pos;
+            if unread >= MAX_LINE_READ_BYTES {
+                let cap_end = self.pos + MAX_LINE_READ_BYTES;
+                let raw = decode_ignore(&self.buf[self.pos..cap_end]);
+                let line = take_chars(&raw, MAX_LINE_CHARS);
+                self.pos = cap_end;
+                self.skip_to_next_line()?;
+                return Ok(Some(line));
+            }
         }
     }
 }
@@ -718,5 +785,117 @@ mod tests {
         assert!(is_tsv(std::path::Path::new("x.tsv")));
         assert!(is_tsv(std::path::Path::new("x.TSV")));
         assert!(!is_tsv(std::path::Path::new("x.csv")));
+    }
+
+    // --- per-line cap tests (issue #222) ---
+
+    /// A line whose char count slightly exceeds MAX_LINE_CHARS (no newline until
+    /// EOF) must be truncated to exactly MAX_LINE_CHARS chars on the EOF flush
+    /// path. The file is ~2 MB — no stream-skip needed; the cap applies in the
+    /// EOF tail flush branch.
+    #[test]
+    fn cap_giant_eof_line_truncated_to_max_chars() {
+        // MAX_LINE_CHARS + 100 ASCII bytes, no newline until EOF.
+        let content: Vec<u8> = b"a".repeat(MAX_LINE_CHARS + 100);
+        let f = tmp(&content, ".csv");
+        let lines = read_universal_lines(f.path()).unwrap();
+        assert_eq!(lines.len(), 1, "should yield exactly one line");
+        assert_eq!(
+            lines[0].chars().count(),
+            MAX_LINE_CHARS,
+            "line must be capped at MAX_LINE_CHARS chars"
+        );
+    }
+
+    /// Giant ASCII line terminated by '\n' followed by a normal line.
+    /// The first line exceeds MAX_LINE_CHARS, so it must be capped; the second
+    /// line must still be read correctly (alignment after cap applies).
+    #[test]
+    fn cap_giant_lf_line_then_next_line_reads_correctly() {
+        // Build a file: (MAX_LINE_CHARS + 50) 'a' bytes + '\n' + "next_line\n".
+        // The first physical line has MAX_LINE_CHARS + 50 chars (all ASCII).
+        let mut content: Vec<u8> = b"a".repeat(MAX_LINE_CHARS + 50);
+        content.extend_from_slice(b"\nnext_line\n");
+        let f = tmp(&content, ".csv");
+        let lines = read_universal_lines(f.path()).unwrap();
+        assert_eq!(lines.len(), 2, "should yield the giant line and the next line");
+        assert_eq!(
+            lines[0].chars().count(),
+            MAX_LINE_CHARS,
+            "giant line capped at MAX_LINE_CHARS"
+        );
+        assert_eq!(lines[1], "next_line", "second line must read correctly after cap");
+    }
+
+    /// Giant line terminated by '\r\n' must be capped and the '\r\n' counted
+    /// as a single line terminator (not two). The line after it must be intact.
+    #[test]
+    fn cap_giant_crlf_line_then_next_line_reads_correctly() {
+        let mut content: Vec<u8> = b"b".repeat(MAX_LINE_CHARS + 50);
+        content.extend_from_slice(b"\r\nnext_line\n");
+        let f = tmp(&content, ".csv");
+        let lines = read_universal_lines(f.path()).unwrap();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].chars().count(), MAX_LINE_CHARS);
+        assert_eq!(lines[1], "next_line");
+    }
+
+    /// Multibyte char (€, 3 bytes) placed just before the char boundary:
+    /// (MAX_LINE_CHARS - 1) ASCII 'a's + '€' + 200 more 'a's.
+    /// The line has MAX_LINE_CHARS + 200 chars total; truncation must yield
+    /// exactly MAX_LINE_CHARS chars = (MAX_LINE_CHARS - 1) 'a's + '€'.
+    #[test]
+    fn cap_multibyte_char_at_boundary() {
+        let mut content: Vec<u8> = b"a".repeat(MAX_LINE_CHARS - 1);
+        content.extend_from_slice("€".as_bytes()); // 3-byte UTF-8 char
+        content.extend_from_slice(&b"a".repeat(200));
+        content.push(b'\n');
+        let f = tmp(&content, ".csv");
+        let lines = read_universal_lines(f.path()).unwrap();
+        assert_eq!(lines.len(), 1);
+        let line = &lines[0];
+        assert_eq!(
+            line.chars().count(),
+            MAX_LINE_CHARS,
+            "truncation must yield exactly MAX_LINE_CHARS chars"
+        );
+        // The last included char must be '€' (char index MAX_LINE_CHARS - 1).
+        assert_eq!(
+            line.chars().last().unwrap(),
+            '€',
+            "multibyte char at boundary must be the last included char"
+        );
+    }
+
+    /// A file with no newline and exactly MAX_LINE_READ_BYTES bytes triggers
+    /// the stream-skip path in next_line (not the EOF flush). The resulting
+    /// line must contain exactly MAX_LINE_CHARS chars, and no extra lines are
+    /// produced.
+    ///
+    /// NOTE: this test allocates ~8 MB + small overhead — it is intentionally
+    /// larger than the unit tests above because it targets the stream-skip branch
+    /// specifically (the EOF-flush branch fires first for smaller inputs).
+    #[test]
+    fn cap_stream_skip_path_giant_no_newline() {
+        // MAX_LINE_READ_BYTES = 4 * MAX_LINE_CHARS bytes, all ASCII.
+        // After this many bytes without a '\n', next_line must cap + skip.
+        let content: Vec<u8> = b"x".repeat(MAX_LINE_READ_BYTES + 100);
+        let f = tmp(&content, ".csv");
+        let lines = read_universal_lines(f.path()).unwrap();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].chars().count(), MAX_LINE_CHARS);
+    }
+
+    /// Stream-skip path followed by a valid next line: the giant (>MAX_LINE_READ_BYTES)
+    /// line is capped and the line after the terminator is read intact.
+    #[test]
+    fn cap_stream_skip_then_next_line() {
+        let mut content: Vec<u8> = b"z".repeat(MAX_LINE_READ_BYTES + 100);
+        content.extend_from_slice(b"\nafter_giant\n");
+        let f = tmp(&content, ".csv");
+        let lines = read_universal_lines(f.path()).unwrap();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].chars().count(), MAX_LINE_CHARS);
+        assert_eq!(lines[1], "after_giant");
     }
 }

--- a/rust/datagrunt-core/src/io.rs
+++ b/rust/datagrunt-core/src/io.rs
@@ -12,7 +12,7 @@ const CHUNK_SIZE: usize = 64 * 1024;
 pub const MAX_LINE_CHARS: usize = 2 * 1024 * 1024;
 /// Byte read bound: 4x the char cap (UTF-8 is ≤4 bytes/char), so the char cap
 /// is always the binding limit and memory stays bounded.
-const MAX_LINE_READ_BYTES: usize = MAX_LINE_CHARS * 4;
+pub const MAX_LINE_READ_BYTES: usize = MAX_LINE_CHARS * 4;
 
 /// Truncate `s` to at most `n` Unicode scalar values (chars).
 ///
@@ -42,6 +42,38 @@ pub fn decode_ignore(bytes: &[u8]) -> String {
                 // tail, so consuming all of it is correct.
                 let skip = e.error_len().unwrap_or(after.len());
                 rest = &after[skip..];
+            }
+        }
+    }
+    out
+}
+
+/// Decode bytes with errors="ignore", carrying any incomplete trailing
+/// multibyte sequence into `carry` for the next call (boundary-safe).
+/// Truly-invalid bytes are dropped. Used by the cap accumulation loop in
+/// `UniversalLines::next_line` to avoid splitting multibyte chars at chunk
+/// boundaries while streaming through a giant line.
+fn decode_chunk_with_carry(bytes: &[u8], carry: &mut Vec<u8>) -> String {
+    let mut out = String::with_capacity(bytes.len());
+    let mut rest = bytes;
+    loop {
+        match std::str::from_utf8(rest) {
+            Ok(s) => {
+                out.push_str(s);
+                break;
+            }
+            Err(e) => {
+                let (valid, after) = rest.split_at(e.valid_up_to());
+                // SAFETY: `from_utf8` validated `0..valid_up_to()`.
+                out.push_str(unsafe { std::str::from_utf8_unchecked(valid) });
+                match e.error_len() {
+                    Some(skip) => rest = &after[skip..], // truly invalid: drop
+                    None => {
+                        // Incomplete multibyte sequence at chunk boundary: carry forward.
+                        carry.extend_from_slice(after);
+                        break;
+                    }
+                }
             }
         }
     }
@@ -420,13 +452,66 @@ impl UniversalLines {
             self.fill()?;
             // Cap: if we've buffered more than MAX_LINE_READ_BYTES without
             // finding a newline, emit the capped line and stream-skip the rest.
-            // This prevents unbounded allocation on malformed newline-free files.
+            // Budget on DECODED chars (not raw bytes) for parity with Python's
+            // `decode(errors="ignore"); line[:MAX_LINE_CHARS]`. An all-invalid
+            // byte stream never accumulates MAX_LINE_CHARS chars, but raw bytes
+            // are drained as we go, keeping memory bounded.
             let unread = self.buf.len() - self.pos;
             if unread >= MAX_LINE_READ_BYTES {
-                let cap_end = self.pos + MAX_LINE_READ_BYTES;
-                let raw = decode_ignore(&self.buf[self.pos..cap_end]);
-                let line = take_chars(&raw, MAX_LINE_CHARS);
-                self.pos = cap_end;
+                let mut line = String::with_capacity(MAX_LINE_CHARS * 4);
+                let mut decoded_char_count: usize = 0;
+                let mut carry: Vec<u8> = Vec::new();
+
+                while decoded_char_count < MAX_LINE_CHARS {
+                    // Drain already-processed bytes to keep memory bounded.
+                    if self.pos > 0 {
+                        self.buf.drain(..self.pos);
+                        self.pos = 0;
+                    }
+                    if self.buf.is_empty() {
+                        if self.eof {
+                            break;
+                        }
+                        self.fill()?;
+                        if self.buf.is_empty() {
+                            break;
+                        }
+                    }
+                    // Scan for newline so we don't over-read past the line end.
+                    let scan_end = self.buf.len().min(CHUNK_SIZE);
+                    let nl_pos = self.buf[..scan_end]
+                        .iter()
+                        .position(|&b| b == b'\n' || b == b'\r');
+                    let chunk_end = nl_pos.unwrap_or(scan_end);
+
+                    // Prepend any incomplete multibyte carry from previous chunk.
+                    let to_decode: Vec<u8> = if carry.is_empty() {
+                        self.buf[..chunk_end].to_vec()
+                    } else {
+                        let mut v = std::mem::take(&mut carry);
+                        v.extend_from_slice(&self.buf[..chunk_end]);
+                        v
+                    };
+
+                    let decoded = decode_chunk_with_carry(&to_decode, &mut carry);
+                    let need = MAX_LINE_CHARS - decoded_char_count;
+                    let added: String = decoded.chars().take(need).collect();
+                    decoded_char_count += added.chars().count();
+                    line.push_str(&added);
+                    self.pos = chunk_end;
+
+                    // If we hit a newline mid-scan, stop accumulating — let
+                    // skip_to_next_line handle the terminator.
+                    if nl_pos.is_some() {
+                        break;
+                    }
+                }
+                // Drain remaining processed bytes before skip.
+                if self.pos > 0 {
+                    self.buf.drain(..self.pos);
+                    self.pos = 0;
+                }
+                // carry holds an incomplete multibyte seq — drop it (errors="ignore").
                 self.skip_to_next_line()?;
                 return Ok(Some(line));
             }
@@ -897,5 +982,59 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].chars().count(), MAX_LINE_CHARS);
         assert_eq!(lines[1], "after_giant");
+    }
+
+    /// Invalid bytes followed by 4-byte chars (😀): the cap branch must yield
+    /// exactly MAX_LINE_CHARS decoded chars, not MAX_LINE_CHARS minus the number
+    /// of dropped invalid bytes. Reproduces the raw-byte-budget parity bug.
+    #[test]
+    fn cap_invalid_bytes_then_4byte_chars_parity() {
+        let four_byte: &[u8] = "😀".as_bytes(); // 4 bytes per char
+        let n = MAX_LINE_CHARS + 50;
+        let mut content = vec![0xFF_u8]; // 1 invalid byte (dropped on decode)
+        for _ in 0..n {
+            content.extend_from_slice(four_byte);
+        }
+        // No newline: cap + EOF path fires.
+        let f = tmp(&content, ".csv");
+        let lines = read_universal_lines(f.path()).unwrap();
+        assert_eq!(lines.len(), 1, "should yield exactly one line");
+        assert_eq!(
+            lines[0].chars().count(),
+            MAX_LINE_CHARS,
+            "must yield exactly MAX_LINE_CHARS decoded chars (not MAX_LINE_CHARS - dropped_bytes)"
+        );
+    }
+
+    /// All-invalid-byte input with no newline must terminate with bounded memory
+    /// and yield an empty or very short result (all bytes dropped on decode).
+    #[test]
+    fn cap_all_invalid_bytes_no_newline_bounded_and_completes() {
+        let content: Vec<u8> = vec![0xFF; MAX_LINE_READ_BYTES + 100];
+        let f = tmp(&content, ".csv");
+        let lines = read_universal_lines(f.path()).unwrap();
+        assert!(
+            lines.is_empty() || (lines.len() == 1 && lines[0].is_empty()),
+            "all-invalid no-newline: expected 0 or 1 empty line, got {:?}",
+            lines
+        );
+    }
+
+    /// Invalid byte + 4-byte chars giant line followed by a normal line:
+    /// after capping, the next line must still read correctly.
+    #[test]
+    fn cap_invalid_bytes_4byte_chars_then_next_line() {
+        let four_byte: &[u8] = "😀".as_bytes();
+        let n = MAX_LINE_CHARS + 50;
+        let mut content = vec![0xFF_u8];
+        for _ in 0..n {
+            content.extend_from_slice(four_byte);
+        }
+        content.extend_from_slice(b"\nnext_line_ok\n");
+        let f = tmp(&content, ".csv");
+        let lines = read_universal_lines(f.path()).unwrap();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].chars().count(), MAX_LINE_CHARS);
+        assert_eq!(lines[1], "next_line_ok");
     }
 }

--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -2,15 +2,10 @@
 
 use crate::io::{
     decode_ignore, is_empty, is_legacy_mac_newlines, take_chars, universal_lines, DecodedReader,
-    MAX_LINE_CHARS,
+    MAX_LINE_CHARS, MAX_LINE_READ_BYTES,
 };
 use std::io::{self, BufRead, BufReader};
 use std::path::Path;
-
-/// Byte read bound for probe_csv_header: 4x the char cap (UTF-8 ≤4 bytes/char),
-/// matching io.rs MAX_LINE_READ_BYTES. Prevents unbounded `segment` growth on
-/// malformed newline-free files.
-const MAX_LINE_READ_BYTES: usize = MAX_LINE_CHARS * 4;
 
 // ---- probe_csv_header constants ----
 /// Python CANDIDATE_SAMPLE_ROWS = 5.

--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -1,8 +1,13 @@
 //! Ports of CSVRows probes and the leading-line counters.
 
-use crate::io::{is_empty, is_legacy_mac_newlines, universal_lines, DecodedReader};
+use crate::io::{is_empty, is_legacy_mac_newlines, take_chars, universal_lines, DecodedReader, MAX_LINE_CHARS};
 use std::io::{self, BufRead, BufReader};
 use std::path::Path;
+
+/// Byte read bound for probe_csv_header: 4x the char cap (UTF-8 ≤4 bytes/char),
+/// matching io.rs MAX_LINE_READ_BYTES. Prevents unbounded `segment` growth on
+/// malformed newline-free files.
+const MAX_LINE_READ_BYTES: usize = MAX_LINE_CHARS * 4;
 
 // ---- probe_csv_header constants ----
 /// Python CANDIDATE_SAMPLE_ROWS = 5.
@@ -52,14 +57,59 @@ pub fn probe_csv_header(path: &Path) -> std::io::Result<HeaderProbe> {
     let mut saw_nonblank = false;
     let mut segment: Vec<u8> = Vec::new();
     loop {
+        // Bounded read: accumulate bytes up to MAX_LINE_READ_BYTES or until
+        // we find a '\n' (whichever comes first). If we hit the byte cap
+        // before finding '\n', stream-skip the rest of the physical line so
+        // a malformed newline-free file cannot grow `segment` without bound.
         segment.clear();
-        let n = reader.read_until(b'\n', &mut segment)?;
-        if n == 0 {
+        let mut total_read = 0usize;
+        let mut found_newline = false;
+        loop {
+            let available = reader.fill_buf()?;
+            if available.is_empty() {
+                break; // EOF
+            }
+            let newline_pos = available.iter().position(|&b| b == b'\n');
+            let take = if let Some(pos) = newline_pos {
+                pos + 1 // include the '\n'
+            } else {
+                available.len()
+            };
+            let budget = MAX_LINE_READ_BYTES.saturating_sub(total_read);
+            let capped_take = take.min(budget);
+            segment.extend_from_slice(&available[..capped_take]);
+            reader.consume(capped_take);
+            total_read += capped_take;
+            if newline_pos.map_or(false, |pos| capped_take >= pos + 1) {
+                found_newline = true;
+                break;
+            }
+            if total_read >= MAX_LINE_READ_BYTES {
+                // Byte cap hit before newline: stream-skip to end of line.
+                loop {
+                    let avail2 = reader.fill_buf()?;
+                    if avail2.is_empty() {
+                        break; // EOF
+                    }
+                    let nl = avail2.iter().position(|&b| b == b'\n');
+                    if let Some(pos) = nl {
+                        reader.consume(pos + 1);
+                        break;
+                    } else {
+                        let len = avail2.len();
+                        reader.consume(len);
+                    }
+                }
+                break;
+            }
+        }
+        if total_read == 0 && !found_newline {
             break; // EOF
         }
-        // DecodedReader yields valid UTF-8 only.
-        let text =
+        // DecodedReader yields valid UTF-8 only; apply char cap for parity.
+        let raw =
             String::from_utf8(std::mem::take(&mut segment)).expect("DecodedReader yields UTF-8");
+        let text = take_chars(&raw, MAX_LINE_CHARS);
         // `stripped` mirrors Python's `line.strip()`.
         let stripped = text.trim();
         if !stripped.is_empty() {

--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -1,6 +1,9 @@
 //! Ports of CSVRows probes and the leading-line counters.
 
-use crate::io::{is_empty, is_legacy_mac_newlines, take_chars, universal_lines, DecodedReader, MAX_LINE_CHARS};
+use crate::io::{
+    decode_ignore, is_empty, is_legacy_mac_newlines, take_chars, universal_lines, DecodedReader,
+    MAX_LINE_CHARS,
+};
 use std::io::{self, BufRead, BufReader};
 use std::path::Path;
 
@@ -106,9 +109,13 @@ pub fn probe_csv_header(path: &Path) -> std::io::Result<HeaderProbe> {
         if total_read == 0 && !found_newline {
             break; // EOF
         }
-        // DecodedReader yields valid UTF-8 only; apply char cap for parity.
-        let raw =
-            String::from_utf8(std::mem::take(&mut segment)).expect("DecodedReader yields UTF-8");
+        // Decode with `decode_ignore` (not `from_utf8`): the byte-cap path above
+        // can stop mid-multibyte-char at MAX_LINE_READ_BYTES, leaving an
+        // incomplete trailing sequence in `segment`. `decode_ignore` drops it
+        // (matching io.rs and Python's errors="ignore"), so a malformed
+        // newline-free file cannot panic across the PyO3 boundary. Then apply
+        // the char cap for parity with the Python reference.
+        let raw = decode_ignore(&segment);
         let text = take_chars(&raw, MAX_LINE_CHARS);
         // `stripped` mirrors Python's `line.strip()`.
         let stripped = text.trim();
@@ -319,5 +326,23 @@ mod tests {
         assert_eq!(p.sample_lines[0], "\n"); // the blank line
         assert_eq!(p.sample_lines[1], "name,age\n");
         assert_eq!(p.sample_lines[2], "Alice,30\n");
+    }
+
+    /// Regression (panic-DoS): a newline-free line whose bytes exceed
+    /// MAX_LINE_READ_BYTES with a multibyte char straddling the byte cap must
+    /// NOT panic. The byte-cap chop leaves an incomplete UTF-8 sequence in the
+    /// buffer; `decode_ignore` drops it instead of `from_utf8` panicking across
+    /// the PyO3 boundary.
+    #[test]
+    fn probe_multibyte_straddling_byte_cap_does_not_panic() {
+        // (MAX_LINE_READ_BYTES - 1) ASCII bytes + '€' (3 bytes): the byte cap at
+        // MAX_LINE_READ_BYTES slices the first byte of '€', leaving an incomplete
+        // sequence. No trailing newline (pure #222 scenario).
+        let mut content: Vec<u8> = b"a".repeat(MAX_LINE_READ_BYTES - 1);
+        content.extend_from_slice("€".as_bytes());
+        let f = tmp(&content);
+        let p = probe_csv_header(f.path()).unwrap(); // must not panic
+        assert_eq!(p.first_row.chars().count(), MAX_LINE_CHARS);
+        assert_eq!(p.sample_lines[0].chars().count(), MAX_LINE_CHARS);
     }
 }

--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -340,4 +340,22 @@ mod tests {
         assert_eq!(p.first_row.chars().count(), MAX_LINE_CHARS);
         assert_eq!(p.sample_lines[0].chars().count(), MAX_LINE_CHARS);
     }
+
+    /// Parity-class lock: a giant line of a leading invalid byte + all-4-byte
+    /// chars. The probe budgets on the DECODED stream (DecodedReader drops the
+    /// invalid byte before the byte budget), so 8 MiB of decoded 4-byte chars is
+    /// exactly MAX_LINE_CHARS chars — matching Python's decode-then-slice. This
+    /// guards the probe path against the raw-vs-decoded-budget bug class that was
+    /// fixed in io.rs (the probe was already correct via DecodedReader; this keeps
+    /// it that way). A pure (undelimited) case can't live in the shared parity
+    /// corpus because Python's csv.field_size_limit would trip in row-count parity.
+    #[test]
+    fn probe_giant_4byte_with_leading_invalid_byte_yields_full_char_cap() {
+        let mut content: Vec<u8> = vec![0xff];
+        content.extend_from_slice("\u{1F600}".repeat(MAX_LINE_CHARS + 50).as_bytes());
+        let f = tmp(&content);
+        let p = probe_csv_header(f.path()).unwrap();
+        assert_eq!(p.first_row.chars().count(), MAX_LINE_CHARS);
+        assert_eq!(p.sample_lines[0].chars().count(), MAX_LINE_CHARS);
+    }
 }

--- a/src/datagrunt/core/csv_io/_compute_python.py
+++ b/src/datagrunt/core/csv_io/_compute_python.py
@@ -42,6 +42,22 @@ SPECIAL_CHARS_PATTERN = re.compile(r"[^a-z0-9]+")
 MULTI_UNDERSCORE_PATTERN = re.compile(r"_+")
 EMPTY_NAME_PLACEHOLDER = "column"
 
+# Bound per-physical-line length so a malformed newline-free file (one giant
+# line) cannot force unbounded buffering (issue #222). 2Mi chars is far above
+# any realistic CSV line/header, so this only ever truncates pathological input.
+MAX_LINE_CHARS = 2 * 1024 * 1024
+
+
+def _capped_lines(f):
+    """Yield each line from a text file, truncated to ``MAX_LINE_CHARS`` chars.
+
+    Mirrors the Rust line readers' per-line cap so the two backends agree on
+    pathological (multi-MB single-line) input. The cap is by character count
+    (identical to Rust's), keeping parity decode-agnostic.
+    """
+    for line in f:
+        yield line if len(line) <= MAX_LINE_CHARS else line[:MAX_LINE_CHARS]
+
 
 def is_legacy_mac_newlines(filepath):
     """True if the file uses legacy Mac OS carriage returns (\\r) as line endings."""
@@ -57,7 +73,7 @@ def count_leading_comments(filepath):
     """Count leading ``#``-prefixed comment lines before the header (blanks skipped)."""
     count = 0
     with open(filepath, "r", encoding=FileProperties(filepath).DEFAULT_ENCODING, errors="ignore") as f:
-        for line in f:
+        for line in _capped_lines(f):
             stripped = line.strip()
             if stripped.startswith("#"):
                 count += 1
@@ -72,7 +88,7 @@ def count_leading_physical_lines_before_header(filepath):
     """Count every leading physical line up to and including the header line."""
     count = 0
     with open(filepath, "r", encoding=FileProperties(filepath).DEFAULT_ENCODING, errors="ignore") as f:
-        for line in f:
+        for line in _capped_lines(f):
             stripped = line.strip()
             count += 1
             if stripped and not stripped.startswith("#"):
@@ -84,7 +100,7 @@ def leading_rows(filepath, limit):
     """Up to ``limit`` leading non-blank, non-comment rows, each stripped."""
     rows = []
     with open(filepath, "r", encoding=FileProperties(filepath).DEFAULT_ENCODING, errors="ignore") as f:
-        for line in f:
+        for line in _capped_lines(f):
             stripped = line.strip()
             if stripped and not stripped.startswith("#"):
                 rows.append(stripped)
@@ -187,7 +203,7 @@ def probe_csv_header(filepath):
     sample_rows = []
     saw_nonblank = False
     with open(filepath, "r", encoding=props.DEFAULT_ENCODING, errors="ignore") as f:
-        for line in f:
+        for line in _capped_lines(f):
             stripped = line.strip()
             if stripped:
                 saw_nonblank = True

--- a/tests/core_tests/csv_io_tests/test_line_length_cap.py
+++ b/tests/core_tests/csv_io_tests/test_line_length_cap.py
@@ -1,0 +1,29 @@
+"""Per-line cap bounds pathological newline-free input (issue #222)."""
+from datagrunt.core.csv_io import _compute_python as py
+
+
+def test_probe_caps_giant_single_line(tmp_path):
+    path = tmp_path / "huge.csv"
+    # One physical line, no newline, far over the cap.
+    path.write_bytes(b"a," * (py.MAX_LINE_CHARS))  # ~2x cap in chars
+    probe = py.probe_csv_header(str(path))
+    assert probe["sample_lines"], "should still yield the (capped) line"
+    assert len(probe["sample_lines"][0]) <= py.MAX_LINE_CHARS
+    assert len(probe["first_row"]) <= py.MAX_LINE_CHARS
+
+
+def test_realistic_wide_line_is_unaffected(tmp_path):
+    path = tmp_path / "wide.csv"
+    header = ",".join(f"col{i}" for i in range(5000))  # wide but << cap
+    path.write_text(header + "\n1,2\n")
+    probe = py.probe_csv_header(str(path))
+    assert probe["first_row"] == header  # not truncated
+    assert py.infer_delimiter(str(path)) == ","
+
+
+def test_leading_rows_caps_long_line(tmp_path):
+    path = tmp_path / "long.csv"
+    path.write_text(("x" * (py.MAX_LINE_CHARS + 10)) + "\nsecond\n")
+    rows = py.leading_rows(str(path), 5)
+    assert len(rows[0]) <= py.MAX_LINE_CHARS
+    assert rows[1] == "second"  # line alignment preserved after a capped line

--- a/tests/parity/corpus.py
+++ b/tests/parity/corpus.py
@@ -63,4 +63,25 @@ CORPUS: dict[str, bytes] = {
     # quoted \r must stay part of one record rather than splitting the row.
     # Exercises the legacy-mac branch and quoting together for both backends.
     "legacy_mac_quoted_cr.csv": b'id,note\r1,"line one\rline two"\r2,plain\r',
+    # Giant-line entries for per-line cap parity (issue #222 / #176).
+    # These verify that both backends truncate to exactly MAX_LINE_CHARS chars
+    # and that char-based (not byte-based) counting governs the boundary.
+    #
+    # (a) Giant ASCII line: 2,252,800 chars > MAX_LINE_CHARS (2,097,152).
+    #     Both backends must yield exactly MAX_LINE_CHARS chars from this line.
+    "giant_ascii_line.csv": b"a," * 1_126_400 + b"\n",
+    # (b) Giant line with a 3-byte UTF-8 char (€) placed right at the char
+    #     boundary. The line uses a comma-delimited "a," pattern so no single
+    #     field exceeds CPython's csv field-size limit (the cap is per physical
+    #     line, not per field); the '€' lands at char index MAX_LINE_CHARS-1
+    #     (the last char kept by truncation). 2Mi-2 pattern chars + 'a' + '€'
+    #     puts '€' exactly on the boundary, then ",more" overflows the cap.
+    #     Verifies Rust counts CHARS (not bytes) and lands on the multibyte char.
+    "giant_multibyte_near_cap.csv": (
+        b"a," * (1024 * 1024 - 1) + b"a" + "€".encode("utf-8") + b",more,fields,here\n"
+    ),
+    # (c) Giant line terminated with \r\n followed by a normal data line.
+    #     After capping the giant line, the next line must still be read
+    #     correctly — validates stream-skip alignment for both backends.
+    "giant_crlf_line.csv": b"b," * 1_126_400 + b"\r\nnext_line\n",
 }

--- a/tests/parity/corpus.py
+++ b/tests/parity/corpus.py
@@ -84,4 +84,25 @@ CORPUS: dict[str, bytes] = {
     #     After capping the giant line, the next line must still be read
     #     correctly — validates stream-skip alignment for both backends.
     "giant_crlf_line.csv": b"b," * 1_126_400 + b"\r\nnext_line\n",
+    # (d) Giant line with a LEADING invalid UTF-8 byte followed by a long run
+    #     of comma-delimited 4-byte chars (😀). Repro for the raw-byte-budget
+    #     bug: the leading \xff is dropped by errors="ignore", so a byte-budgeted
+    #     decoder yields MAX_LINE_CHARS-1 chars while Python decodes the whole
+    #     line then slices [:MAX_LINE_CHARS]. Both backends must yield exactly
+    #     MAX_LINE_CHARS decoded chars (budget on DECODED chars, not raw bytes).
+    #
+    #     Uses a comma-delimited "😀," pattern (each field is a single 😀, well
+    #     under CPython's csv field-size limit — the cap is per physical line,
+    #     not per field). 1_800_000 reps = 9,000,000 raw bytes (> 8 MiB
+    #     MAX_LINE_READ_BYTES, so the streaming cap branch fires) and 3,600,000
+    #     decoded chars (> 2 Mi MAX_LINE_CHARS).
+    "giant_invalid_leading_byte.csv": (
+        b"\xff" + "😀,".encode("utf-8") * 1_800_000 + b"\n"
+    ),
+    # (e) Same shape as (d) but WITHOUT the leading invalid byte: no dropped
+    #     bytes. Both backends must still yield exactly MAX_LINE_CHARS chars —
+    #     verifies the fix does not regress clean 4-byte-char giant lines.
+    "giant_4byte_chars_no_invalid.csv": (
+        "😀,".encode("utf-8") * 1_800_000 + b"\n"
+    ),
 }


### PR DESCRIPTION
Bounds per-physical-line buffering in the CSV line readers so a malformed newline-free file (one multi-GB line) cannot force unbounded allocation. Closes #222; addresses #176's sniff-line-cap (the sniff sample derives from the now-capped `probe_csv_header`).

## Design
A single character-based cap, identical in both backends: `MAX_LINE_CHARS = 2*1024*1024` (2Mi chars — far above any realistic CSV line; only ever truncates pathological input). **Truncate, not error** (preserve-not-transform: never raises on user data, never corrupts row counts). Char-based so Rust↔Python parity is decode-agnostic; Rust additionally bounds the byte read at `4×` the char cap and **stream-skips** the rest of the physical line, giving the default path a real memory bound.

- `daa4dcf` — Python reference: `_capped_lines` helper across `probe_csv_header`/`leading_rows`/comment counters.
- `106daaa` — Rust port: cap `UniversalLines::next_line` + `probe_csv_header`; new parity corpus cases; Rust unit tests.
- `e6da8c3` — **security fix:** the probe's byte-cap path used `from_utf8().expect()`, which panics when the cap chops a multibyte char (panic across PyO3 = DoS). Switched to `decode_ignore` (matching `io.rs` + Python `errors="ignore"`) + regression test.
- `88cc9a0` — **parity fix:** `io.rs` budgeted on raw bytes, so a `>2Mi`-char line mixing dropped invalid bytes with 4-byte chars yielded fewer chars than Python. Restructured to budget on **decoded** chars (boundary-safe, still memory-bounded even for all-invalid input); single-sourced `MAX_LINE_READ_BYTES`; corpus cases.
- `46a5083` — lock the probe path (verified already correct via `DecodedReader`) with a pure-4-byte-char unit test.

## Memory bound
Peak is O(CHUNK_SIZE + MAX_LINE_CHARS), not O(line length) — including an all-invalid-byte no-newline line (raw bytes are drained as scanned; the decoded accumulator is capped).

## Scope / residual
The csv-crate record path (`row_count_with_header`/`check_ragged`) is a distinct mechanism: Python's `csv` already bounds fields via `csv.field_size_limit` (raises); the Rust `csv` crate has no field cap. Documented as a residual, not forced (a giant single *field* ≠ a giant *line*; it doesn't affect counts).

## Testing
- `cargo test` 52 · differential parity 567 (incl. giant ASCII / multibyte-at-byte-cap / CRLF / leading-invalid+4-byte corpus cases) · `pytest tests/` both backends 1115 · `ruff` clean.
- Exact repro now matches: `b"\xff" + "😀"*(2Mi+50)` → Rust 2,097,152 == Python 2,097,152.

## Review
Subagent-driven with per-task reviews + an Opus final review (caught the io.rs raw-vs-decoded parity bug → fixed) + an automated security review (caught the `from_utf8` panic → fixed) + an Opus re-review whose "probe still diverges" finding was empirically disproven (full probe dict matches Python on the pure repro) and instead locked with a unit test.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)