### PR TITLE
fix(pdf): cap PageLayoutSorter recursion depth (RecursionError DoS)

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
+++ b/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
@@ -11,6 +11,15 @@ import math
 # affects legitimate layouts.
 MAX_HISTOGRAM_BINS = 100_000
 
+# Maximum recursion depth for partition() and its re-entrant helpers. A
+# crafted 'staircase' PDF layout that peels one item per recursive level drives
+# O(n) stack depth and raises RecursionError beyond ~1000 items. Real
+# multi-column pages never nest more than a handful of levels (left/right then
+# sub-columns), so 32 is well above any legitimate need. When the cap is
+# reached, the remaining items are returned as a single unsplit segment --
+# all content is preserved, only sub-column ordering is coarser.
+MAX_PARTITION_DEPTH = 32
+
 
 class LayoutAdapter:
     """Interface to abstract coordinate and weight access for different item types."""
@@ -65,10 +74,22 @@ class PageLayoutSorter:
             sorted_elements.extend(seg)
         return sorted_elements
 
-    def partition(self, items: list) -> list[list]:
-        """Recursively partition items into column-aware segments."""
+    def partition(self, items: list, depth: int = 0) -> list[list]:
+        """Recursively partition items into column-aware segments.
+
+        ``depth`` tracks how many recursive column-split levels have been
+        entered. When it reaches ``MAX_PARTITION_DEPTH``, further splitting
+        stops and the items are returned as a single segment. All content is
+        still preserved; only sub-column ordering becomes coarser. This bounds
+        worst-case stack depth on adversarial staircase layouts (O(n) recursion)
+        while never affecting real pages, which stay well below the cap.
+        """
         if not items:
             return []
+
+        # Stop splitting rather than risk a RecursionError on pathological input.
+        if depth >= MAX_PARTITION_DEPTH:
+            return [items]
 
         text_items = self._filter_text_items(items)
         if not text_items:
@@ -112,10 +133,10 @@ class PageLayoutSorter:
                     right.append(it)
             if not left or not right:
                 return [items]
-            return self.partition(left) + self.partition(right)
+            return self.partition(left, depth + 1) + self.partition(right, depth + 1)
 
         intervals = self._group_spanning_intervals(spanning)
-        return self._slice_y_bands(columns, intervals)
+        return self._slice_y_bands(columns, intervals, depth)
 
     def _filter_text_items(self, items: list) -> list:
         """Filter only text-like elements to identify page layout gutters."""
@@ -227,8 +248,12 @@ class PageLayoutSorter:
                 intervals[-1]["items"].append(it)
         return intervals
 
-    def _slice_y_bands(self, columns: list, intervals: list[dict]) -> list[list]:
-        """Slice Y bands based on spanning intervals."""
+    def _slice_y_bands(self, columns: list, intervals: list[dict], depth: int = 0) -> list[list]:
+        """Slice Y bands based on spanning intervals.
+
+        ``depth`` is forwarded to recursive ``partition`` calls so the depth
+        cap is maintained across the Y-band re-entries.
+        """
         segments = []
         # Start below every finite coordinate so the first "above" band captures
         # elements with a negative y_top (off-page/cropped/rotated content);
@@ -247,7 +272,7 @@ class PageLayoutSorter:
                     above.append(it)
                     placed.add(id(it))
             if above:
-                segments.extend(self.partition(above))
+                segments.extend(self.partition(above, depth + 1))
 
             mid = list(interval["items"])
             for it in columns:
@@ -271,7 +296,7 @@ class PageLayoutSorter:
                 below.append(it)
                 placed.add(id(it))
         if below:
-            segments.extend(self.partition(below))
+            segments.extend(self.partition(below, depth + 1))
 
         # Capture any leftover elements that were not placed in any band
         leftover = [it for it in columns if id(it) not in placed]

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_layout_sorter.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_layout_sorter.py
@@ -2,14 +2,17 @@
 
 These focus on hardening ``partition`` against pathological coordinates that a
 corrupt or cropped PDF can produce: off-page (negative) positions, non-finite
-values (NaN/inf), and absurdly large finite coordinates. Each must degrade
-gracefully (return the items as segments) instead of crashing, hanging, or
-allocating gigabytes -- while still partitioning a normal multi-column page
-correctly.
+values (NaN/inf), absurdly large finite coordinates, and adversarial staircase
+layouts that drive O(n) recursion depth. Each must degrade gracefully (return
+the items as segments) instead of crashing, hanging, or allocating gigabytes --
+while still partitioning a normal multi-column page correctly.
 """
+
+import sys
 
 from datagrunt.core.pdf_io.extraction.layout_sorter import (
     MAX_HISTOGRAM_BINS,
+    MAX_PARTITION_DEPTH,
     PageLayoutSorter,
     TextItemAdapter,
 )
@@ -228,3 +231,93 @@ class TestSliceYBandsNegativeY:
         flattened = _flatten(segments)
 
         assert flattened == items
+
+
+class TestPartitionRecursionDepthCap:
+    """partition() must not raise RecursionError on adversarial staircase layouts.
+
+    A crafted 'staircase' layout peels one item per recursive level, driving
+    O(n) recursion depth. The depth cap stops further sub-partitioning at
+    MAX_PARTITION_DEPTH levels while preserving ALL items (content is never
+    dropped, only coarser sorting).
+    """
+
+    def _staircase_items(self, count: int) -> list[TextItem]:
+        """Build a staircase layout: each item shifts right by one unit.
+
+        Each item is positioned so the widest gutter is always to the left of
+        the rightmost item, causing the two-column pure split to recursively
+        peel one item per level. With enough items this exceeds Python's default
+        recursion limit.
+
+        Layout: item i occupies x=[i*4, i*4+2] and y=[i*2, i*2+8], on a wide
+        page so page_width > 100 and each recursion finds a new gutter.
+        """
+        return [_text_item(i * 4.0, i * 4.0 + 2.0, i * 2.0, text="w" * 5) for i in range(count)]
+
+    def test_staircase_layout_does_not_raise_recursion_error(self):
+        """A staircase of items that would exceed stack depth must not crash.
+
+        We temporarily lower the recursion limit to make the old code fail
+        with a small, deterministic item count, then restore it. The new code
+        must return without raising regardless of recursion limit.
+
+        Pre-fix behavior: RecursionError at depth ~item_count.
+        Post-fix behavior: returns at most MAX_PARTITION_DEPTH levels deep.
+        """
+        item_count = 120  # Deep enough to exceed a limit of 100 but not the default
+        items = self._staircase_items(item_count)
+
+        old_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(100)
+        try:
+            segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+        finally:
+            sys.setrecursionlimit(old_limit)
+
+        flattened = _flatten(segments)
+        assert len(flattened) == item_count, (
+            f"All {item_count} items must be preserved; got {len(flattened)}"
+        )
+        assert {id(it) for it in flattened} == {id(it) for it in items}, (
+            "No items must be dropped or duplicated"
+        )
+
+    def test_sort_staircase_preserves_all_items(self):
+        """sort() on a staircase layout must preserve all items end-to-end."""
+        item_count = 120
+        items = self._staircase_items(item_count)
+
+        old_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(100)
+        try:
+            result = PageLayoutSorter(TextItemAdapter()).sort(items)
+        finally:
+            sys.setrecursionlimit(old_limit)
+
+        assert len(result) == item_count
+        assert {id(it) for it in result} == {id(it) for it in items}
+
+    def test_max_partition_depth_constant_is_sane(self):
+        """MAX_PARTITION_DEPTH must be a reasonable cap: above real column nesting but below Python stack risk."""
+        assert 8 <= MAX_PARTITION_DEPTH <= 64, (
+            f"MAX_PARTITION_DEPTH={MAX_PARTITION_DEPTH} is outside the safe range [8, 64]"
+        )
+
+    def test_normal_two_column_layout_unaffected_by_depth_cap(self):
+        """Real multi-column pages never approach the depth cap and must behave identically.
+
+        This is a regression guard: the depth cap must not alter sorting of
+        any layout a real PDF would produce (which never nests more than a
+        few column levels).
+        """
+        left_column = [_text_item(50, 240, y) for y in (50, 70, 90, 110)]
+        right_column = [_text_item(360, 550, y) for y in (50, 70, 90, 110)]
+        items = left_column + right_column
+
+        segments = PageLayoutSorter(TextItemAdapter()).partition(items)
+        flattened = _flatten(segments)
+
+        assert len(flattened) == len(items)
+        # Reading order: all left items before all right items.
+        assert [it.x0 for it in flattened] == [50, 50, 50, 50, 360, 360, 360, 360]


### PR DESCRIPTION
`PageLayoutSorter.partition` recurses per column/y-band split with no depth bound, so a crafted 'staircase' PDF layout that peels one item per level can exceed CPython's recursion limit and raise `RecursionError` — caught per-page, but it degrades that whole page to an error entry (denial-of-extraction on one page).

## Fix
Thread a `depth` parameter (default 0) through `partition` and `_slice_y_bands`, incrementing on each recursive descent; at `depth >= MAX_PARTITION_DEPTH` (32), return the remaining items as a single segment. This bounds worst-case depth while:
- preserving behavior for all real pages (multi-column nesting never approaches 32), and
- **preserving 100% extraction** on pathological pages — all items are still returned (just coarser ordering) instead of losing the page to `RecursionError`.

## Testing
- 4 new tests (`TestPartitionRecursionDepthCap`): a 120-item staircase with `sys.setrecursionlimit(100)` raises pre-fix and passes post-fix with every item preserved (id-set in == out); plus a two-column regression guard and a cap-sanity bound.
- Full suite: 1119 passed; `ruff` clean on `layout_sorter.py`.

## Review
Subagent-implemented (TDD) + spec+quality review: Approved, no Critical/Important.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)