### PR TITLE
fix(pdf): harden markdown-output escaping (leading =/|/fences; whitespace link targets)

### DIFF
--- a/src/datagrunt/core/pdf_io/extraction/markdown_escape.py
+++ b/src/datagrunt/core/pdf_io/extraction/markdown_escape.py
@@ -2,28 +2,53 @@
 
 import re
 
-# A leading markdown metacharacter ('#', '>', '*', '+', '-') or an ordered-list
-# marker ('1.') turns verbatim body text into markdown structure. Match the
-# leading whitespace plus either a block metacharacter or the dot of an
-# ordered-list marker so the structural character can be backslash-escaped.
-_LEADING_MARKDOWN_METACHAR = re.compile(r"^(\s*)(?:([#>*+-])|(\d+)(\.))")
+# A leading markdown metacharacter or structural token that would cause a
+# CommonMark renderer to reinterpret verbatim body text as document structure.
+#
+# Captured groups (by index in the match):
+#   1 — leading whitespace (preserved verbatim)
+#   2 — single block-structural char: # > * + - = |
+#   3 — digits of an ordered-list marker (e.g. "1", "42")
+#   4 — dot of an ordered-list marker (".")
+#   5 — fence opener: 3+ backticks or 3+ tildes
+#
+# Only the *first* structural character is escaped; the rest of the line is
+# left untouched, which is the minimum intervention needed for safe rendering.
+_LEADING_MARKDOWN_METACHAR = re.compile(
+    r"^(\s*)(?:"
+    r"([#>*+=|]|[-])"          # group 2 — single structural char (includes = and |)
+    r"|(\d+)(\.)"              # groups 3+4 — ordered-list marker "N."
+    r"|(```+|~~~+)"            # group 5 — code-fence opener (3+ backticks or tildes)
+    r")"
+)
 
 
 def escape_leading_markdown(text: str) -> str:
     """Backslash-escape a leading markdown metacharacter in body/caption text.
 
     Prevents extracted text such as ``# rm -rf is not a heading`` from being
-    reinterpreted as markdown structure (an H1, list item, or blockquote).
+    reinterpreted as markdown structure (an H1, list item, blockquote, setext
+    underline, table row, or code fence).
+
     Only the leading structural character is escaped; the rest of the text is
     left untouched. Non-string input is returned unchanged.
+
+    Extended in #220 to cover:
+    - ``=`` (setext H1/H2 underline when repeated)
+    - ``|`` (table row opener)
+    - `` ``` `` / ``~~~`` (fenced code block — only 3+ chars trigger a fence)
     """
     if not isinstance(text, str):
         return text
 
     def _escape(match: re.Match) -> str:
-        indent, block_char, digits, dot = match.groups()
+        indent, block_char, digits, dot, fence = match.groups()
         if block_char is not None:
             return f"{indent}\\{block_char}"
+        if fence is not None:
+            # Escape only the first character of the fence opener so the
+            # remaining backticks/tildes no longer form a 3-char run.
+            return f"{indent}\\{fence}"
         return f"{indent}{digits}\\{dot}"
 
     return _LEADING_MARKDOWN_METACHAR.sub(_escape, text, count=1)
@@ -37,12 +62,66 @@ def escape_markdown_link_text(text: str) -> str:
 
 
 def escape_markdown_link_target(target: str) -> str:
-    """Escape ``(`` / ``)`` / ``[`` / ``\\`` in markdown link *destination* URLs/paths."""
+    """Escape a markdown link *destination* (URL or file path) for safe rendering.
+
+    Two forms are produced depending on whether the target contains whitespace,
+    following CommonMark § 6.3 link-destination rules:
+
+    Bare form (no whitespace after stripping):
+        Escape ``\\ ) ( [`` with backslashes, unchanged from original behaviour.
+        Example: ``/path/(file)`` → ``/path/\\(file\\)``
+
+    Angle-bracket form (space or tab present):
+        Wrap the entire destination in ``<...>``.  Inside that wrapper only
+        ``\\ < >`` need escaping; ``( ) [ ]`` are ordinary characters.
+        Example: ``/my path/file`` → ``</my path/file>``
+
+    Newlines (``\\n`` / ``\\r``) are invalid in any CommonMark link destination
+    and are stripped before the whitespace test is applied.  If stripping them
+    leaves no whitespace, the bare form is used; if whitespace remains, the
+    angle-bracket form is used.
+
+    This approach (angle-bracket wrapping) preserves the literal path characters
+    and is the CommonMark-recommended way to embed spaces in a link destination.
+    """
     if not isinstance(target, str):
         return target
+
+    # Strip characters that are unconditionally invalid in any link destination.
+    sanitized = target.replace("\n", "").replace("\r", "")
+
+    if _contains_whitespace(sanitized):
+        return _angle_bracket_form(sanitized)
+
+    return _bare_form(sanitized)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _contains_whitespace(text: str) -> bool:
+    """Return True if *text* contains a space or tab."""
+    return " " in text or "\t" in text
+
+
+def _bare_form(target: str) -> str:
+    """Escape structural chars for a bare (non-angle-bracket) link destination."""
     return (
         target.replace("\\", "\\\\")
         .replace(")", "\\)")
         .replace("(", "\\(")
         .replace("[", "\\[")
     )
+
+
+def _angle_bracket_form(target: str) -> str:
+    """Wrap *target* in ``<...>`` and escape interior ``\\ < >``."""
+    # Inside an angle-bracket destination only \, <, > are special.
+    interior = (
+        target.replace("\\", "\\\\")
+        .replace("<", "\\<")
+        .replace(">", "\\>")
+    )
+    return f"<{interior}>"

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_markdown_escape.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_markdown_escape.py
@@ -1,0 +1,226 @@
+"""Tests for markdown_escape helpers — issues #220 and #221.
+
+#220: escape_leading_markdown must escape leading '=', '|', and code fences
+      (``` / ~~~).
+#221: escape_markdown_link_target must handle whitespace and newlines
+      (angle-bracket wrapping for space/tab; stripping for newlines).
+"""
+
+import pytest
+
+from datagrunt.core.pdf_io.extraction.markdown_escape import (
+    escape_leading_markdown,
+    escape_markdown_link_target,
+)
+
+
+# ---------------------------------------------------------------------------
+# Existing behaviour that must continue to pass
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeLeadingMarkdownExistingBehaviour:
+    def test_heading_escaped(self):
+        assert escape_leading_markdown("# Heading") == "\\# Heading"
+
+    def test_blockquote_escaped(self):
+        assert escape_leading_markdown("> quote") == "\\> quote"
+
+    def test_bullet_star_escaped(self):
+        assert escape_leading_markdown("* item") == "\\* item"
+
+    def test_bullet_plus_escaped(self):
+        assert escape_leading_markdown("+ item") == "\\+ item"
+
+    def test_bullet_dash_escaped(self):
+        assert escape_leading_markdown("- item") == "\\- item"
+
+    def test_ordered_list_dot_escaped(self):
+        assert escape_leading_markdown("1. item") == "1\\. item"
+
+    def test_ordered_list_large_number(self):
+        assert escape_leading_markdown("42. foo") == "42\\. foo"
+
+    def test_plain_text_untouched(self):
+        assert escape_leading_markdown("just plain text") == "just plain text"
+
+    def test_non_string_returned_unchanged(self):
+        assert escape_leading_markdown(None) is None
+        assert escape_leading_markdown(42) == 42
+
+    def test_leading_indent_preserved(self):
+        assert escape_leading_markdown("   # indented") == "   \\# indented"
+
+
+# ---------------------------------------------------------------------------
+# #220 — new cases: '=', '|', code fences
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeLeadingMarkdownIssue220:
+    """Leading '=', '|', and fence markers must be backslash-escaped."""
+
+    # --- setext H1/H2 underline ---
+
+    def test_equals_sign_escaped(self):
+        assert escape_leading_markdown("=== underline") == "\\=== underline"
+
+    def test_single_equals_escaped(self):
+        assert escape_leading_markdown("= foo") == "\\= foo"
+
+    def test_equals_with_leading_whitespace(self):
+        assert escape_leading_markdown("  === underline") == "  \\=== underline"
+
+    # --- table row ---
+
+    def test_pipe_escaped(self):
+        assert escape_leading_markdown("| a | b |") == "\\| a | b |"
+
+    def test_pipe_with_leading_whitespace(self):
+        assert escape_leading_markdown("  | col |") == "  \\| col |"
+
+    # --- backtick code fence ---
+
+    def test_backtick_fence_three_escaped(self):
+        result = escape_leading_markdown("```python")
+        assert result == "\\```python"
+
+    def test_backtick_fence_four_escaped(self):
+        result = escape_leading_markdown("````")
+        assert result == "\\````"
+
+    def test_backtick_fence_with_leading_whitespace(self):
+        result = escape_leading_markdown("  ```py")
+        assert result == "  \\```py"
+
+    # --- tilde code fence ---
+
+    def test_tilde_fence_three_escaped(self):
+        result = escape_leading_markdown("~~~")
+        assert result == "\\~~~"
+
+    def test_tilde_fence_four_escaped(self):
+        result = escape_leading_markdown("~~~~sh")
+        assert result == "\\~~~~sh"
+
+    def test_tilde_fence_with_leading_whitespace(self):
+        result = escape_leading_markdown("  ~~~")
+        assert result == "  \\~~~"
+
+    # --- one/two backticks are NOT fences; must not be escaped ---
+
+    def test_single_backtick_not_escaped(self):
+        # A single backtick is inline code, not a fence — outside scope of #220.
+        # The contract only escapes fences (3+). Single backtick should be left as-is.
+        result = escape_leading_markdown("`code`")
+        assert result == "`code`"
+
+    def test_two_backticks_not_escaped(self):
+        result = escape_leading_markdown("``code``")
+        assert result == "``code``"
+
+
+# ---------------------------------------------------------------------------
+# Existing escape_markdown_link_target behaviour that must continue to pass
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeMarkdownLinkTargetExistingBehaviour:
+    def test_backslash_escaped(self):
+        assert escape_markdown_link_target("a\\b") == "a\\\\b"
+
+    def test_close_paren_escaped(self):
+        assert escape_markdown_link_target("a)b") == "a\\)b"
+
+    def test_open_paren_escaped(self):
+        assert escape_markdown_link_target("a(b") == "a\\(b"
+
+    def test_open_bracket_escaped(self):
+        assert escape_markdown_link_target("a[b") == "a\\[b"
+
+    def test_no_whitespace_plain_url(self):
+        assert escape_markdown_link_target("https://example.com") == "https://example.com"
+
+    def test_non_string_returned_unchanged(self):
+        assert escape_markdown_link_target(None) is None
+        assert escape_markdown_link_target(42) == 42
+
+
+# ---------------------------------------------------------------------------
+# #221 — whitespace / newline handling
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeMarkdownLinkTargetIssue221:
+    """Whitespace and newlines in link destinations must be handled."""
+
+    # --- space → angle-bracket wrap ---
+
+    def test_space_triggers_angle_wrap(self):
+        result = escape_markdown_link_target("/my path/file.pdf")
+        assert result == "</my path/file.pdf>"
+
+    def test_multiple_spaces_angle_wrap(self):
+        result = escape_markdown_link_target("/a b c")
+        assert result == "</a b c>"
+
+    # --- tab → angle-bracket wrap ---
+
+    def test_tab_triggers_angle_wrap(self):
+        result = escape_markdown_link_target("/my\tpath/file.pdf")
+        assert result == "</my\tpath/file.pdf>"
+
+    # --- angle-bracket wrap: interior < and > are escaped ---
+
+    def test_angle_wrap_escapes_inner_less_than(self):
+        # The '>' after '1' is also inside the angle-bracket wrapper, so it is
+        # escaped too. The space triggers angle-bracket form for the whole string.
+        result = escape_markdown_link_target("/path <1>/file")
+        assert result == "</path \\<1\\>/file>"
+
+    def test_angle_wrap_escapes_inner_greater_than(self):
+        result = escape_markdown_link_target("/path >1/file")
+        assert result == "</path \\>1/file>"
+
+    def test_angle_wrap_escapes_both_angle_chars(self):
+        result = escape_markdown_link_target("/a <b> c")
+        assert result == "</a \\<b\\> c>"
+
+    def test_angle_wrap_escapes_backslash_inside(self):
+        result = escape_markdown_link_target("/a\\b c")
+        assert result == "</a\\\\b c>"
+
+    # --- In the angle-bracket form, ( ) [ ] are literal — no escaping ---
+
+    def test_angle_wrap_parens_not_escaped(self):
+        result = escape_markdown_link_target("/a (b) c")
+        assert result == "</a (b) c>"
+
+    def test_angle_wrap_brackets_not_escaped(self):
+        result = escape_markdown_link_target("/a [b] c")
+        assert result == "</a [b] c>"
+
+    # --- newline / carriage-return stripped ---
+
+    def test_newline_stripped(self):
+        result = escape_markdown_link_target("https://example.com\npath")
+        # newline removed → "https://example.compath" → no spaces → bare form, unchanged
+        assert result == "https://example.compath"
+        assert "\n" not in result
+
+    def test_carriage_return_stripped(self):
+        result = escape_markdown_link_target("https://example.com\rpath")
+        assert "\r" not in result
+
+    def test_newline_stripped_whitespace_remains_wraps(self):
+        # newline removed but a space still present → angle-bracket wrap
+        result = escape_markdown_link_target("/my path\nfile")
+        assert result.startswith("<")
+        assert result.endswith(">")
+        assert "\n" not in result
+
+    def test_only_newline_no_space_bare_form(self):
+        # After stripping newline, no whitespace remains → bare form
+        result = escape_markdown_link_target("https://example.com\n/path")
+        assert "\n" not in result
+        assert not result.startswith("<")

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -499,9 +499,17 @@ class TestMarkdownMetacharacterEscaping:
     def test_image_file_path_paren_does_not_inject_markdown(self):
         malicious = "x) ![](https://evil.example/pwn.png"
         md = self._markdown([self._image_element(malicious)])
-        # Must remain a single markdown image, not an injected second image link.
-        assert md.count("![") == 1
-        assert "\\)" in md
+        # The path contains a space so it is wrapped in angle brackets
+        # (CommonMark angle-bracket destination).  The entire malicious path,
+        # including its ')' and embedded '![](', is enclosed inside the '<...>'
+        # wrapper — no injected image link is structurally valid.
+        assert "<x) ![](https://evil.example/pwn.png>" in md
+        # The output contains exactly ONE standalone image marker (the outer
+        # '![alt]' prefix).  Any second '![' that appears is inside the
+        # angle-bracket destination and is not structural markdown.
+        #
+        # Line shape: ![alt](<malicious path>)\n — a single markdown image.
+        assert md.strip().startswith("![")
 
     def test_image_file_path_bracket_in_alt_is_escaped(self):
         from pathlib import Path


### PR DESCRIPTION
Closes two markdown-rendering escaping gaps in `markdown_escape.py` (the module's purpose — rendering-structure escaping, not value sanitization).

## #220 — `escape_leading_markdown`
Now also escapes a leading `=` (setext H1 underline), leading `|` (table row), and a leading 3+-backtick/3+-tilde code fence (escaping the first structural char). `\=`/`\|` render literally; an escaped first backtick leaves ≤2 consecutive → not a fence. Existing `#>*+-`/ordered-list behavior and the "only the leading structural char is escaped" contract are unchanged.

## #221 — `escape_markdown_link_target`
Strips `\r`/`\n` (invalid in any destination); if a space/tab remains, wraps the target in CommonMark angle brackets `<...>` (escaping `<`/`>`/`\` inside; `()[]` literal there), preserving the literal path. No-whitespace targets keep the existing bare escaping byte-identical.

## Testing
- 42 new tests in `test_markdown_escape.py` (24 fail pre-fix; all pass post-fix).
- One existing injection test (`test_image_file_path_paren_does_not_inject_markdown`) updated to a **tighter** structural assertion (the `)`-injection is now enclosed in `<...>`) — injection still neutralized, verified not weakened.
- Full suite: 1161 passed; `ruff` clean on the module.

## Review
Subagent-implemented (TDD) + spec+quality review: Approved, no Critical/Important.

Closes #220
Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)