### PR TITLE
fix: robustness & edge-case hardening (#224)

### DIFF
--- a/src/datagrunt/core/csv_io/_compute_python.py
+++ b/src/datagrunt/core/csv_io/_compute_python.py
@@ -202,6 +202,14 @@ def probe_csv_header(filepath):
     sample_lines = []
     sample_rows = []
     saw_nonblank = False
+    # NOTE on blankness semantics: this probe derives ``blank`` from
+    # ``saw_nonblank`` over lines decoded with ``errors="ignore"``. An
+    # all-invalid-UTF-8 file therefore reads as ``blank=True`` here, whereas
+    # ``FileProperties.is_blank`` treats undecodable bytes as content and
+    # returns ``blank=False`` (issue #146). Do NOT align them: aligning would
+    # require a Rust+parity change for a negligible edge case — all-invalid
+    # input yields DEFAULT_DELIMITER/None from both paths anyway. The probe
+    # intentionally uses a lighter "errors=ignore" blankness notion.
     with open(filepath, "r", encoding=props.DEFAULT_ENCODING, errors="ignore") as f:
         for line in _capped_lines(f):
             stripped = line.strip()

--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -344,14 +344,21 @@ class CSVColumns:
         if _is_legacy_mac_newlines(self.filepath):
             try:
                 encoding = FileProperties(self.filepath).DEFAULT_ENCODING
+                # Open with newline=None so the OS translates \r -> \n
+                # (universal newlines). Feed the handle to csv.reader so it
+                # can reassemble a quoted field containing an embedded \r
+                # (now seen as \n after translation) — wrapping a single
+                # pre-split line string cannot do this.
                 with open(self.filepath, "r", encoding=encoding, newline=None, errors="ignore") as f:
-                    for line in f:
-                        stripped = line.strip()
-                        if not stripped.startswith("#") and stripped:
-                            import csv
+                    import csv
 
-                            reader = csv.reader([line], delimiter=self.delimiter)
-                            return next(reader)
+                    reader = csv.reader(f, delimiter=self.delimiter)
+                    for record in reader:
+                        if not record:
+                            continue
+                        if record[0].strip().startswith("#"):
+                            continue
+                        return record
             except Exception:  # noqa: BLE001 - best-effort legacy-mac header; fall back to polars
                 logger.debug("Legacy-mac column read failed for %s; using polars", self.filepath, exc_info=True)
         df = pl.read_csv(

--- a/src/datagrunt/core/csv_io/csvcomponents.py
+++ b/src/datagrunt/core/csv_io/csvcomponents.py
@@ -463,6 +463,14 @@ class CSVComponents(FileProperties):
 
     @cached_property
     def _dialect(self):
+        # NOTE: ``is_empty`` and ``is_blank`` are passed for API symmetry but
+        # ``CSVDialect._get_csv_dialect`` delegates entirely to the compute
+        # backend (``sniff_dialect``), which performs its own empty/blank
+        # short-circuit via the internal ``probe_csv_header`` call. The probe
+        # uses a lighter ``errors="ignore"`` blankness notion (see
+        # ``probe_csv_header`` in ``_compute_python.py``), not
+        # ``FileProperties.is_blank``, so these arguments are effectively
+        # unused by the dialect-sniff path.
         return CSVDialect(
             self.filepath,
             delimiter=self.delimiter,

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -241,16 +241,33 @@ class DuckDBQueries:
         return f"tbl_{stem}_{path_hash}"
 
     def set_export_filename(self, default_filename, export_filename=None):
+        """Return the export filename if explicitly provided, else the default.
+
+        Raises ``ValueError`` when ``export_filename`` is provided but is an
+        empty or whitespace-only string — callers almost certainly passed a
+        bug rather than intending to write to a file named ``""``.
+
+        Args:
+            default_filename (str): Fallback filename used when ``export_filename``
+                is ``None``.
+            export_filename (str or None): The caller-supplied filename. ``None``
+                means "use the default"; a non-``None`` value is validated.
+
+        Returns:
+            str: The resolved export filename.
+
+        Raises:
+            ValueError: If ``export_filename`` is a non-``None`` empty or
+                whitespace-only string.
         """
-        Return the export filename if provided, otherwise return the default.
-        """
-        # This method doesn't really fit the class but it's the only place it's
-        # relevant.
-        if export_filename:
-            filename = export_filename
-        else:
-            filename = default_filename
-        return filename
+        if export_filename is not None:
+            if not export_filename.strip():
+                raise ValueError(
+                    f"export_filename must not be empty or whitespace-only; "
+                    f"got {export_filename!r}. Pass None to use the default."
+                )
+            return export_filename
+        return default_filename
 
     def import_csv_query(self):
         """Query to import a CSV file into a DuckDB table.

--- a/src/datagrunt/core/databases/databases.py
+++ b/src/datagrunt/core/databases/databases.py
@@ -107,8 +107,11 @@ class DuckDBQueries:
         """
         if not DuckDBQueries._spatial_installed:
             connection.execute("INSTALL spatial;")
-            DuckDBQueries._spatial_installed = True
         connection.execute("LOAD spatial;")
+        # Only mark installed after LOAD succeeds: if INSTALL succeeds but LOAD
+        # then fails, the flag must stay False so the next connection retries
+        # rather than LOADing an extension that never actually installed.
+        DuckDBQueries._spatial_installed = True
 
     @cached_property
     def delimiter(self):

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -58,12 +58,20 @@ def _parse_page_native_worker(filepath_str: str, page_index: int, image_output_d
 
 
 def set_export_filename(default_filename, export_filename=None):
-    """Return the export filename if provided, otherwise the default.
+    """Return the export filename if explicitly provided, otherwise the default.
 
-    Mirrors the CSV writer's path-resolution semantics without coupling PDF to
-    DuckDB.
+    Mirrors ``DuckDBQueries.set_export_filename``: ``None`` means "use the
+    default"; a provided-but-empty/whitespace-only string raises ``ValueError``
+    rather than silently writing to the default name (almost always a caller bug).
     """
-    return export_filename if export_filename else default_filename
+    if export_filename is not None:
+        if not export_filename.strip():
+            raise ValueError(
+                f"export_filename must not be empty or whitespace-only; "
+                f"got {export_filename!r}. Pass None to use the default."
+            )
+        return export_filename
+    return default_filename
 
 
 @dataclass

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
@@ -49,7 +49,15 @@ class PdfiumPage:
         """
         self._page = page
         self._raw = raw_module
-        self._textpage = page.get_textpage()
+        # If textpage acquisition fails (corrupt page), close the page handle
+        # before re-raising — otherwise the constructor aborts before any
+        # PdfiumPage is handed to the `with` block, so close()/__exit__ never
+        # run and the page handle leaks for the document's lifetime.
+        try:
+            self._textpage = page.get_textpage()
+        except Exception:
+            page.close()
+            raise
 
     def __enter__(self) -> "PdfiumPage":
         return self

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -387,6 +387,14 @@ class PDFComponents(FileProperties):
                     )
                 with open(filepath_path, "r", encoding="utf-8") as f:
                     self._parsed_dict = json.load(f)
+                # Untrusted JSON: a top-level non-object (list/number/string/null)
+                # would otherwise raise a bare AttributeError deep in .get(...)
+                # at total_pages / flatten paths. Fail fast with a clear message.
+                if not isinstance(self._parsed_dict, dict):
+                    raise ValueError(
+                        f"Expected a JSON object for the parsed document, got "
+                        f"{type(self._parsed_dict).__name__}"
+                    )
                 self._apply_virtual_file_properties(
                     filepath=filepath_path,
                     size_in_bytes=size_in_bytes,

--- a/tests/core_tests/csv_io_tests/test_csvcomponents.py
+++ b/tests/core_tests/csv_io_tests/test_csvcomponents.py
@@ -540,3 +540,32 @@ class TestCSVComponents:
     def test_empty_file_delimiter(self, sample_csv_files):
         delimiter = CSVDelimiter(sample_csv_files["empty.csv"])
         assert delimiter.delimiter == ","  # Should return default delimiter
+
+
+class TestLegacyMacEmbeddedNewlineInHeader:
+    """CSVColumns._get_columns handles a quoted header field with an embedded \\r.
+
+    A legacy-mac file uses \\r as its line terminator. If the HEADER itself
+    contains a quoted field that embeds another \\r (e.g.
+    ``"col\\rone",col2\\r``), the old single-line approach split the header
+    at that embedded \\r and returned a truncated column list. The fixed code
+    feeds the file handle to csv.reader so the quoted field is reassembled.
+    """
+
+    def test_embedded_cr_in_quoted_header_parsed_correctly(self, tmp_path):
+        # Build a legacy-mac CSV: \r is the line terminator.
+        # Header: `"col\rone",col2`  (first field has an embedded \r)
+        # Data row: `val1,val2`
+        # All line endings are \r (no \n).
+        content = b'"col\rone",col2\rval1,val2\r'
+        legacy_mac_file = tmp_path / "legacy_mac_embedded.csv"
+        legacy_mac_file.write_bytes(content)
+
+        columns = CSVColumns(str(legacy_mac_file)).columns
+
+        # The quoted field "col\rone" must be returned as a single column
+        # (with the embedded \r preserved or stripped, but NOT split).
+        assert len(columns) == 2
+        # The first column contains the embedded newline content
+        assert "col" in columns[0]
+        assert columns[1] == "col2"

--- a/tests/core_tests/databases_tests/test_databases.py
+++ b/tests/core_tests/databases_tests/test_databases.py
@@ -383,3 +383,35 @@ class TestSpatialExtensionInstallOnce:
         loads = [s for s in executed if s.upper().startswith("LOAD SPATIAL")]
         assert len(installs) == 1
         assert len(loads) == 2
+
+
+class TestSetExportFilename:
+    """set_export_filename distinguishes None (use default) from '' (error)."""
+
+    def test_none_uses_default(self, tmp_path):
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1\n1\n")
+        queries = DuckDBQueries(str(csv))
+        result = queries.set_export_filename("default.csv", None)
+        assert result == "default.csv"
+
+    def test_provided_filename_returned(self, tmp_path):
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1\n1\n")
+        queries = DuckDBQueries(str(csv))
+        result = queries.set_export_filename("default.csv", "custom.csv")
+        assert result == "custom.csv"
+
+    def test_empty_string_raises_value_error(self, tmp_path):
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1\n1\n")
+        queries = DuckDBQueries(str(csv))
+        with pytest.raises(ValueError, match="export_filename"):
+            queries.set_export_filename("default.csv", "")
+
+    def test_whitespace_only_raises_value_error(self, tmp_path):
+        csv = tmp_path / "data.csv"
+        csv.write_text("col1\n1\n")
+        queries = DuckDBQueries(str(csv))
+        with pytest.raises(ValueError, match="export_filename"):
+            queries.set_export_filename("default.csv", "   ")

--- a/tests/core_tests/test_robustness_224.py
+++ b/tests/core_tests/test_robustness_224.py
@@ -65,3 +65,16 @@ def test_pdfium_page_closes_page_when_textpage_acquisition_fails():
         PdfiumPage(FakePage(), None)
 
     assert closed["n"] == 1  # page handle closed despite textpage failure
+
+
+def test_pdf_set_export_filename_empty_raises_consistent_with_csv():
+    """Item 3+5 consistency: the PDF set_export_filename mirrors the CSV one —
+    empty/whitespace raises ValueError; None uses the default; a real name returns."""
+    from datagrunt.core.pdf_io.engines import set_export_filename
+
+    assert set_export_filename("output.json", None) == "output.json"
+    assert set_export_filename("output.json", "custom.json") == "custom.json"
+    with pytest.raises(ValueError, match="must not be empty"):
+        set_export_filename("output.json", "")
+    with pytest.raises(ValueError, match="must not be empty"):
+        set_export_filename("output.json", "   ")

--- a/tests/core_tests/test_robustness_224.py
+++ b/tests/core_tests/test_robustness_224.py
@@ -1,0 +1,67 @@
+"""Regression tests for issue #224 robustness fixes (items 4, 6, 7)."""
+
+import json
+
+import pytest
+
+
+def test_load_spatial_flag_not_set_when_load_fails(monkeypatch, tmp_path):
+    """Item 4: if INSTALL succeeds but LOAD fails, _spatial_installed stays False
+    so the next connection retries instead of LOADing a never-installed extension.
+    """
+    from datagrunt.core.databases.databases import DuckDBQueries
+
+    monkeypatch.setattr(DuckDBQueries, "_spatial_installed", False)  # auto-restored
+    csv = tmp_path / "x.csv"
+    csv.write_text("a,b\n1,2\n")
+    q = DuckDBQueries(str(csv))
+
+    class FakeConn:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, sql):
+            self.calls.append(sql)
+            if sql.startswith("LOAD"):
+                raise RuntimeError("load failed")
+
+    conn = FakeConn()
+    with pytest.raises(RuntimeError, match="load failed"):
+        q.load_spatial_extension(conn)
+
+    assert DuckDBQueries._spatial_installed is False  # NOT set after LOAD failure
+    assert conn.calls == ["INSTALL spatial;", "LOAD spatial;"]  # INSTALL ran, LOAD attempted
+
+
+def test_json_top_level_non_object_raises_valueerror(tmp_path):
+    """Item 6: a .json document that deserializes to a non-dict (e.g. a list)
+    raises a clear ValueError instead of a bare AttributeError deep in .get(...).
+    """
+    from datagrunt.core.pdf_io.pdfcomponents import PDFComponents
+
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps([1, 2, 3]))
+    with pytest.raises(ValueError, match="Expected a JSON object"):
+        PDFComponents(str(bad))
+
+
+def test_pdfium_page_closes_page_when_textpage_acquisition_fails():
+    """Item 7: PdfiumPage closes the page handle if get_textpage() raises in
+    __init__, so a corrupt page does not leak the handle (close()/__exit__ would
+    otherwise never run because no PdfiumPage object is returned).
+    """
+    from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumPage
+
+    closed = {"n": 0}
+
+    class FakePage:
+        def get_textpage(self):
+            raise RuntimeError("corrupt page")
+
+        def close(self):
+            closed["n"] += 1
+
+    with pytest.raises(RuntimeError, match="corrupt page"):
+        PdfiumPage(FakePage(), None)
+
+    assert closed["n"] == 1  # page handle closed despite textpage failure


### PR DESCRIPTION
Six low-severity robustness fixes from the audit (all pure Python).

- **Probe blankness doc** — documented that `probe_csv_header`'s `errors="ignore"` blankness intentionally differs from `FileProperties.is_blank` on all-invalid-UTF-8 files (comment-only; aligning would need a Rust+parity round-trip for a negligible edge → not worth it).
- **Legacy-mac header with quoted embedded newline** — `CSVColumns._get_columns` feeds the file handle to `csv.reader` (newline=None) instead of a single pre-split line, so a quoted field with an embedded `\r` parses correctly.
- **Empty `export_filename`** — `set_export_filename` (DuckDB **and** the PDF engine) now distinguishes `None` (default) from `""` (raises `ValueError`) instead of silently writing to the default name.
- **`load_spatial_extension`** — `_spatial_installed=True` is set only after `LOAD` succeeds, so a `LOAD` failure after `INSTALL` doesn't poison later connections.
- **Malformed JSON document** — `PDFComponents` validates `json.load` is a dict → clear `ValueError` instead of a bare `AttributeError` on a top-level non-object.
- **PdfiumPage handle leak** — `PdfiumPage.__init__` closes the page handle if `get_textpage()` raises (corrupt page), preventing a leak.

## Testing
- New tests for each behavioral fix (`test_robustness_224.py` + legacy-mac/empty-filename suites).
- Both pytest backends: **1170 passed**; `ruff` introduces no new errors (the 7 pre-existing ones are fixed in #225).

## Review
Subagent-implemented + spec+quality review (Approved). The review's one gap (PDF `set_export_filename` left inconsistent) was then aligned with the CSV contract in this PR.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)