### PR TITLE
refactor: DRY consolidations — CSV polars-fallback, PDF writers, backend lifecycle (#237)

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -59,6 +59,58 @@ def _has_midfile_comments(filepath):
     return False
 
 
+def _polars_read_csv(filepath, delimiter, truncate_ragged_lines, n_rows=None):
+    """Read a CSV file with Polars using the parity-critical option set.
+
+    All three Polars-backed read paths must agree on these parameters.
+    ``skip_rows`` skips only the LEADING comment block. Using
+    ``comment_prefix`` here would also drop any data row whose first field
+    begins with ``#`` (e.g. a hex color like ``#FF0000``), silently losing
+    rows (issue #73).
+
+    Args:
+        filepath: Path to the CSV file.
+        delimiter: Field separator character.
+        truncate_ragged_lines: Whether to silently truncate rows with more
+            fields than the header (lenient / ragged mode).
+        n_rows: Maximum number of data rows to read, or ``None`` for all.
+
+    Returns:
+        A Polars DataFrame with all columns kept as their raw string values
+        (``infer_schema=False``).
+    """
+    return pl.read_csv(
+        filepath,
+        separator=delimiter,
+        truncate_ragged_lines=truncate_ragged_lines,
+        infer_schema=False,
+        n_rows=n_rows,
+        skip_rows=_count_leading_comments(filepath),
+    )
+
+
+def _polars_read_to_string_arrow(filepath, delimiter, truncate_ragged_lines, n_rows=None):
+    """Read a CSV via Polars and return an all-string PyArrow table.
+
+    Calls ``_polars_read_csv`` then converts to Arrow and casts every column
+    to ``pa.string()``. Shared by the two PyArrow engine paths that fall back
+    to Polars (ragged rows and mid-file ``#`` comments that crash PyArrow's
+    native reader).
+
+    Args:
+        filepath: Path to the CSV file.
+        delimiter: Field separator character.
+        truncate_ragged_lines: Whether to silently truncate ragged rows.
+        n_rows: Maximum number of data rows to read, or ``None`` for all.
+
+    Returns:
+        A PyArrow table with every column typed as ``pa.string()``.
+    """
+    df = _polars_read_csv(filepath, delimiter, truncate_ragged_lines, n_rows=n_rows)
+    table = df.to_arrow()
+    return table.cast(pa.schema([(name, pa.string()) for name in table.column_names]))
+
+
 @dataclass
 class CSVEngineProperties:
     """Base properties for CSV operations."""
@@ -406,16 +458,11 @@ class CSVReaderPolarsEngine(DataFrameDerivedReaderMixin, CSVBaseReaderEngine):
             )
         if self.lenient:
             _check_csv_ragged_and_warn(self.filepath, self.delimiter)
-        # Skip only the LEADING comment block. Using comment_prefix here would
-        # also drop any data row whose first field begins with "#" (e.g. a hex
-        # color like "#FF0000"), silently losing rows.
-        df = pl.read_csv(
+        df = _polars_read_csv(
             self.filepath,
-            separator=self.delimiter,
-            truncate_ragged_lines=self.lenient,
-            infer_schema=False,
+            self.delimiter,
+            self.lenient,
             n_rows=CSVEngineProperties.dataframe_sample_rows if sample else None,
-            skip_rows=_count_leading_comments(self.filepath),
         )
         if normalize_columns:
             df = df.rename(CSVColumnNameNormalizer(self.filepath, columns=df.columns).columns_to_normalized_mapping)
@@ -696,17 +743,7 @@ class CSVReaderPyArrowEngine(_PyArrowEngineMixin, CSVBaseReaderEngine):
         Returns:
             A PyArrow table with all columns cast to string.
         """
-        df = pl.read_csv(
-            self.filepath,
-            separator=self.delimiter,
-            truncate_ragged_lines=truncate_ragged_lines,
-            infer_schema=False,
-            skip_rows=_count_leading_comments(self.filepath),
-            n_rows=n_rows,
-        )
-        table = df.to_arrow()
-        string_schema = pa.schema([(name, pa.string()) for name in table.column_names])
-        table = table.cast(string_schema)
+        table = _polars_read_to_string_arrow(self.filepath, self.delimiter, truncate_ragged_lines, n_rows=n_rows)
         if normalize_columns:
             table = self._normalize_arrow_columns(table, columns)
         return table
@@ -904,15 +941,7 @@ class CSVWriterPyArrowEngine(_PyArrowEngineMixin, CSVBaseWriterEngine):
                 _check_csv_ragged_and_warn(self.filepath, self.queries.delimiter)
             # Fallback to Polars: it parses ragged rows and skips mid-file ``#``
             # comment lines that the native PyArrow reader chokes on (issue #90).
-            df = pl.read_csv(
-                self.filepath,
-                separator=self.queries.delimiter,
-                truncate_ragged_lines=self.lenient,
-                infer_schema=False,
-                skip_rows=_count_leading_comments(self.filepath),
-            )
-            table = df.to_arrow()
-            table = table.cast(pa.schema([(name, pa.string()) for name in table.column_names]))
+            table = _polars_read_to_string_arrow(self.filepath, self.queries.delimiter, self.lenient)
         else:
             skip_count = _count_leading_physical_lines_before_header(self.filepath)
             table = pacsv.read_csv(

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -1,7 +1,6 @@
 """Module to create engines for PDF processing."""
 
 # standard library
-import json
 import logging
 import os
 from abc import ABC, abstractmethod
@@ -333,22 +332,52 @@ class PDFBaseWriterEngine(ABC):
             self._cached_parse_key = key
         return self._cached_document
 
-    @abstractmethod
     def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
-        """Write the unified document JSON to disk."""
-        pass
+        """Parse the PDF and write the unified document JSON to disk.
 
-    @abstractmethod
+        Args:
+            export_filename (optional, str): Output path; defaults to output.json.
+            image_output_dir (optional, str): If provided, embedded images are
+                written here and referenced in the JSON; otherwise image
+                ``file_path`` values are null.
+            dedupe_images (bool, default True): When images are written, collapse
+                byte-identical duplicates to a single file and repoint references.
+            drop_layout_tables (bool, default False): Drop 1xN / Nx1 "tables"
+                that are layout boxes rather than real tabular data.
+        """
+        filename = set_export_filename(self.properties.json_export_filename, export_filename)
+        document = self._parse_document(image_output_dir, drop_layout_tables)
+        if image_output_dir and dedupe_images:
+            pdfcomponents.dedupe_document_images(document, image_output_dir)
+        return pdfcomponents.write_document_json(document, filename)
+
     def write_json_newline_delimited(
         self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False
     ):
-        """Write one element per line as JSON Lines."""
-        pass
+        """Parse the PDF and write one flattened element per line (JSONL)."""
+        filename = set_export_filename(self.properties.json_newline_export_filename, export_filename)
+        document = self._parse_document(image_output_dir, drop_layout_tables)
+        if image_output_dir and dedupe_images:
+            pdfcomponents.dedupe_document_images(document, image_output_dir)
+        return pdfcomponents.write_document_jsonl(document, filename)
 
-    @abstractmethod
     def write_markdown(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
-        """Write the document Markdown representation to disk."""
-        pass
+        """Parse the PDF and write the document Markdown to disk.
+
+        Args:
+            export_filename (optional, str): Output path; defaults to output.md.
+            image_output_dir (optional, str): If provided, embedded images are
+                written there and referenced in the Markdown.
+            dedupe_images (bool, default True): When images are written, collapse
+                byte-identical duplicates to a single file and repoint references.
+            drop_layout_tables (bool, default False): Drop 1xN / Nx1 "tables"
+                that are layout boxes rather than real tabular data.
+        """
+        filename = set_export_filename(self.properties.markdown_export_filename, export_filename)
+        document = self._parse_document(image_output_dir, drop_layout_tables)
+        if image_output_dir and dedupe_images:
+            pdfcomponents.dedupe_document_images(document, image_output_dir)
+        return pdfcomponents.write_document_markdown(document, filename)
 
     def extract_images(self, output_dir=None, dedupe=True):
         """Parse the PDF, write embedded images to disk, return their paths.
@@ -377,62 +406,6 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
             self._reader_engine = PDFReaderPyMuPDFEngine(self.filepath, workers=self.workers)
         return self._reader_engine
 
-    def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
-        """Parse the PDF and write the unified document JSON.
-
-        Args:
-            export_filename (optional, str): Output path; defaults to output.json.
-            image_output_dir (optional, str): If provided, embedded images are
-                written here and referenced in the JSON; otherwise image
-                ``file_path`` values are null.
-            dedupe_images (bool, default True): When images are written, collapse
-                byte-identical duplicates to a single file and repoint references.
-            drop_layout_tables (bool, default False): Drop 1xN / Nx1 "tables"
-                that are layout boxes rather than real tabular data.
-        """
-        filename = set_export_filename(self.properties.json_export_filename, export_filename)
-        document = self._parse_document(image_output_dir, drop_layout_tables)
-        if image_output_dir and dedupe_images:
-            pdfcomponents.dedupe_document_images(document, image_output_dir)
-        with open(filename, "w", encoding="utf-8") as f:
-            json.dump(document, f, indent=2)
-        return filename
-
-    def write_json_newline_delimited(
-        self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False
-    ):
-        """Parse the PDF and write one flattened element per line (JSONL)."""
-        filename = set_export_filename(self.properties.json_newline_export_filename, export_filename)
-        document = self._parse_document(image_output_dir, drop_layout_tables)
-        if image_output_dir and dedupe_images:
-            pdfcomponents.dedupe_document_images(document, image_output_dir)
-        records = pdfcomponents.flatten_document(document)
-        with open(filename, "w", encoding="utf-8") as f:
-            for record in records:
-                f.write(json.dumps(record) + "\n")
-        return filename
-
-    def write_markdown(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
-        """Parse the PDF and write the document Markdown.
-
-        Args:
-            export_filename (optional, str): Output path; defaults to output.md.
-            image_output_dir (optional, str): If provided, embedded images are
-                written there and referenced in the Markdown.
-            dedupe_images (bool, default True): When images are written, collapse
-                byte-identical duplicates to a single file and repoint references.
-            drop_layout_tables (bool, default False): Drop 1xN / Nx1 "tables"
-                that are layout boxes rather than real tabular data.
-        """
-        filename = set_export_filename(self.properties.markdown_export_filename, export_filename)
-        document = self._parse_document(image_output_dir, drop_layout_tables)
-        if image_output_dir and dedupe_images:
-            pdfcomponents.dedupe_document_images(document, image_output_dir)
-        markdown_text = pdfcomponents.ParsedDocument(document).to_markdown(export_filename=filename)
-        with open(filename, "w", encoding="utf-8") as f:
-            f.write(markdown_text)
-        return filename
-
 
 class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
     """Write parsed PDFium output. Native schema by default; unified when structured."""
@@ -445,41 +418,3 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
         if self._reader_engine is None:
             self._reader_engine = PDFReaderPdfiumEngine(self.filepath, workers=self.workers, structured=self.structured)
         return self._reader_engine
-
-    def write_json(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
-        """Parse the PDF and write the document JSON (native or unified schema)."""
-        filename = set_export_filename(self.properties.json_export_filename, export_filename)
-        document = self._parse_document(image_output_dir, drop_layout_tables)
-        if image_output_dir and dedupe_images:
-            pdfcomponents.dedupe_document_images(document, image_output_dir)
-        with open(filename, "w", encoding="utf-8") as f:
-            json.dump(document, f, indent=2)
-        return filename
-
-    def write_json_newline_delimited(
-        self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False
-    ):
-        """Parse the PDF and write one flattened element per line (JSONL)."""
-        filename = set_export_filename(self.properties.json_newline_export_filename, export_filename)
-        document = self._parse_document(image_output_dir, drop_layout_tables)
-        if image_output_dir and dedupe_images:
-            pdfcomponents.dedupe_document_images(document, image_output_dir)
-        records = pdfcomponents.flatten_document(document)
-        with open(filename, "w", encoding="utf-8") as f:
-            for record in records:
-                f.write(json.dumps(record) + "\n")
-        return filename
-
-    def write_markdown(self, export_filename=None, image_output_dir=None, dedupe_images=True, drop_layout_tables=False):
-        """Parse the PDF and write the document Markdown (native or structured schema)."""
-        filename = set_export_filename(self.properties.markdown_export_filename, export_filename)
-        document = self._parse_document(image_output_dir, drop_layout_tables)
-        if image_output_dir and dedupe_images:
-            pdfcomponents.dedupe_document_images(document, image_output_dir)
-        if self.structured:
-            markdown_text = pdfcomponents.ParsedDocument(document).to_markdown(export_filename=filename)
-        else:
-            markdown_text = PdfiumNativeReader.to_markdown(document)
-        with open(filename, "w", encoding="utf-8") as f:
-            f.write(markdown_text)
-        return filename

--- a/src/datagrunt/core/pdf_io/extraction/_doc_session.py
+++ b/src/datagrunt/core/pdf_io/extraction/_doc_session.py
@@ -1,0 +1,56 @@
+"""Shared thread-local, depth-counted document session for PDF backends."""
+
+
+class _ThreadLocalDocSession:
+    """Mixin providing a reused, per-thread document handle.
+
+    The outermost ``with`` opens the resource once per thread; nested ``with``
+    blocks reuse it; it is closed when the outermost scope exits. Outside any
+    scope, ``_get_doc()`` returns a transient resource the caller must close.
+
+    Subclasses MUST set ``self.filepath`` and ``self._local`` (a
+    ``threading.local()``) in their own ``__init__`` and implement
+    ``_open_resource()``. Override ``_close_resource()`` if closing differs, and
+    set ``_lazy_open = True`` to defer opening until first use (table extractor).
+    ``_open_resource()`` may return ``None`` to signal a soft open-failure.
+    """
+
+    _lazy_open = False
+
+    def _open_resource(self):
+        raise NotImplementedError
+
+    def _close_resource(self, resource):
+        resource.close()
+
+    def __enter__(self):
+        if not hasattr(self._local, "depth"):
+            self._local.depth = 0
+            self._local.doc = None
+        if self._local.depth == 0 and not self._lazy_open:
+            self._local.doc = self._open_resource()
+        self._local.depth += 1
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._local.depth -= 1
+        if self._local.depth == 0:
+            doc = getattr(self._local, "doc", None)
+            if doc:
+                self._close_resource(doc)
+            self._local.doc = None
+
+    def _get_doc(self):
+        """Return ``(resource, should_close)``. Cached in-scope (False); lazy
+        opens-and-caches on first in-scope use; transient outside scope (True);
+        ``(None, False)`` on a soft open-failure."""
+        doc = getattr(self._local, "doc", None)
+        if doc:
+            return doc, False
+        resource = self._open_resource()
+        if resource is None:
+            return None, False
+        if getattr(self._local, "depth", 0) > 0:
+            self._local.doc = resource
+            return resource, False
+        return resource, True

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
@@ -1,5 +1,6 @@
 """pdfium-backed extraction backend (structured/unified schema)."""
 
+from datagrunt.core.pdf_io.extraction._doc_session import _ThreadLocalDocSession
 from datagrunt.core.pdf_io.extraction.base import ExtractionBackend
 from datagrunt.core.pdf_io.extraction.ocr import ocr_data_to_blocks
 from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
@@ -7,7 +8,7 @@ from datagrunt.core.pdf_io.extraction.shapes import PageAnalysis
 from datagrunt.core.pdf_io.extraction.text_block_builder import TextBlockBuilder
 
 
-class PdfiumBackend(ExtractionBackend):
+class PdfiumBackend(_ThreadLocalDocSession, ExtractionBackend):
     """Extraction via pypdfium2: text objects, images, and pdfium-rendered OCR."""
 
     def __init__(self, filepath):
@@ -16,25 +17,8 @@ class PdfiumBackend(ExtractionBackend):
 
         self._local = threading.local()
 
-    def __enter__(self):
-        if not hasattr(self._local, "depth"):
-            self._local.depth = 0
-        if self._local.depth == 0:
-            self._local.doc = PdfiumDocument(self.filepath)
-        self._local.depth += 1
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._local.depth -= 1
-        if self._local.depth == 0:
-            if hasattr(self._local, "doc") and self._local.doc:
-                self._local.doc.close()
-                self._local.doc = None
-
-    def _get_doc(self):
-        if hasattr(self._local, "doc") and self._local.doc:
-            return self._local.doc, False
-        return PdfiumDocument(self.filepath), True
+    def _open_resource(self):
+        return PdfiumDocument(self.filepath)
 
     def analyze_page(self, page_number: int) -> PageAnalysis:
         """Return page metadata (raises if the page/file is invalid)."""

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -3,13 +3,14 @@
 import json
 from pathlib import Path
 
+from datagrunt.core.pdf_io.extraction._doc_session import _ThreadLocalDocSession
 from datagrunt.core.pdf_io.extraction.image_dedupe import dedupe_image_files
 from datagrunt.core.pdf_io.extraction.markdown_escape import escape_leading_markdown
 from datagrunt.core.pdf_io.extraction.ocr import dpi_for_page, ocr_data_to_blocks
 from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
 
 
-class PdfiumNativeReader:
+class PdfiumNativeReader(_ThreadLocalDocSession):
     """Parse pages into the native pdfium schema and assemble documents."""
 
     def __init__(self, filepath):
@@ -23,25 +24,8 @@ class PdfiumNativeReader:
 
         self._local = threading.local()
 
-    def __enter__(self):
-        if not hasattr(self._local, "depth"):
-            self._local.depth = 0
-        if self._local.depth == 0:
-            self._local.doc = PdfiumDocument(self.filepath)
-        self._local.depth += 1
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._local.depth -= 1
-        if self._local.depth == 0:
-            if hasattr(self._local, "doc") and self._local.doc:
-                self._local.doc.close()
-                self._local.doc = None
-
-    def _get_doc(self):
-        if hasattr(self._local, "doc") and self._local.doc:
-            return self._local.doc, False
-        return PdfiumDocument(self.filepath), True
+    def _open_resource(self):
+        return PdfiumDocument(self.filepath)
 
     def parse_page(self, page_index: int, image_output_dir: str = None) -> dict:
         """Parse one page into the native schema dict."""

--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from datagrunt.core.pdf_io.extraction._doc_session import _ThreadLocalDocSession
 from datagrunt.core.pdf_io.extraction.base import ExtractionBackend
 from datagrunt.core.pdf_io.extraction.ocr import ocr_data_to_blocks
 from datagrunt.core.pdf_io.extraction.pdfium_document import ENCRYPTED_PDF_MESSAGE
@@ -20,7 +21,7 @@ def _import_pymupdf():
     return pymupdf
 
 
-class PyMuPDFBackend(ExtractionBackend):
+class PyMuPDFBackend(_ThreadLocalDocSession, ExtractionBackend):
     """Extraction via PyMuPDF (text/dict spans, images) + Tesseract OCR."""
 
     def __init__(self, filepath):
@@ -43,25 +44,8 @@ class PyMuPDFBackend(ExtractionBackend):
             raise ValueError(ENCRYPTED_PDF_MESSAGE)
         return doc
 
-    def __enter__(self):
-        if not hasattr(self._local, "depth"):
-            self._local.depth = 0
-        if self._local.depth == 0:
-            self._local.doc = self._open_doc()
-        self._local.depth += 1
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._local.depth -= 1
-        if self._local.depth == 0:
-            if hasattr(self._local, "doc") and self._local.doc:
-                self._local.doc.close()
-                self._local.doc = None
-
-    def _get_doc(self):
-        if hasattr(self._local, "doc") and self._local.doc:
-            return self._local.doc, False
-        return self._open_doc(), True
+    def _open_resource(self):
+        return self._open_doc()
 
     def page_count(self) -> int:
         """Return the document's page count using pymupdf (no pdfium dependency)."""

--- a/src/datagrunt/core/pdf_io/extraction/tables.py
+++ b/src/datagrunt/core/pdf_io/extraction/tables.py
@@ -3,6 +3,7 @@
 import logging
 from pathlib import Path
 
+from datagrunt.core.pdf_io.extraction._doc_session import _ThreadLocalDocSession
 from datagrunt.core.pdf_io.extraction.shapes import BBox, TableBlock
 
 logger = logging.getLogger(__name__)
@@ -17,8 +18,10 @@ def _import_pdfplumber():
     return pdfplumber
 
 
-class PdfPlumberTableExtractor:
+class PdfPlumberTableExtractor(_ThreadLocalDocSession):
     """Detect and extract tables on a page using pdfplumber."""
+
+    _lazy_open = True
 
     def __init__(self, filepath):
         """Store the path.
@@ -31,48 +34,25 @@ class PdfPlumberTableExtractor:
 
         self._local = threading.local()
 
-    def __enter__(self):
+    def _open_resource(self):
         # Mark a held-open scope but defer the pdfplumber.open() until a page
         # actually needs tables. Text-only documents (no line drawings, has a
         # text layer) never call extract(), so they must never pay for opening
         # pdfplumber. The shared handle is opened lazily on first extract() and
         # closed when the outermost scope exits.
-        if not hasattr(self._local, "depth"):
-            self._local.depth = 0
-            self._local.pdf = None
-        self._local.depth += 1
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._local.depth -= 1
-        if self._local.depth == 0:
-            if getattr(self._local, "pdf", None):
-                self._local.pdf.close()
-            self._local.pdf = None
-
-    def _get_pdf(self):
-        # Inside a held-open scope (depth > 0) the handle is opened once and
-        # cached for the scope; __exit__ owns closing it. Outside a scope it is
-        # opened transiently and the caller closes it.
-        if getattr(self._local, "pdf", None):
-            return self._local.pdf, False
         pdfplumber = _import_pdfplumber()
         try:
-            pdf = pdfplumber.open(self.filepath)
+            return pdfplumber.open(self.filepath)
         except Exception:  # noqa: BLE001 - pdfplumber raises many types; tables are best-effort
             logger.debug("pdfplumber.open failed for %s; skipping table extraction", self.filepath, exc_info=True)
-            return None, False
-        if getattr(self._local, "depth", 0) > 0:
-            self._local.pdf = pdf
-            return pdf, False
-        return pdf, True
+            return None
 
     def extract(self, page_number: int) -> list:
         """Return ``TableBlock`` objects on ``page_number`` (0-indexed).
 
         Returns an empty list on open/parse failure or out-of-range page (soft).
         """
-        pdf, should_close = self._get_pdf()
+        pdf, should_close = self._get_doc()
         if not pdf:
             return []
         try:

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -363,6 +363,78 @@ def dedupe_document_images(document: dict, image_output_dir: str) -> None:
         PdfiumNativeReader.dedupe_images(document, image_output_dir=image_output_dir)
 
 
+def write_document_json(document: dict, filename: str) -> str:
+    """Serialize *document* to a JSON file at *filename* and return *filename*.
+
+    The file is written with ``indent=2`` to match the historical engine output
+    exactly. This is the single source of truth for JSON serialization — both
+    the engine base class and the ``PDFWriter`` ``_parsed_dict`` path delegate
+    here so the byte output is identical regardless of call site.
+
+    Args:
+        document (dict): A parsed document dict (unified or native schema).
+        filename (str): Destination file path.
+
+    Returns:
+        str: The same *filename* that was written.
+    """
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump(document, f, indent=2)
+    return filename
+
+
+def write_document_jsonl(document: dict, filename: str) -> str:
+    """Flatten *document* and write one JSON record per line to *filename*.
+
+    Dispatches via ``flatten_document`` so both the unified and native pdfium
+    schemas produce the correct flat records. Byte output is identical to the
+    historical per-engine implementation (``json.dumps(record) + "\\n"`` per
+    line, no trailing blank line).
+
+    Args:
+        document (dict): A parsed document dict (unified or native schema).
+        filename (str): Destination file path.
+
+    Returns:
+        str: The same *filename* that was written.
+    """
+    records = flatten_document(document)
+    with open(filename, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record) + "\n")
+    return filename
+
+
+def write_document_markdown(document: dict, filename: str) -> str:
+    """Render *document* to Markdown and write it to *filename*.
+
+    Dispatches on schema via ``document_is_structured``:
+
+    - **Structured** (unified element schema from pymupdf or pdfium structured
+      mode) → ``ParsedDocument.to_markdown``, which resolves image paths
+      relative to *filename*'s directory.
+    - **Native** (lean pdfium schema without ``elements`` per page) →
+      ``PdfiumNativeReader.to_markdown``, which concatenates the page-level
+      ``text`` fields.
+
+    This is the single source of truth for Markdown serialization.
+
+    Args:
+        document (dict): A parsed document dict (unified or native schema).
+        filename (str): Destination file path.
+
+    Returns:
+        str: The same *filename* that was written.
+    """
+    if document_is_structured(document):
+        text = ParsedDocument(document).to_markdown(export_filename=filename)
+    else:
+        text = PdfiumNativeReader.to_markdown(document)
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(text)
+    return filename
+
+
 def collect_image_paths(document: dict) -> list:
     """Return unique image file paths in document order, dispatching on schema."""
     structured = document_is_structured(document)

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -5,7 +5,6 @@ import json
 
 # local libraries
 from datagrunt.core.pdf_io import pdfcomponents
-from datagrunt.core.pdf_io.extraction import PdfiumNativeReader
 from datagrunt.pdf_api._engine_backed import _PDFEngineBacked
 
 
@@ -46,9 +45,7 @@ class PDFWriter(_PDFEngineBacked):
             document = self._parsed_dict
             if image_output_dir and dedupe_images:
                 pdfcomponents.dedupe_document_images(document, image_output_dir)
-            with open(filename, "w", encoding="utf-8") as f:
-                json.dump(document, f, indent=2)
-            return filename
+            return pdfcomponents.write_document_json(document, filename)
         # Mirror PDFReader's is_empty handling: a 0-byte PDF produces an empty
         # document ({}) rather than a raw PdfiumError from loading the file.
         if self.is_empty:
@@ -77,11 +74,7 @@ class PDFWriter(_PDFEngineBacked):
             document = self._parsed_dict
             if image_output_dir and dedupe_images:
                 pdfcomponents.dedupe_document_images(document, image_output_dir)
-            records = pdfcomponents.flatten_document(document)
-            with open(filename, "w", encoding="utf-8") as f:
-                for record in records:
-                    f.write(json.dumps(record) + "\n")
-            return filename
+            return pdfcomponents.write_document_jsonl(document, filename)
         # Mirror PDFReader's is_empty handling: a 0-byte PDF has no elements, so
         # the JSONL output is an empty file rather than a raw PdfiumError.
         if self.is_empty:
@@ -110,13 +103,7 @@ class PDFWriter(_PDFEngineBacked):
             document = self._parsed_dict
             if image_output_dir and dedupe_images:
                 pdfcomponents.dedupe_document_images(document, image_output_dir)
-            if pdfcomponents.document_is_structured(document):
-                markdown_text = pdfcomponents.ParsedDocument(document).to_markdown(export_filename=filename)
-            else:
-                markdown_text = PdfiumNativeReader.to_markdown(document)
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(markdown_text)
-            return filename
+            return pdfcomponents.write_document_markdown(document, filename)
         # Mirror PDFReader's is_empty handling: a 0-byte PDF has no content, so
         # the Markdown output is an empty file rather than a raw PdfiumError.
         if self.is_empty:

--- a/tests/core_tests/csv_io_tests/test_polars_read_helpers.py
+++ b/tests/core_tests/csv_io_tests/test_polars_read_helpers.py
@@ -1,0 +1,99 @@
+"""Unit tests for the _polars_read_csv and _polars_read_to_string_arrow helpers.
+
+These helpers are the single source of truth for the parity-critical Polars
+read options shared by all three Polars-backed CSV read paths. Tests verify:
+  - Leading comment lines are skipped (not treated as data).
+  - Ragged rows are truncated when truncate_ragged_lines=True.
+  - n_rows limits the result to the requested count.
+  - All returned columns are typed as pa.string() (arrow helper).
+"""
+
+import polars as pl
+import pyarrow as pa
+import pytest
+
+from datagrunt.core.csv_io.engines import (
+    _polars_read_csv,
+    _polars_read_to_string_arrow,
+)
+
+
+@pytest.fixture()
+def comment_csv(tmp_path):
+    """CSV with two leading comment lines before the header."""
+    p = tmp_path / "comments.csv"
+    p.write_text("# first comment\n# second comment\nname,color\nalice,#FF0000\nbob,#00FF00\n")
+    return p
+
+
+@pytest.fixture()
+def ragged_csv(tmp_path):
+    """CSV with a ragged (extra-field) row."""
+    p = tmp_path / "ragged.csv"
+    p.write_text("a,b\n1,2\n3,4,EXTRA\n5,6\n")
+    return p
+
+
+class TestPolarsReadCsv:
+    def test_leading_comments_are_skipped(self, comment_csv):
+        df = _polars_read_csv(comment_csv, delimiter=",", truncate_ragged_lines=False)
+        # Header must be the real header, not a comment line.
+        assert df.columns == ["name", "color"]
+        # Data rows only — comments are not treated as data rows.
+        assert len(df) == 2
+        assert df["name"].to_list() == ["alice", "bob"]
+
+    def test_hash_value_in_data_is_preserved(self, comment_csv):
+        """A '#' value in a data column must NOT be silently dropped."""
+        df = _polars_read_csv(comment_csv, delimiter=",", truncate_ragged_lines=False)
+        assert "#FF0000" in df["color"].to_list()
+
+    def test_ragged_rows_truncated(self, ragged_csv):
+        df = _polars_read_csv(ragged_csv, delimiter=",", truncate_ragged_lines=True)
+        assert df.columns == ["a", "b"]
+        assert len(df) == 3
+
+    def test_n_rows_limits_result(self, comment_csv):
+        df = _polars_read_csv(comment_csv, delimiter=",", truncate_ragged_lines=False, n_rows=1)
+        assert len(df) == 1
+        assert df["name"][0] == "alice"
+
+    def test_returns_polars_dataframe(self, comment_csv):
+        result = _polars_read_csv(comment_csv, delimiter=",", truncate_ragged_lines=False)
+        assert isinstance(result, pl.DataFrame)
+
+    def test_infer_schema_false_all_string_dtypes(self, comment_csv):
+        df = _polars_read_csv(comment_csv, delimiter=",", truncate_ragged_lines=False)
+        for dtype in df.dtypes:
+            assert dtype == pl.String
+
+
+class TestPolarsReadToStringArrow:
+    def test_returns_pyarrow_table(self, comment_csv):
+        table = _polars_read_to_string_arrow(comment_csv, delimiter=",", truncate_ragged_lines=False)
+        assert isinstance(table, pa.Table)
+
+    def test_all_columns_are_string_type(self, comment_csv):
+        table = _polars_read_to_string_arrow(comment_csv, delimiter=",", truncate_ragged_lines=False)
+        for field in table.schema:
+            assert field.type == pa.string(), f"Column '{field.name}' has type {field.type}, expected string"
+
+    def test_leading_comments_skipped(self, comment_csv):
+        table = _polars_read_to_string_arrow(comment_csv, delimiter=",", truncate_ragged_lines=False)
+        assert table.column_names == ["name", "color"]
+        assert table.num_rows == 2
+
+    def test_hash_data_value_preserved(self, comment_csv):
+        table = _polars_read_to_string_arrow(comment_csv, delimiter=",", truncate_ragged_lines=False)
+        colors = table.column("color").to_pylist()
+        assert "#FF0000" in colors
+
+    def test_ragged_rows_truncated(self, ragged_csv):
+        table = _polars_read_to_string_arrow(ragged_csv, delimiter=",", truncate_ragged_lines=True)
+        assert table.column_names == ["a", "b"]
+        assert table.num_rows == 3
+
+    def test_n_rows_limits_result(self, comment_csv):
+        table = _polars_read_to_string_arrow(comment_csv, delimiter=",", truncate_ragged_lines=False, n_rows=1)
+        assert table.num_rows == 1
+        assert table.column("name").to_pylist() == ["alice"]

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_doc_session_mixin.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_doc_session_mixin.py
@@ -1,0 +1,182 @@
+"""Tests for the _ThreadLocalDocSession mixin."""
+
+import threading
+
+from datagrunt.core.pdf_io.extraction._doc_session import _ThreadLocalDocSession
+
+# ---------------------------------------------------------------------------
+# Fake subclasses for testing
+# ---------------------------------------------------------------------------
+
+
+class _FakeResource:
+    """Minimal resource with a close() method."""
+
+    def __init__(self, name="resource"):
+        self.name = name
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class _EagerFake(_ThreadLocalDocSession):
+    """Eager (non-lazy) fake subclass."""
+
+    def __init__(self):
+        self.filepath = "fake.pdf"
+        self._local = threading.local()
+        self._open_count = 0
+
+    def _open_resource(self):
+        self._open_count += 1
+        return _FakeResource(f"resource-{self._open_count}")
+
+
+class _LazyFake(_ThreadLocalDocSession):
+    """Lazy fake subclass (mirrors PdfPlumberTableExtractor behaviour)."""
+
+    _lazy_open = True
+
+    def __init__(self):
+        self.filepath = "fake.pdf"
+        self._local = threading.local()
+        self._open_count = 0
+
+    def _open_resource(self):
+        self._open_count += 1
+        return _FakeResource(f"lazy-{self._open_count}")
+
+
+class _SoftFailFake(_ThreadLocalDocSession):
+    """Fake that always returns None from _open_resource (soft open-failure)."""
+
+    def __init__(self):
+        self.filepath = "bad.pdf"
+        self._local = threading.local()
+
+    def _open_resource(self):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Nested ``with`` opens once / closes once (depth counting)
+# ---------------------------------------------------------------------------
+
+
+def test_nested_with_opens_once_closes_once():
+    fake = _EagerFake()
+    with fake:
+        assert fake._local.depth == 1
+        first_doc = fake._local.doc
+        assert first_doc is not None
+        with fake:
+            assert fake._local.depth == 2
+            # Same handle reused
+            assert fake._local.doc is first_doc
+        # After inner exit, depth back to 1, handle still open
+        assert fake._local.depth == 1
+        assert not first_doc.closed
+    # After outermost exit, handle closed
+    assert fake._local.depth == 0
+    assert first_doc.closed
+    # Opened exactly once
+    assert fake._open_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — Outside-scope ``_get_doc()`` returns (resource, True)
+# ---------------------------------------------------------------------------
+
+
+def test_outside_scope_get_doc_returns_transient():
+    fake = _EagerFake()
+    resource, should_close = fake._get_doc()
+    assert resource is not None
+    assert should_close is True
+    # Opened once (transient)
+    assert fake._open_count == 1
+    # Manually close transient handle as caller should
+    resource.close()
+    assert resource.closed
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Lazy subclass does NOT open on ``__enter__`` but opens on first ``_get_doc()``
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_does_not_open_on_enter_opens_on_get_doc():
+    fake = _LazyFake()
+    with fake:
+        # __enter__ must NOT have opened the resource
+        assert fake._open_count == 0
+        assert getattr(fake._local, "doc", None) is None
+
+        # First _get_doc() inside scope opens and caches
+        doc, should_close = fake._get_doc()
+        assert doc is not None
+        assert should_close is False
+        assert fake._open_count == 1
+        assert fake._local.doc is doc
+
+        # Second _get_doc() reuses the cached handle
+        doc2, should_close2 = fake._get_doc()
+        assert doc2 is doc
+        assert should_close2 is False
+        assert fake._open_count == 1  # still only one open
+
+    # After scope exits, handle closed
+    assert doc.closed
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Soft-fail: ``_open_resource`` returns None → ``_get_doc()`` returns (None, False)
+# ---------------------------------------------------------------------------
+
+
+def test_soft_fail_returns_none_false():
+    fake = _SoftFailFake()
+    resource, should_close = fake._get_doc()
+    assert resource is None
+    assert should_close is False
+
+
+def test_soft_fail_inside_scope():
+    fake = _SoftFailFake()
+    with fake:
+        resource, should_close = fake._get_doc()
+        assert resource is None
+        assert should_close is False
+    # Exiting cleanly (no crash) even though no handle was opened
+    assert fake._local.depth == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Per-thread independence: two threads each get their own handle
+# ---------------------------------------------------------------------------
+
+
+def test_per_thread_independence():
+    fake = _EagerFake()
+    # Keep strong references to the docs opened per thread so CPython does not
+    # reuse the same memory address before we compare them.
+    docs = {}
+    barrier = threading.Barrier(2)
+
+    def thread_fn(thread_id):
+        with fake:
+            docs[thread_id] = fake._local.doc
+            barrier.wait()  # hold both threads open at the same time
+
+    t1 = threading.Thread(target=thread_fn, args=(1,))
+    t2 = threading.Thread(target=thread_fn, args=(2,))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # Both threads opened the resource (total 2 opens)
+    assert fake._open_count == 2
+    # Each thread got a distinct resource object
+    assert docs[1] is not docs[2]

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -666,8 +666,11 @@ class TestWriteDocumentJsonl:
         out = tmp_path / "term.jsonl"
         write_document_jsonl(_STRUCTURED_DOC, str(out))
         raw = out.read_bytes()
-        # Every line in the file ends with b'\n' (no bare CR, no missing LF).
-        assert all(ln.endswith(b"\n") or ln == b"" for ln in raw.splitlines(keepends=True))
+        # The file ends with a trailing LF and uses no CR (records are
+        # '\n'-separated, never '\r\n' or bare CR). ``json.dumps`` escapes any
+        # control bytes inside values, so a raw '\r' can only come from the
+        # separator — this assertion would catch that regression.
+        assert raw.endswith(b"\n") and b"\r" not in raw
 
 
 class TestWriteDocumentMarkdown:

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -530,3 +530,204 @@ class TestMarkdownMetacharacterEscaping:
         path = str(Path("/tmp/foo]bar.png"))
         md = self._markdown([self._image_element(path)])
         assert "foo\\]bar.png" in md
+
+
+# ---------------------------------------------------------------------------
+# Shared serialization helpers: write_document_json / jsonl / markdown
+# ---------------------------------------------------------------------------
+
+# Minimal structured document (unified element schema).
+_STRUCTURED_DOC = {
+    "document": {
+        "source": "test.pdf",
+        "total_pages": 1,
+        "processing_id": "proc_py_0",
+        "pipeline_type": "pure_python_local_v1",
+        "errors": None,
+        "pages": [
+            {
+                "page_number": 1,
+                "width": 612.0,
+                "height": 792.0,
+                "classification": "text_only",
+                "elements": [
+                    {
+                        "id": "elem_01_001",
+                        "type": "header",
+                        "content": "Test Header",
+                        "page": 1,
+                        "position": {"x": 0.0, "y": 0.0, "w": 100.0, "h": 20.0},
+                        "confidence": 1.0,
+                        "metadata": {
+                            "font": "Helvetica",
+                            "font_size": 18.0,
+                            "is_bold": True,
+                            "is_italic": False,
+                            "reading_order": 1,
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+}
+
+# Minimal native pdfium document (no 'elements' per page).
+# text_objects must be non-empty for flatten() to produce records.
+_NATIVE_DOC = {
+    "document": {
+        "source": "test.pdf",
+        "page_count": 1,
+        "pages": [
+            {
+                "page_number": 1,
+                "width": 612.0,
+                "height": 792.0,
+                "text": "Hello from native pdfium",
+                "text_objects": [{"x": 0.0, "y": 0.0, "text": "Hello from native pdfium", "size": 12.0}],
+                "images": [],
+                "ocr": [],
+            }
+        ],
+    }
+}
+
+
+class TestWriteDocumentJson:
+    """write_document_json writes valid JSON with indent=2 and returns the path."""
+
+    def test_structured_doc_roundtrips(self, tmp_path):
+        import json
+
+        from datagrunt.core.pdf_io.pdfcomponents import write_document_json
+
+        out = tmp_path / "doc.json"
+        result = write_document_json(_STRUCTURED_DOC, str(out))
+
+        assert result == str(out)
+        loaded = json.loads(out.read_text(encoding="utf-8"))
+        assert loaded == _STRUCTURED_DOC
+
+    def test_native_doc_roundtrips(self, tmp_path):
+        import json
+
+        from datagrunt.core.pdf_io.pdfcomponents import write_document_json
+
+        out = tmp_path / "native.json"
+        write_document_json(_NATIVE_DOC, str(out))
+        loaded = json.loads(out.read_text(encoding="utf-8"))
+        assert loaded == _NATIVE_DOC
+
+    def test_uses_indent_2(self, tmp_path):
+        """Output must use indent=2 to be byte-identical to the historical engine output."""
+        import json
+
+        from datagrunt.core.pdf_io.pdfcomponents import write_document_json
+
+        out = tmp_path / "indented.json"
+        write_document_json(_STRUCTURED_DOC, str(out))
+        expected = json.dumps(_STRUCTURED_DOC, indent=2)
+        assert out.read_text(encoding="utf-8") == expected
+
+
+class TestWriteDocumentJsonl:
+    """write_document_jsonl writes one flattened record per line."""
+
+    def test_structured_doc_produces_records(self, tmp_path):
+        import json
+
+        from datagrunt.core.pdf_io.pdfcomponents import write_document_jsonl
+
+        out = tmp_path / "doc.jsonl"
+        result = write_document_jsonl(_STRUCTURED_DOC, str(out))
+
+        assert result == str(out)
+        lines = [ln for ln in out.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        assert len(lines) == 1  # one element in the doc
+        record = json.loads(lines[0])
+        assert record["type"] == "header"
+        assert record["content"] == "Test Header"
+
+    def test_native_doc_produces_records(self, tmp_path):
+        import json
+
+        from datagrunt.core.pdf_io.pdfcomponents import write_document_jsonl
+
+        out = tmp_path / "native.jsonl"
+        write_document_jsonl(_NATIVE_DOC, str(out))
+        lines = [ln for ln in out.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        assert len(lines) >= 1
+        json.loads(lines[0])  # each line is valid JSON
+
+    def test_each_line_newline_terminated(self, tmp_path):
+        """Each record must end with '\\n' to match the historical byte output."""
+        from datagrunt.core.pdf_io.pdfcomponents import write_document_jsonl
+
+        out = tmp_path / "term.jsonl"
+        write_document_jsonl(_STRUCTURED_DOC, str(out))
+        raw = out.read_bytes()
+        # Every line in the file ends with b'\n' (no bare CR, no missing LF).
+        assert all(ln.endswith(b"\n") or ln == b"" for ln in raw.splitlines(keepends=True))
+
+
+class TestWriteDocumentMarkdown:
+    """write_document_markdown dispatches on schema and writes the rendered text."""
+
+    def test_structured_doc_uses_parsed_document_renderer(self, tmp_path):
+        """Structured docs → ParsedDocument.to_markdown (unified element renderer)."""
+        from datagrunt.core.pdf_io.pdfcomponents import write_document_markdown
+
+        out = tmp_path / "doc.md"
+        result = write_document_markdown(_STRUCTURED_DOC, str(out))
+
+        assert result == str(out)
+        text = out.read_text(encoding="utf-8")
+        # The header element renders as an H1 heading.
+        assert "# Test Header" in text
+
+    def test_native_doc_uses_pdfium_native_renderer(self, tmp_path):
+        """Native pdfium docs → PdfiumNativeReader.to_markdown (text concatenation)."""
+        from datagrunt.core.pdf_io.pdfcomponents import write_document_markdown
+
+        out = tmp_path / "native.md"
+        result = write_document_markdown(_NATIVE_DOC, str(out))
+
+        assert result == str(out)
+        text = out.read_text(encoding="utf-8")
+        assert "Hello from native pdfium" in text
+
+    def test_dispatch_picks_right_renderer(self, tmp_path, monkeypatch):
+        """document_is_structured controls which renderer is called."""
+        from datagrunt.core.pdf_io import pdfcomponents
+
+        structured_calls = []
+        native_calls = []
+
+        original_is_structured = pdfcomponents.document_is_structured
+
+        def fake_is_structured(doc):
+            return original_is_structured(doc)
+
+        original_parsed_to_markdown = pdfcomponents.ParsedDocument.to_markdown
+
+        def spy_parsed(self, **kwargs):
+            structured_calls.append(True)
+            return original_parsed_to_markdown(self, **kwargs)
+
+        original_native_to_markdown = pdfcomponents.PdfiumNativeReader.to_markdown
+
+        @staticmethod
+        def spy_native(doc):
+            native_calls.append(True)
+            return original_native_to_markdown(doc)
+
+        monkeypatch.setattr(pdfcomponents.ParsedDocument, "to_markdown", spy_parsed)
+        monkeypatch.setattr(pdfcomponents.PdfiumNativeReader, "to_markdown", spy_native)
+
+        out_s = tmp_path / "s.md"
+        out_n = tmp_path / "n.md"
+        pdfcomponents.write_document_markdown(_STRUCTURED_DOC, str(out_s))
+        pdfcomponents.write_document_markdown(_NATIVE_DOC, str(out_n))
+
+        assert structured_calls == [True], "ParsedDocument.to_markdown not called for structured doc"
+        assert native_calls == [True], "PdfiumNativeReader.to_markdown not called for native doc"


### PR DESCRIPTION
Three of the four DRY consolidations from #237. All are pure refactors — output/behavior byte-identical, verified by the differential-parity suite + the PDF backend-parity harness.

- **CSV** — extract `_polars_read_csv` / `_polars_read_to_string_arrow` helpers in `csv_io/engines.py`; the three Polars-fallback read blocks (`_create_dataframe`, `_polars_fallback_table`, `CSVWriterPyArrowEngine._create_table`) now delegate. Parity-critical read options live in one place.
- **PDF writers** — extract `write_document_json/jsonl/markdown` into `pdfcomponents.py`; `PDFBaseWriterEngine`'s `write_*` are now concrete (markdown renderer chosen via `document_is_structured(document)`, so the PDFium engine needs no override); `pdfwriter.py`'s `_parsed_dict` branches route through the same helpers. Removes the 4-way duplication.
- **PDF backends** — extract a `_ThreadLocalDocSession` mixin (`extraction/_doc_session.py`); the four backends (pdfium, pdfium-native, pymupdf, pdfplumber-tables) inherit the depth-counted thread-local lifecycle. `_lazy_open` flag + `None` soft-fail capture the only two variations.

## Deferred (your call)
The 4th item — unifying the two Rust universal-newline line-splitters (`io.rs::UniversalLines` vs `rows.rs::probe_csv_header`) — is **deferred**. They have different contracts (terminator-stripped vs preserved), were just stabilized in #222/#233, and the differential-parity suite already guards against silent drift, so the DRY win doesn't justify re-risking the security-critical CSV reader. **#237 stays open** for that item.

## Testing
- Both pytest backends **1197**; differential parity **567**; PDF backend parity **19**; `ruff check src tests` + `ruff format --check .` clean; zero `rust/` touched.
- New focused tests for each helper/mixin (CSV read helpers; `write_document_*`; the doc-session mixin incl. lazy/soft-fail/per-thread).

## Review
Each task: TDD implementer + per-task spec+quality review (all Approved). Plus a final whole-branch Opus integration review: **Ready to merge — Yes**, no Critical/Important.

Refs #237 (Tasks 1–3 of 4; Rust line-splitter deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)