### PR TITLE
ci(security): harden release pipeline — SHA-pin actions + advisory audits (#175)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
           - { os: ubuntu-24.04-arm, target: aarch64,                manylinux: auto }
           - { os: windows-latest,   target: x86_64-pc-windows-msvc, manylinux: auto }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist
@@ -53,7 +53,7 @@ jobs:
       # 4.0.0 linux wheels are live). The sdist (the file that actually broke) is
       # built on the host and twine-checked below.
       - name: Upload wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheel-${{ matrix.target }}
           path: dist/*.whl
@@ -63,8 +63,8 @@ jobs:
     name: sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       # Build the sdist on the host (it is pure source — no manylinux container
@@ -77,7 +77,7 @@ jobs:
           maturin sdist --out dist
           twine check dist/*.tar.gz
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sdist
           path: dist/*.tar.gz

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -29,13 +29,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          # TODO(#242): retire this long-lived PAT (GitHub App token or
+          # fine-grained scoped PAT). Tracked separately — needs maintainer
+          # provisioning.
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     name: cargo + pytest (both backends)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: "3.12"
 
@@ -37,6 +37,8 @@ jobs:
 
       - name: cargo test
         working-directory: rust
+        env:
+          CARGO_NET_RETRY: "10" # tolerate transient crates.io HTTP/2 fetch flakes
         run: cargo test
 
       - name: pytest (Rust backend)
@@ -56,3 +58,41 @@ jobs:
   build:
     name: wheel matrix
     uses: ./.github/workflows/build.yml
+
+  audit:
+    name: dependency audit (advisory)
+    runs-on: ubuntu-latest
+    # Advisory, NOT blocking: a newly published advisory in a transitive
+    # dependency (duckdb, polars, pyarrow, pymupdf, …) must not break CI or the
+    # release path overnight. Findings surface in the step logs; promote to
+    # blocking once a clean baseline + an ignore-list of accepted advisories is
+    # curated (RUSTSEC-* / GHSA-* / PYSEC-*).
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: cargo audit
+        continue-on-error: true
+        working-directory: rust
+        env:
+          CARGO_NET_RETRY: "10"
+        run: |
+          cargo install cargo-audit --locked
+          cargo audit
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          python-version: "3.12"
+
+      - name: pip-audit
+        continue-on-error: true
+        # Audit the project's resolved dependency tree (installed into the venv).
+        # ``pip`` is installed alongside because pip-audit's environment source
+        # enumerates installed dists via pip (uv venvs omit pip by default).
+        run: |
+          uv venv --clear
+          uv pip install -e . pip-audit pip
+          .venv/bin/pip-audit

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -34,14 +34,14 @@ jobs:
       id-token: write
     steps:
       - name: Download all wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           pattern: "wheel-*"
           merge-multiple: true
 
       - name: Download sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: sdist
           path: dist
@@ -51,10 +51,10 @@ jobs:
 
       - name: Publish to TestPyPI
         if: ${{ github.event.inputs.target == 'testpypi' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (v1.14.0)
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish to PyPI
         if: ${{ github.event.inputs.target != 'testpypi' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (v1.14.0)


### PR DESCRIPTION
From the 4.0.0 security review (#175). No source changes — workflows only.

## Changes
- **Pin every action to a full commit SHA** (with a `# version` comment) across `ci.yml`, `build.yml`, `bump-version.yml`, `publish-to-pypi.yml`. Same versions as before (no major bumps). The highest-value pin: the OIDC-privileged **`pypa/gh-action-pypi-publish`** moves off the floating `release/v1` **branch** to a pinned SHA (= `v1.14.0`).
- **Advisory dependency audit** — a new `continue-on-error` CI job runs `cargo-audit` + `pip-audit`. Deliberately non-blocking: a newly published advisory in a big transitive dep (duckdb/polars/pymupdf/…) must not break CI or the release path overnight. Findings surface in the logs; promote to blocking later behind a curated ignore-list.
- **`CARGO_NET_RETRY=10`** on the cargo steps (the transient crates.io HTTP/2 fetch flake we hit during a post-merge run).

## Deferred → #242
Item 2 (retire the long-lived `PAT_TOKEN`) needs maintainer provisioning (GitHub App token or fine-grained PAT) or a pipeline restructure — can't be done safely from a PR without risking the live release chain. Tracked in **#242**; `bump-version.yml` keeps the working PAT with a `TODO(#242)` pointer.

## Verification
- All 8 action SHAs independently re-verified against the GitHub API (incl. the publish action = `v1.14.0`).
- All 4 workflows parse under PyYAML; pipeline semantics unchanged (triggers, `id-token: write` only on the publish job, `workflow_run` chain, environment gating, the local reusable-workflow call left unpinned).
- Opus security review: **Ready to merge — Yes**, no Critical/Important.
- This PR's own CI run exercises the pinned actions + the new audit job.

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)