### PR TITLE
perf(rust): release the GIL during large CSV scans (#177)

### DIFF
--- a/rust/datagrunt-python/src/lib.rs
+++ b/rust/datagrunt-python/src/lib.rs
@@ -53,19 +53,30 @@ fn delimiter_byte(delimiter: &str) -> PyResult<u8> {
     }
 }
 
+// These functions do file I/O whose cost scales with file size (most of all
+// `row_count_with_header`, a full-file scan). The work runs inside `py.detach`
+// (PyO3's GIL-release API, formerly `allow_threads`) so a long scan no longer
+// blocks every other Python thread for its full duration (issue #177). The
+// closures touch no Python objects, so releasing the GIL is sound; `delimiter`
+// is validated first because that step can raise a Python exception and must
+// hold the GIL.
 #[pyfunction]
-fn infer_delimiter(path: PathBuf) -> PyResult<String> {
-    datagrunt_core::delimiter::infer_delimiter(&path).map_err(oserr)
+fn infer_delimiter(py: Python<'_>, path: PathBuf) -> PyResult<String> {
+    py.detach(|| datagrunt_core::delimiter::infer_delimiter(&path))
+        .map_err(oserr)
 }
 
 #[pyfunction]
-fn row_count_with_header(path: PathBuf, delimiter: &str) -> PyResult<u64> {
-    datagrunt_core::rows::row_count_with_header(&path, delimiter_byte(delimiter)?).map_err(oserr)
+fn row_count_with_header(py: Python<'_>, path: PathBuf, delimiter: &str) -> PyResult<u64> {
+    let delimiter = delimiter_byte(delimiter)?;
+    py.detach(|| datagrunt_core::rows::row_count_with_header(&path, delimiter))
+        .map_err(oserr)
 }
 
 #[pyfunction]
-fn check_ragged(path: PathBuf, delimiter: &str) -> PyResult<bool> {
-    Ok(datagrunt_core::ragged::check_ragged(&path, delimiter_byte(delimiter)?))
+fn check_ragged(py: Python<'_>, path: PathBuf, delimiter: &str) -> PyResult<bool> {
+    let delimiter = delimiter_byte(delimiter)?;
+    Ok(py.detach(|| datagrunt_core::ragged::check_ragged(&path, delimiter)))
 }
 
 /// CSVDialect equivalent: None for empty/blank files or an undeterminable
@@ -82,16 +93,25 @@ fn sniff_dialect(
     path: PathBuf,
     delimiter: Option<String>,
 ) -> PyResult<Option<Py<PyDict>>> {
-    let probe = datagrunt_core::rows::probe_csv_header(&path).map_err(oserr)?;
-    if probe.empty || probe.blank {
-        return Ok(None);
-    }
-    let sample = probe.sample_lines.join("");
-    // An empty delimiter string is Python-falsy (`if delimiter:`), meaning "no
-    // restriction" — normalize it to None so it doesn't reject every candidate
-    // (Some("") would make the substring guard `"".contains(x)` reject all).
-    let delimiter = delimiter.as_deref().filter(|s| !s.is_empty());
-    let Some(d) = datagrunt_core::dialect::sniff(&sample, delimiter) else {
+    // The header probe (file I/O) and sniffing run without the GIL so other
+    // Python threads make progress during the scan (issue #177); the GIL is
+    // reacquired only to build the result dict.
+    let sniffed = py
+        .detach(|| -> std::io::Result<Option<datagrunt_core::dialect::SniffedDialect>> {
+            let probe = datagrunt_core::rows::probe_csv_header(&path)?;
+            if probe.empty || probe.blank {
+                return Ok(None);
+            }
+            let sample = probe.sample_lines.join("");
+            // An empty delimiter string is Python-falsy (`if delimiter:`), meaning
+            // "no restriction" — normalize it to None so it doesn't reject every
+            // candidate (Some("") would make the substring guard `"".contains(x)`
+            // reject all).
+            let delimiter = delimiter.as_deref().filter(|s| !s.is_empty());
+            Ok(datagrunt_core::dialect::sniff(&sample, delimiter))
+        })
+        .map_err(oserr)?;
+    let Some(d) = sniffed else {
         return Ok(None);
     };
     let dict = PyDict::new(py);

--- a/tests/core_tests/csv_io_tests/test_gil_release.py
+++ b/tests/core_tests/csv_io_tests/test_gil_release.py
@@ -1,0 +1,137 @@
+"""The Rust CSV-scan #[pyfunction]s release the GIL during heavy file I/O.
+
+``row_count_with_header`` scans the entire file. Before issue #177 it held the
+GIL for the whole scan, blocking every other Python thread until it finished.
+After wrapping the heavy compute in ``py.detach`` (PyO3's GIL-release API) a
+concurrent Python thread runs in parallel for the scan's duration.
+
+Proving GIL release by an *absolute* iteration count is unreliable: even a
+GIL-holding C call leaks the GIL in brief slices, so a background loop always
+advances *somewhat*. The robust discriminator is the background loop's rate as
+a fraction of its unobstructed (free) rate:
+
+* GIL held for the scan  -> background runs at a small fraction of free (~7%).
+* GIL released           -> background runs at nearly the free rate (~98%).
+
+The assertion threshold sits in the wide gap between those regimes, so it holds
+across machines and core counts without being timing-flaky. ``row_count`` is the
+only one of the four wrapped functions that does a true full-file scan
+(``check_ragged`` caps at 10k rows; ``infer_delimiter``/``sniff_dialect`` read
+only a header sample), so it is the probe here; the others' wrappers are covered
+by ``test_concurrent_scans_stay_correct``.
+"""
+
+import threading
+import time
+
+import pytest
+
+from datagrunt import _native
+
+# Wide rows so a modest row count still yields a multi-megabyte file whose scan
+# takes long enough (tens of ms) to measure the background thread's rate.
+_ROW = b"alpha,bravo,charlie,delta,echo,foxtrot,golf,hotel\n"
+_HEADER = b"col1,col2,col3,col4,col5,col6,col7,col8\n"
+_TARGET_BYTES = 48 * 1024 * 1024
+
+# Background must reach at least this fraction of its free rate during the scan
+# for the GIL to count as released. Measured: ~0.07 (held) vs ~0.98 (released);
+# 0.4 clears the held regime by >5x while tolerating a single-core, time-sharing
+# scheduler (which still yields ~0.5) and CI noise.
+_MIN_RATE_FRACTION = 0.4
+
+
+@pytest.fixture
+def large_csv(tmp_path):
+    """A multi-megabyte CSV whose full scan takes long enough to time."""
+    path = tmp_path / "large.csv"
+    path.write_bytes(_HEADER + _ROW * (_TARGET_BYTES // len(_ROW)))
+    return str(path)
+
+
+class _BackgroundCounter:
+    """A daemon thread running a pure-Python loop that needs the GIL to advance."""
+
+    def __init__(self):
+        self._count = 0
+        self._stop = False
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self):
+        while not self._stop:
+            self._count += 1
+
+    def __enter__(self):
+        self._thread.start()
+        time.sleep(0.05)  # let the loop reach steady state before sampling
+        return self
+
+    def __exit__(self, *exc):
+        self._stop = True
+        self._thread.join(timeout=1.0)
+
+    def rate_during(self, action):
+        """Iterations/sec the background loop achieved while ``action`` ran."""
+        before = self._count
+        start = time.perf_counter()
+        action()
+        elapsed = time.perf_counter() - start
+        return (self._count - before) / elapsed, elapsed
+
+
+def test_row_count_releases_gil_during_scan(large_csv):
+    with _BackgroundCounter() as counter:
+        # Free rate: main thread sleeps, so the background loop owns the GIL.
+        free_rate, _ = counter.rate_during(lambda: time.sleep(0.08))
+        # Scan rate: best of a few runs, so one scheduler hiccup can't fail it.
+        # If the GIL is released the background loop keeps near its free rate.
+        scan_rate = 0.0
+        scan_elapsed = 0.0
+        for _ in range(3):
+            rate, elapsed = counter.rate_during(lambda: _native.row_count_with_header(large_csv, ","))
+            scan_rate = max(scan_rate, rate)
+            scan_elapsed = max(scan_elapsed, elapsed)
+
+    if scan_elapsed < 0.02:
+        pytest.skip(f"scan too fast ({scan_elapsed * 1000:.1f}ms) to measure reliably")
+
+    fraction = scan_rate / free_rate
+    assert fraction >= _MIN_RATE_FRACTION, (
+        f"background thread ran at only {fraction:.0%} of its free rate during "
+        f"the scan ({scan_rate / 1e6:.1f}M/s vs {free_rate / 1e6:.1f}M/s) — the "
+        f"GIL was not released"
+    )
+
+
+def test_concurrent_scans_stay_correct(large_csv):
+    """The GIL-releasing scans return consistent results when run concurrently.
+
+    Guards against any data race or unsafety introduced by releasing the GIL:
+    every worker thread must agree with a single-threaded baseline across all
+    four wrapped functions.
+    """
+
+    def snapshot():
+        return (
+            _native.row_count_with_header(large_csv, ","),
+            _native.check_ragged(large_csv, ","),
+            _native.infer_delimiter(large_csv),
+            _native.sniff_dialect(large_csv)["delimiter"],
+        )
+
+    baseline = snapshot()
+    results = []
+    results_lock = threading.Lock()
+
+    def worker():
+        result = snapshot()
+        with results_lock:
+            results.append(result)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30.0)
+
+    assert results == [baseline] * 8


### PR DESCRIPTION
## Summary

The four PyO3 binding functions that read files — `infer_delimiter`, `row_count_with_header`, `check_ragged`, and `sniff_dialect` — held the GIL for their entire duration, blocking every other Python thread during a long scan (most impactful for `row_count_with_header`, a full-file scan). This wraps the heavy compute in `py.detach` (PyO3 0.29's renamed `allow_threads`) so concurrent Python threads make progress while a scan runs.

Perf-only; observable behavior is unchanged.

Closes #177

## Soundness

- The `detach` closures capture only `PathBuf`, a copied delimiter `u8`, or a moved `Option<String>` — never a Python handle (`py`, `Bound`, `Py<…>`), so the `Ungil` bound holds.
- Delimiter validation (which can raise `PyValueError`) stays **before** `py.detach`, i.e. GIL-held.
- `sniff_dialect` builds its result `PyDict` **after** the GIL is reacquired; the closure returns a plain `SniffedDialect`. Empty/blank early-return, empty-delimiter normalization, and all dict fields are byte-for-byte identical to before.
- No new panic-across-FFI path.
- Scope: deliberately **not** applied to the cheap bounded-read functions (`leading_rows`, `first_row`, `count_leading_comments`, `probe_csv_header`) — detaching for sub-millisecond reads is pure overhead.

## Testing

New `tests/core_tests/csv_io_tests/test_gil_release.py`:

- **`test_row_count_releases_gil_during_scan`** — measures a background Python loop's rate as a fraction of its unobstructed (free) rate during a scan. An absolute iteration count is unreliable (a GIL-*holding* C call still leaks the GIL in brief slices), so a ratio is used. Verified red→green: **~8% of free rate with the GIL held → fails; ~98% once released → passes** (threshold 0.4, robust on single-core/loaded CI; skips if the scan is too fast to measure).
- **`test_concurrent_scans_stay_correct`** — 8 threads snapshot all four wrapped functions; each must equal a single-threaded baseline (deterministic data-race guard).

Gates (all green locally):
- `uv run pytest tests/ -q` — 1199 passed
- `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` — 1199 passed
- `cd rust && cargo test` — 55 passed
- `uv run pytest tests/parity/ -q` — 567 passed
- `ruff check` (csv_io + src/tests) — clean
- `cargo clippy -p datagrunt-python` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)