### PR TITLE
fix(rust): treat C0 separators as whitespace for Python parity (#176)

### DIFF
--- a/rust/datagrunt-core/src/delimiter.rs
+++ b/rust/datagrunt-core/src/delimiter.rs
@@ -38,9 +38,11 @@ fn candidates_most_common_first(first_row: &str) -> Vec<char> {
 }
 
 /// Python _split_row: ' ' uses str.split() (whitespace runs), else split(char).
+/// `py_split_whitespace` matches Python's whitespace set (incl. C0 separators),
+/// unlike Rust's `str::split_whitespace` (issue #176).
 fn field_count(row: &str, c: char) -> usize {
     if c == SPACE_DELIMITER {
-        row.split_whitespace().count()
+        io::py_split_whitespace(row).count()
     } else {
         row.split(c).count()
     }

--- a/rust/datagrunt-core/src/io.rs
+++ b/rust/datagrunt-core/src/io.rs
@@ -21,6 +21,30 @@ pub fn take_chars(s: &str, n: usize) -> String {
     s.chars().take(n).collect()
 }
 
+/// Python `str.isspace()` for a single char.
+///
+/// Identical to Rust's `char::is_whitespace` (Unicode `White_Space`) EXCEPT
+/// that CPython also treats the C0 information separators FS/GS/RS/US
+/// (U+001C-U+001F) as whitespace. Those four are the ONLY divergence between
+/// the two definitions across the whole of Unicode (verified exhaustively), so
+/// adding them makes Rust `strip`/`split` agree with Python (issue #176).
+pub(crate) fn is_python_whitespace(c: char) -> bool {
+    c.is_whitespace() || matches!(c, '\u{1c}'..='\u{1f}')
+}
+
+/// Python `str.strip()` with no arguments: trim leading/trailing whitespace
+/// using Python's whitespace definition (see [`is_python_whitespace`]).
+pub(crate) fn py_strip(s: &str) -> &str {
+    s.trim_matches(is_python_whitespace)
+}
+
+/// Python `str.split()` with no arguments: split on runs of Python-whitespace,
+/// discarding empty leading/trailing fields. Mirrors `str::split_whitespace`
+/// but with Python's whitespace definition (see [`is_python_whitespace`]).
+pub(crate) fn py_split_whitespace(s: &str) -> impl Iterator<Item = &str> {
+    s.split(is_python_whitespace).filter(|field| !field.is_empty())
+}
+
 /// Python `errors="ignore"`: invalid byte sequences are dropped, not replaced.
 pub fn decode_ignore(bytes: &[u8]) -> String {
     let mut out = String::with_capacity(bytes.len());
@@ -600,7 +624,9 @@ pub(crate) fn is_blank(path: &Path) -> bool {
     }
     let body = if bytes.starts_with(BOM) { &bytes[BOM.len()..] } else { &bytes[..] };
     match std::str::from_utf8(body) {
-        Ok(s) => s.trim().is_empty(),
+        // `py_strip` matches Python's `str.strip()` whitespace set (incl. the
+        // C0 separators), so an all-separator file reads as blank (issue #176).
+        Ok(s) => py_strip(s).is_empty(),
         Err(_) => false,
     }
 }
@@ -627,6 +653,46 @@ mod tests {
     fn decode_ignore_drops_invalid_bytes() {
         assert_eq!(decode_ignore(b"Jos\xe9,NYC"), "Jos,NYC"); // errors="ignore" DROPS
         assert_eq!(decode_ignore("héllo".as_bytes()), "héllo");
+    }
+
+    #[test]
+    fn python_whitespace_includes_c0_separators() {
+        // The C0 information separators (U+001C-001F) are whitespace to Python
+        // but NOT to Rust's char::is_whitespace — the entire divergence set.
+        for c in ['\u{1c}', '\u{1d}', '\u{1e}', '\u{1f}'] {
+            assert!(is_python_whitespace(c), "{c:?} should be Python whitespace");
+            assert!(!c.is_whitespace(), "{c:?} is not Rust White_Space (precondition)");
+        }
+        // Ordinary whitespace (incl. \xa0 NBSP, already shared) is unchanged.
+        for c in [' ', '\t', '\n', '\r', '\u{0c}', '\u{a0}'] {
+            assert!(is_python_whitespace(c));
+        }
+        // '\u{1b}' (ESC, just below the separators) is whitespace in neither.
+        assert!(!is_python_whitespace('\u{1b}'));
+        assert!(!is_python_whitespace('a'));
+        assert!(!is_python_whitespace('#'));
+    }
+
+    #[test]
+    fn py_strip_trims_c0_separators_like_python() {
+        // "\x1c# c".strip() == "# c"  =>  recognised as a comment after strip.
+        assert_eq!(py_strip("\u{1c}# c"), "# c");
+        assert_eq!(py_strip("\u{1c}\u{1d}name,age\u{1e}\u{1f}"), "name,age");
+        // A line of only separators strips to empty (blank).
+        assert_eq!(py_strip("\u{1c}\u{1d}\u{1e}\u{1f}"), "");
+        // Mixed with ordinary whitespace.
+        assert_eq!(py_strip(" \t\u{1f}x\u{1c} \n"), "x");
+    }
+
+    #[test]
+    fn py_split_whitespace_splits_on_c0_separators_like_python() {
+        // Python: "a\x1cb\x1cc".split() == ["a", "b", "c"].
+        assert_eq!(py_split_whitespace("a\u{1c}b\u{1c}c").collect::<Vec<_>>(), ["a", "b", "c"]);
+        // Mixed separators and ordinary whitespace collapse into one split.
+        assert_eq!(py_split_whitespace("a\u{1d} \tb").collect::<Vec<_>>(), ["a", "b"]);
+        // Leading/trailing separators produce no empty fields.
+        assert_eq!(py_split_whitespace("\u{1f}a b\u{1c}").collect::<Vec<_>>(), ["a", "b"]);
+        assert_eq!(py_split_whitespace("\u{1c}\u{1d}\u{1e}\u{1f}").count(), 0);
     }
 
     #[test]
@@ -876,6 +942,9 @@ mod tests {
         assert!(!is_blank(tmp(b"a", ".csv").path()));
         assert!(!is_blank(tmp(b"\xff\xfe", ".csv").path())); // invalid UTF-8 = content
         assert!(is_blank(tmp(b"\xef\xbb\xbf \n", ".csv").path())); // BOM + whitespace
+        // C0 separators are whitespace to Python's strip, so an all-separator
+        // file is blank (issue #176) — matching BlankFile.is_blank.
+        assert!(is_blank(tmp(b"\x1c\x1d\x1e\x1f\n", ".csv").path()));
         assert!(is_tsv(std::path::Path::new("x.tsv")));
         assert!(is_tsv(std::path::Path::new("x.TSV")));
         assert!(!is_tsv(std::path::Path::new("x.csv")));

--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -1,7 +1,7 @@
 //! Ports of CSVRows probes and the leading-line counters.
 
 use crate::io::{
-    decode_ignore, is_empty, take_chars, universal_lines, DecodedReader, MAX_LINE_CHARS,
+    decode_ignore, is_empty, py_strip, take_chars, universal_lines, DecodedReader, MAX_LINE_CHARS,
     MAX_LINE_READ_BYTES,
 };
 use std::fs::File;
@@ -113,8 +113,8 @@ pub fn probe_csv_header(path: &Path) -> std::io::Result<HeaderProbe> {
         // the char cap for parity with the Python reference.
         let raw = decode_ignore(&segment);
         let text = take_chars(&raw, MAX_LINE_CHARS);
-        // `stripped` mirrors Python's `line.strip()`.
-        let stripped = text.trim();
+        // `stripped` mirrors Python's `line.strip()` (incl. C0 separators).
+        let stripped = py_strip(&text);
         if !stripped.is_empty() {
             saw_nonblank = true;
         }
@@ -151,7 +151,7 @@ pub fn leading_rows(path: &Path, limit: usize) -> std::io::Result<Vec<String>> {
     let mut rows = Vec::new();
     for line in universal_lines(path)? {
         let line = line?;
-        let stripped = line.trim();
+        let stripped = py_strip(&line);
         if !stripped.is_empty() && !stripped.starts_with('#') {
             rows.push(stripped.to_string());
             if rows.len() >= limit {
@@ -172,7 +172,7 @@ pub fn count_leading_comments(path: &Path) -> std::io::Result<usize> {
     let mut count = 0;
     for line in universal_lines(path)? {
         let line = line?;
-        let stripped = line.trim();
+        let stripped = py_strip(&line);
         if stripped.starts_with('#') {
             count += 1;
         } else if stripped.is_empty() {
@@ -190,7 +190,7 @@ pub fn count_leading_physical_lines_before_header(path: &Path) -> std::io::Resul
     let mut count = 0;
     for line in universal_lines(path)? {
         let line = line?;
-        let stripped = line.trim();
+        let stripped = py_strip(&line);
         count += 1;
         if !stripped.is_empty() && !stripped.starts_with('#') {
             break;

--- a/tests/parity/corpus.py
+++ b/tests/parity/corpus.py
@@ -99,4 +99,27 @@ CORPUS: dict[str, bytes] = {
     #     bytes. Both backends must still yield exactly MAX_LINE_CHARS chars —
     #     verifies the fix does not regress clean 4-byte-char giant lines.
     "giant_4byte_chars_no_invalid.csv": ("😀,".encode("utf-8") * 1_800_000 + b"\n"),
+    # C0 information separators FS/GS/RS/US (U+001C-001F) parity (issue #176).
+    # Python str.strip()/str.split() treat these four as whitespace; Rust's
+    # trim()/split_whitespace() (Unicode White_Space) do not. They are the ONLY
+    # such divergence across all of Unicode, so both backends must agree on
+    # comment/blank/strip/split decisions for lines containing them.
+    #
+    # (a) A leading comment whose '#' is preceded by a C0 separator: after
+    #     stripping it IS a comment (count_leading_comments / probe must skip it).
+    "c0_leading_comment.csv": b"\x1c# leading comment\nname,age\nalice,30\n",
+    # (b) A line of only C0 separators between data rows: stripped it is blank,
+    #     so it must not become a sample/data row (probe blankness, ragged).
+    "c0_blank_only_line.csv": b"name,age\n\x1c\x1d\x1e\x1f\nalice,30\n",
+    # (c) A whole file of only C0 separators: the probe must report blank=True
+    #     with no surviving rows (the equivalent BlankFile.is_blank path is
+    #     locked by a Rust unit test, as it is not exposed to _native).
+    "c0_all_whitespace.csv": b"\x1c\x1d\x1e\x1f\n",
+    # (d) Fields separated only by C0 separators: Python's bare split() treats
+    #     them as whitespace runs (3 fields per row), driving space-delimiter
+    #     inference; Rust split_whitespace() must match.
+    "c0_field_separators.csv": b"a\x1cb\x1cc\n1\x1d2\x1d3\nx\x1ey\x1ez\n",
+    # (e) Header with leading/trailing C0 separators: stripping must yield the
+    #     same first_row / sample_rows as Python for both backends.
+    "c0_leading_trailing_strip.csv": b"\x1cname,age\x1d\nalice,30\nbob,25\n",
 }


### PR DESCRIPTION
## Summary

Python's `str.strip()`/`str.split()` treat the C0 information separators **FS/GS/RS/US (U+001C–U+001F)** as whitespace; Rust's `trim()`/`split_whitespace()` (Unicode `White_Space`) do not. Those four code points are the **only** divergence between the two whitespace definitions across all of Unicode (verified exhaustively). So a line like `"\x1c# comment"` was a *comment* to the pure-Python oracle but a *header row* to the Rust `_native` engine — diverging on comment / blank / strip / split decisions.

This is item (1) of #176. Item (2) (sniff-sample line cap) already shipped in #233; this PR closes the issue.

Closes #176

## Fix

Add three helpers to `datagrunt-core/src/io.rs` matching Python's whitespace set, and apply them at the six divergence sites:

- `is_python_whitespace(c)` = `c.is_whitespace() || U+1C..=U+1F`
- `py_strip(s)` ↔ `str.strip()` (no args)
- `py_split_whitespace(s)` ↔ `str.split()` (no args)

| Site | Was | Now |
|------|-----|-----|
| `rows.rs` `probe_csv_header`, `leading_rows`, `count_leading_comments`, `count_leading_physical_lines_before_header` | `.trim()` | `py_strip()` |
| `delimiter.rs` `field_count` (space delimiter) | `.split_whitespace()` | `py_split_whitespace()` |
| `io.rs` `is_blank` | `.trim().is_empty()` | `py_strip().is_empty()` |

**Pure-Rust change** — the Python oracle was already correct, so this is a port-to-match (Python leads, Rust follows). Deliberately **left untouched** (they compare raw fields or a literal character, not whitespace): `row_count`/`check_ragged` (`starts_with('#')` on raw csv fields), `skipinitialspace_for` (literal `"{delim} "`), `normalize.rs` (`strip("_")`), newline `split('\n')`.

## Testing

- **Differential parity (red→green):** five new C0 corpus files in `tests/parity/corpus.py` (comment-after-separator, blank-only-separator line, all-separator file, separator-as-field-delimiter, leading/trailing strip). They produced **17 parity failures before the fix** (e.g. `infer_delimiter` `,`≠` `, `count_leading_comments` `0`≠`1`, `first_row` `\x1c\x1d\x1e\x1f`≠``) and **all pass after**.
- **Rust unit tests** for `is_python_whitespace`/`py_strip`/`py_split_whitespace` and a C0 case added to the `is_blank` probe test (`is_blank` is not exposed to `_native`, so it can't be parity-tested directly).

Gates (all green locally):
- `cd rust && cargo test` — 58 passed
- `uv run pytest tests/ -q` — 1254 passed
- `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` — 1254 passed
- `uv run pytest tests/parity/ -q` — 622 passed
- `ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)