### PR TITLE
feat(pdf): configurable minimum embedded-image size filter (min_image_dimension)

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -33,7 +33,9 @@ def _is_distributed_env() -> bool:
     return any(k in os.environ for k in distributed_keys)
 
 
-def _parse_page_structured_worker(filepath_str: str, page_index: int, image_output_dir: Optional[str]) -> dict:
+def _parse_page_structured_worker(
+    filepath_str: str, page_index: int, image_output_dir: Optional[str], extraction_config=None
+) -> dict:
     """Process worker function to parse a single page using PDFium in structured mode."""
     from pathlib import Path
 
@@ -41,19 +43,25 @@ def _parse_page_structured_worker(filepath_str: str, page_index: int, image_outp
     from datagrunt.core.pdf_io.extraction import PdfiumBackend
 
     filepath = Path(filepath_str)
-    assembler = pdfcomponents.DocumentAssembler(filepath, backend=PdfiumBackend(filepath))
+    assembler = pdfcomponents.DocumentAssembler(
+        filepath,
+        backend=PdfiumBackend(filepath, extraction_config=extraction_config),
+        extraction_config=extraction_config,
+    )
     with assembler.backend, assembler.table_extractor:
         return assembler.parse_page(page_index, image_output_dir)
 
 
-def _parse_page_native_worker(filepath_str: str, page_index: int, image_output_dir: Optional[str]) -> dict:
+def _parse_page_native_worker(
+    filepath_str: str, page_index: int, image_output_dir: Optional[str], extraction_config=None
+) -> dict:
     """Process worker function to parse a single page using PDFium in native mode."""
     from pathlib import Path
 
     from datagrunt.core.pdf_io.extraction import PdfiumNativeReader
 
     filepath = Path(filepath_str)
-    reader = PdfiumNativeReader(filepath)
+    reader = PdfiumNativeReader(filepath, extraction_config=extraction_config)
     with reader:
         return reader.parse_page(page_index, image_output_dir)
 
@@ -237,7 +245,10 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
             pages_map = {}
             with ProcessPoolExecutor(max_workers=self.workers) as executor:
                 futures = {
-                    executor.submit(_parse_page_structured_worker, str(self.filepath), idx, image_output_dir): idx
+                    executor.submit(
+                        _parse_page_structured_worker,
+                        str(self.filepath), idx, image_output_dir, self.extraction_config,
+                    ): idx
                     for idx in range(total_pages)
                 }
                 for future in as_completed(futures):
@@ -285,7 +296,10 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
 
             with ProcessPoolExecutor(max_workers=self.workers) as executor:
                 futures = {
-                    executor.submit(_parse_page_native_worker, str(self.filepath), idx, image_output_dir): idx
+                    executor.submit(
+                        _parse_page_native_worker,
+                        str(self.filepath), idx, image_output_dir, self.extraction_config,
+                    ): idx
                     for idx in range(total_pages)
                 }
                 for future in as_completed(futures):

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -15,6 +15,7 @@ import pyarrow as pa
 # local libraries
 from datagrunt.core.pdf_io import pdfcomponents
 from datagrunt.core.pdf_io.extraction import PdfiumBackend, PdfiumNativeReader, PyMuPDFBackend
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
 
 logger = logging.getLogger(__name__)
@@ -91,15 +92,17 @@ class PDFEngineProperties:
 class PDFBaseReaderEngine(ABC):
     """Abstract base class defining the interface for PDF reader engines."""
 
-    def __init__(self, filepath, workers: int = 1):
+    def __init__(self, filepath, workers: int = 1, extraction_config=None):
         """Initialize the PDF reader engine.
 
         Args:
             filepath (str or Path): Path to the PDF file.
             workers (int): Number of concurrent per-page workers.
+            extraction_config: Optional extraction config; defaults to _PDFExtractionConfig().
         """
         self.filepath = Path(filepath)
         self.workers = workers
+        self.extraction_config = extraction_config or _PDFExtractionConfig()
         if not self.filepath.exists():
             raise FileNotFoundError
         self._parsed_cache = {}
@@ -170,7 +173,7 @@ class PDFReaderPyMuPDFEngine(PDFBaseReaderEngine):
                 "the 'workers=%d' setting is ignored. Use the pdfium engine for parallel parsing.",
                 self.workers,
             )
-        assembler = pdfcomponents.DocumentAssembler(self.filepath)
+        assembler = pdfcomponents.DocumentAssembler(self.filepath, extraction_config=self.extraction_config)
         # Count pages inside the held-open backend context so the count reuses
         # the same pymupdf document handle as the parse — one open per parse
         # (issue #102) with no pdfium dependency for the count (issue #95).
@@ -183,7 +186,7 @@ class PDFReaderPyMuPDFEngine(PDFBaseReaderEngine):
 
     def get_sample(self) -> dict:
         """Parse and return the first page only."""
-        return pdfcomponents.DocumentAssembler(self.filepath).parse_page(0)
+        return pdfcomponents.DocumentAssembler(self.filepath, extraction_config=self.extraction_config).parse_page(0)
 
 
 class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
@@ -198,8 +201,8 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
     process.
     """
 
-    def __init__(self, filepath, workers: int = 1, structured: bool = False):
-        super().__init__(filepath, workers=workers)
+    def __init__(self, filepath, workers: int = 1, structured: bool = False, extraction_config=None):
+        super().__init__(filepath, workers=workers, extraction_config=extraction_config)
         self.structured = structured
 
     def _total_pages(self) -> int:
@@ -217,7 +220,11 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
                     "Distributed environment detected. Defaulting to sequential "
                     "PDFium execution to prevent multiprocessing overhead."
                 )
-            assembler = pdfcomponents.DocumentAssembler(self.filepath, backend=PdfiumBackend(self.filepath))
+            assembler = pdfcomponents.DocumentAssembler(
+                self.filepath,
+                backend=PdfiumBackend(self.filepath, extraction_config=self.extraction_config),
+                extraction_config=self.extraction_config,
+            )
             with assembler.backend, assembler.table_extractor:
                 for idx in range(total_pages):
                     try:
@@ -244,7 +251,11 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
                 if idx in pages_map:
                     pages.append(pages_map[idx])
 
-        assembler = pdfcomponents.DocumentAssembler(self.filepath, backend=PdfiumBackend(self.filepath))
+        assembler = pdfcomponents.DocumentAssembler(
+            self.filepath,
+            backend=PdfiumBackend(self.filepath, extraction_config=self.extraction_config),
+            extraction_config=self.extraction_config,
+        )
         document = assembler.combine(total_pages, pages, errors)
         if drop_layout_tables:
             pdfcomponents.ParsedDocument(document).drop_layout_tables()
@@ -261,7 +272,7 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
                     "Distributed environment detected. Defaulting to sequential "
                     "PDFium execution to prevent multiprocessing overhead."
                 )
-            reader = PdfiumNativeReader(self.filepath)
+            reader = PdfiumNativeReader(self.filepath, extraction_config=self.extraction_config)
             with reader:
                 for idx in range(total_pages):
                     try:
@@ -286,7 +297,7 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
                         errors.append(f"Page {idx + 1}: {e}")
 
         ordered = [page_results[p] for p in sorted(page_results.keys())]
-        reader = PdfiumNativeReader(self.filepath)
+        reader = PdfiumNativeReader(self.filepath, extraction_config=self.extraction_config)
         return reader.combine(total_pages, ordered, errors)
 
     def to_dicts(self, image_output_dir: Optional[str] = None, drop_layout_tables: bool = False) -> dict:
@@ -298,22 +309,28 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
     def get_sample(self) -> dict:
         """Parse and return the first page only."""
         if self.structured:
-            return pdfcomponents.DocumentAssembler(self.filepath, backend=PdfiumBackend(self.filepath)).parse_page(0)
-        return PdfiumNativeReader(self.filepath).parse_page(0)
+            return pdfcomponents.DocumentAssembler(
+                self.filepath,
+                backend=PdfiumBackend(self.filepath, extraction_config=self.extraction_config),
+                extraction_config=self.extraction_config,
+            ).parse_page(0)
+        return PdfiumNativeReader(self.filepath, extraction_config=self.extraction_config).parse_page(0)
 
 
 class PDFBaseWriterEngine(ABC):
     """Abstract base class defining the interface for PDF writer engines."""
 
-    def __init__(self, filepath, workers: int = 1):
+    def __init__(self, filepath, workers: int = 1, extraction_config=None):
         """Initialize the PDF writer engine.
 
         Args:
             filepath (str or Path): Path to the PDF file.
             workers (int): Number of concurrent per-page workers.
+            extraction_config: Optional extraction config; defaults to _PDFExtractionConfig().
         """
         self.filepath = Path(filepath)
         self.workers = workers
+        self.extraction_config = extraction_config or _PDFExtractionConfig()
         self.properties = PDFEngineProperties(filepath=self.filepath)
         if not self.filepath.exists():
             raise FileNotFoundError
@@ -403,18 +420,23 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
 
     def _reader(self):
         if self._reader_engine is None:
-            self._reader_engine = PDFReaderPyMuPDFEngine(self.filepath, workers=self.workers)
+            self._reader_engine = PDFReaderPyMuPDFEngine(
+                self.filepath, workers=self.workers, extraction_config=self.extraction_config
+            )
         return self._reader_engine
 
 
 class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
     """Write parsed PDFium output. Native schema by default; unified when structured."""
 
-    def __init__(self, filepath, workers: int = 1, structured: bool = False):
-        super().__init__(filepath, workers=workers)
+    def __init__(self, filepath, workers: int = 1, structured: bool = False, extraction_config=None):
+        super().__init__(filepath, workers=workers, extraction_config=extraction_config)
         self.structured = structured
 
     def _reader(self):
         if self._reader_engine is None:
-            self._reader_engine = PDFReaderPdfiumEngine(self.filepath, workers=self.workers, structured=self.structured)
+            self._reader_engine = PDFReaderPdfiumEngine(
+                self.filepath, workers=self.workers, structured=self.structured,
+                extraction_config=self.extraction_config,
+            )
         return self._reader_engine

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -247,7 +247,10 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
                 futures = {
                     executor.submit(
                         _parse_page_structured_worker,
-                        str(self.filepath), idx, image_output_dir, self.extraction_config,
+                        str(self.filepath),
+                        idx,
+                        image_output_dir,
+                        self.extraction_config,
                     ): idx
                     for idx in range(total_pages)
                 }
@@ -298,7 +301,10 @@ class PDFReaderPdfiumEngine(PDFBaseReaderEngine):
                 futures = {
                     executor.submit(
                         _parse_page_native_worker,
-                        str(self.filepath), idx, image_output_dir, self.extraction_config,
+                        str(self.filepath),
+                        idx,
+                        image_output_dir,
+                        self.extraction_config,
                     ): idx
                     for idx in range(total_pages)
                 }
@@ -450,7 +456,9 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
     def _reader(self):
         if self._reader_engine is None:
             self._reader_engine = PDFReaderPdfiumEngine(
-                self.filepath, workers=self.workers, structured=self.structured,
+                self.filepath,
+                workers=self.workers,
+                structured=self.structured,
                 extraction_config=self.extraction_config,
             )
         return self._reader_engine

--- a/src/datagrunt/core/pdf_io/extraction/config.py
+++ b/src/datagrunt/core/pdf_io/extraction/config.py
@@ -1,0 +1,35 @@
+"""Private, picklable PDF-extraction tunables threaded to the backends.
+
+Not public API: the leading underscore and absence from every ``__all__`` keep
+``_PDFExtractionConfig`` an internal detail. The public surface is the
+``min_image_dimension`` keyword argument on ``PDFReader``/``PDFWriter``.
+"""
+
+from dataclasses import dataclass
+
+# Single source of truth for the default minimum kept image dimension (px).
+# Images smaller than this on either side are dropped as layout artifacts.
+_DEFAULT_MIN_IMAGE_DIMENSION = 40
+
+
+@dataclass(frozen=True)
+class _PDFExtractionConfig:
+    """Frozen, picklable tunables for PDF extraction.
+
+    Frozen so it is hashable and safe to share, and picklable (primitives only)
+    so it can cross the pdfium process-pool worker boundary unchanged.
+    """
+
+    min_image_dimension: int = _DEFAULT_MIN_IMAGE_DIMENSION
+
+    def __post_init__(self):
+        value = self.min_image_dimension
+        # bool is a subclass of int; reject it explicitly so True/False cannot
+        # masquerade as 1/0.
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(
+                f"min_image_dimension must be an int, got {value!r} "
+                f"({type(value).__name__})"
+            )
+        if value < 0:
+            raise ValueError(f"min_image_dimension must be >= 0, got {value}")

--- a/src/datagrunt/core/pdf_io/extraction/config.py
+++ b/src/datagrunt/core/pdf_io/extraction/config.py
@@ -27,9 +27,6 @@ class _PDFExtractionConfig:
         # bool is a subclass of int; reject it explicitly so True/False cannot
         # masquerade as 1/0.
         if isinstance(value, bool) or not isinstance(value, int):
-            raise TypeError(
-                f"min_image_dimension must be an int, got {value!r} "
-                f"({type(value).__name__})"
-            )
+            raise TypeError(f"min_image_dimension must be an int, got {value!r} ({type(value).__name__})")
         if value < 0:
             raise ValueError(f"min_image_dimension must be >= 0, got {value}")

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
@@ -2,6 +2,7 @@
 
 from datagrunt.core.pdf_io.extraction._doc_session import _ThreadLocalDocSession
 from datagrunt.core.pdf_io.extraction.base import ExtractionBackend
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.ocr import ocr_data_to_blocks
 from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
 from datagrunt.core.pdf_io.extraction.shapes import PageAnalysis
@@ -11,11 +12,12 @@ from datagrunt.core.pdf_io.extraction.text_block_builder import TextBlockBuilder
 class PdfiumBackend(_ThreadLocalDocSession, ExtractionBackend):
     """Extraction via pypdfium2: text objects, images, and pdfium-rendered OCR."""
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, extraction_config=None):
         super().__init__(filepath)
         import threading
 
         self._local = threading.local()
+        self._config = extraction_config or _PDFExtractionConfig()
 
     def _open_resource(self):
         return PdfiumDocument(self.filepath)
@@ -74,7 +76,12 @@ class PdfiumBackend(_ThreadLocalDocSession, ExtractionBackend):
                 images = []
                 if image_objs > 0:
                     images = list(
-                        page.image_items(output_dir=output_dir, name_prefix=name_prefix, page_number=page_number)
+                        page.image_items(
+                            output_dir=output_dir,
+                            name_prefix=name_prefix,
+                            page_number=page_number,
+                            min_image_dimension=self._config.min_image_dimension,
+                        )
                     )
                 return analysis, text_blocks, images
         finally:
@@ -93,11 +100,18 @@ class PdfiumBackend(_ThreadLocalDocSession, ExtractionBackend):
         return TextBlockBuilder().build(items)
 
     def extract_images(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> list:
-        """Return embedded images (>= MIN_IMAGE_DIMENSION); write when output_dir set."""
+        """Return embedded images at or above the configured minimum dimension; write when output_dir set."""
         doc, should_close = self._get_doc()
         try:
             with doc.page(page_number) as page:
-                res = list(page.image_items(output_dir=output_dir, name_prefix=name_prefix, page_number=page_number))
+                res = list(
+                    page.image_items(
+                        output_dir=output_dir,
+                        name_prefix=name_prefix,
+                        page_number=page_number,
+                        min_image_dimension=self._config.min_image_dimension,
+                    )
+                )
         finally:
             if should_close:
                 doc.close()

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
@@ -9,6 +9,7 @@ import ctypes
 import logging
 from pathlib import Path
 
+from datagrunt.core.pdf_io.extraction.config import _DEFAULT_MIN_IMAGE_DIMENSION
 from datagrunt.core.pdf_io.extraction.shapes import BBox, ImageBlock, TextItem
 
 logger = logging.getLogger(__name__)
@@ -19,9 +20,6 @@ PDF_EXTRA_HINT = "PDF parsing requires extra dependencies. Install with: pip ins
 _PDFIUM_PASSWORD_ERROR = "password"
 
 ENCRYPTED_PDF_MESSAGE = "The PDF is encrypted or password-protected and cannot be opened without the correct password."
-
-# Minimum image dimension (px) to keep; smaller images are layout artifacts.
-MIN_IMAGE_DIMENSION = 40
 
 
 def _import_pdfium():
@@ -177,14 +175,21 @@ class PdfiumPage:
                 images += 1
         return texts, images
 
-    def image_items(self, output_dir: str = None, name_prefix: str = "page", page_number: int = 0):
-        """Yield an ``ImageBlock`` per embedded image >= MIN_IMAGE_DIMENSION."""
+    def image_items(
+        self,
+        output_dir: str = None,
+        name_prefix: str = "page",
+        page_number: int = 0,
+        min_image_dimension: int = _DEFAULT_MIN_IMAGE_DIMENSION,
+    ):
+        """Yield an ``ImageBlock`` per embedded image whose pixel sides are both
+        >= ``min_image_dimension``."""
         disp_w, disp_h = self.size()
         rotation = self.rotation()
         idx = 0
         for obj in self._page.get_objects(filter=(self._raw.FPDF_PAGEOBJ_IMAGE,), max_depth=15):
             px_w, px_h = obj.get_px_size()
-            if px_w < MIN_IMAGE_DIMENSION or px_h < MIN_IMAGE_DIMENSION:
+            if px_w < min_image_dimension or px_h < min_image_dimension:
                 continue
             left, bottom, right, top = obj.get_bounds()
             bbox = self._display_box(left, bottom, right, top, rotation, disp_w, disp_h)

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from datagrunt.core.pdf_io.extraction._doc_session import _ThreadLocalDocSession
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.image_dedupe import dedupe_image_files
 from datagrunt.core.pdf_io.extraction.markdown_escape import escape_leading_markdown
 from datagrunt.core.pdf_io.extraction.ocr import dpi_for_page, ocr_data_to_blocks
@@ -13,16 +14,19 @@ from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
 class PdfiumNativeReader(_ThreadLocalDocSession):
     """Parse pages into the native pdfium schema and assemble documents."""
 
-    def __init__(self, filepath):
-        """Store the path.
+    def __init__(self, filepath, extraction_config=None):
+        """Store the path and extraction config.
 
         Args:
             filepath (str or Path): Path to the PDF file.
+            extraction_config (_PDFExtractionConfig, optional): Tunables; defaults
+                to ``_PDFExtractionConfig()``.
         """
         self.filepath = Path(filepath)
         import threading
 
         self._local = threading.local()
+        self._config = extraction_config or _PDFExtractionConfig()
 
     def _open_resource(self):
         return PdfiumDocument(self.filepath)
@@ -38,7 +42,10 @@ class PdfiumNativeReader(_ThreadLocalDocSession):
                 images = [
                     self._image(img)
                     for img in page.image_items(
-                        output_dir=image_output_dir, name_prefix=Path(self.filepath).stem, page_number=page_index
+                        output_dir=image_output_dir,
+                        name_prefix=Path(self.filepath).stem,
+                        page_number=page_index,
+                        min_image_dimension=self._config.min_image_dimension,
                     )
                 ]
                 ocr_used = False

--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -4,6 +4,7 @@ import logging
 
 from datagrunt.core.pdf_io.extraction._doc_session import _ThreadLocalDocSession
 from datagrunt.core.pdf_io.extraction.base import ExtractionBackend
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.ocr import ocr_data_to_blocks
 from datagrunt.core.pdf_io.extraction.pdfium_document import ENCRYPTED_PDF_MESSAGE
 from datagrunt.core.pdf_io.extraction.shapes import BBox, ImageBlock, PageAnalysis, TextBlock
@@ -24,11 +25,12 @@ def _import_pymupdf():
 class PyMuPDFBackend(_ThreadLocalDocSession, ExtractionBackend):
     """Extraction via PyMuPDF (text/dict spans, images) + Tesseract OCR."""
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, extraction_config=None):
         super().__init__(filepath)
         import threading
 
         self._local = threading.local()
+        self._config = extraction_config or _PDFExtractionConfig()
 
     def _open_doc(self):
         """Open the document, translating the encrypted case to a clear error.
@@ -264,7 +266,7 @@ class PyMuPDFBackend(_ThreadLocalDocSession, ExtractionBackend):
         )
 
     def _image_block(self, doc, img_info, idx, bbox, output_dir, name_prefix, page_number):
-        """Extract one image to an ImageBlock (or None to skip), <40px filtered.
+        """Extract one image to an ImageBlock (or None to skip), images below the configured minimum are filtered.
 
         ``bbox`` is the already-resolved (by xref) position for this image.
         """
@@ -275,7 +277,8 @@ class PyMuPDFBackend(_ThreadLocalDocSession, ExtractionBackend):
         ext = base_image.get("ext", "png")
         width, height = base_image.get("width", 0), base_image.get("height", 0)
         image_bytes = base_image.get("image", b"")
-        if not image_bytes or width < 40 or height < 40:
+        minimum = self._config.min_image_dimension
+        if not image_bytes or width < minimum or height < minimum:
             return None
 
         # Convert non-web-friendly formats to PNG using Pixmap

--- a/src/datagrunt/core/pdf_io/factories.py
+++ b/src/datagrunt/core/pdf_io/factories.py
@@ -57,7 +57,9 @@ class PDFEngineFactory:
         if engine_class:
             if self.engine == "pdfium":
                 return engine_class(
-                    self.filepath, workers=self.workers, structured=self.structured,
+                    self.filepath,
+                    workers=self.workers,
+                    structured=self.structured,
                     extraction_config=self.extraction_config,
                 )
             return engine_class(self.filepath, workers=self.workers, extraction_config=self.extraction_config)
@@ -69,7 +71,9 @@ class PDFEngineFactory:
         if engine_class:
             if self.engine == "pdfium":
                 return engine_class(
-                    self.filepath, workers=self.workers, structured=self.structured,
+                    self.filepath,
+                    workers=self.workers,
+                    structured=self.structured,
                     extraction_config=self.extraction_config,
                 )
             return engine_class(self.filepath, workers=self.workers, extraction_config=self.extraction_config)

--- a/src/datagrunt/core/pdf_io/factories.py
+++ b/src/datagrunt/core/pdf_io/factories.py
@@ -26,18 +26,21 @@ class PDFEngineFactory:
         "pdfium": PDFWriterPdfiumEngine,
     }
 
-    def __init__(self, filepath, engine, workers: int = 1, structured: bool = False):
+    def __init__(self, filepath, engine, workers: int = 1, structured: bool = False, extraction_config=None):
         """Initialize the PDF Engine Factory class.
 
         Args:
             filepath (str or Path): Path to the PDF file.
             engine (str): Engine type to create.
             workers (int): Number of concurrent per-page workers.
+            structured (bool): Emit unified element schema when True (pdfium only).
+            extraction_config: Optional extraction config forwarded to the created engine.
         """
         self.filepath = Path(filepath)
         self.engine = engine.lower().replace(" ", "")
         self.workers = workers
         self.structured = structured
+        self.extraction_config = extraction_config
         if not self.filepath.exists():
             raise FileNotFoundError
         if self.engine not in PDFEngineProperties.valid_engines:
@@ -53,8 +56,11 @@ class PDFEngineFactory:
         engine_class = self.READER_ENGINES.get(self.engine)
         if engine_class:
             if self.engine == "pdfium":
-                return engine_class(self.filepath, workers=self.workers, structured=self.structured)
-            return engine_class(self.filepath, workers=self.workers)
+                return engine_class(
+                    self.filepath, workers=self.workers, structured=self.structured,
+                    extraction_config=self.extraction_config,
+                )
+            return engine_class(self.filepath, workers=self.workers, extraction_config=self.extraction_config)
         raise ValueError(f"Unsupported reader engine: {self.engine}")
 
     def create_writer(self):
@@ -62,6 +68,9 @@ class PDFEngineFactory:
         engine_class = self.WRITER_ENGINES.get(self.engine)
         if engine_class:
             if self.engine == "pdfium":
-                return engine_class(self.filepath, workers=self.workers, structured=self.structured)
-            return engine_class(self.filepath, workers=self.workers)
+                return engine_class(
+                    self.filepath, workers=self.workers, structured=self.structured,
+                    extraction_config=self.extraction_config,
+                )
+            return engine_class(self.filepath, workers=self.workers, extraction_config=self.extraction_config)
         raise ValueError(f"Unsupported writer engine: {self.engine}")

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -10,6 +10,7 @@ from pathlib import Path
 # local libraries
 from datagrunt.core.file_io import FileProperties
 from datagrunt.core.pdf_io.extraction import PdfPlumberTableExtractor
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.image_dedupe import dedupe_image_files
 from datagrunt.core.pdf_io.extraction.layout_sorter import ElementAdapter, PageLayoutSorter
 from datagrunt.core.pdf_io.extraction.markdown_escape import (
@@ -32,16 +33,19 @@ class DocumentAssembler:
     unified element dicts.
     """
 
-    def __init__(self, filepath, backend=None, table_extractor=None):
+    def __init__(self, filepath, backend=None, table_extractor=None, extraction_config=None):
         """Initialize the assembler.
 
         Args:
             filepath (str or Path): Path to the PDF file.
             backend (ExtractionBackend, optional): Defaults to PyMuPDFBackend.
             table_extractor (PdfPlumberTableExtractor, optional): Shared table source.
+            extraction_config (_PDFExtractionConfig, optional): Tunables passed to
+                the default backend; defaults to ``_PDFExtractionConfig()``.
         """
         self.filepath = Path(filepath)
-        self.backend = backend or PyMuPDFBackend(filepath)
+        self._extraction_config = extraction_config or _PDFExtractionConfig()
+        self.backend = backend or PyMuPDFBackend(filepath, extraction_config=self._extraction_config)
         self.table_extractor = table_extractor or PdfPlumberTableExtractor(filepath)
 
     def parse_page(self, page_index, image_output_dir=None) -> dict:

--- a/src/datagrunt/pdf_api/_engine_backed.py
+++ b/src/datagrunt/pdf_api/_engine_backed.py
@@ -43,11 +43,7 @@ class _PDFEngineBacked(PDFComponents):
         self.engine = engine.lower().replace(" ", "")
         self.workers = workers
         self.native = native
-        overrides = {
-            k: v
-            for k, v in {"min_image_dimension": min_image_dimension}.items()
-            if v is not None
-        }
+        overrides = {k: v for k, v in {"min_image_dimension": min_image_dimension}.items() if v is not None}
         # Validates immediately (fail-fast at construction).
         self._extraction_config = _PDFExtractionConfig(**overrides)
 
@@ -60,8 +56,11 @@ class _PDFEngineBacked(PDFComponents):
         Released when this object goes out of scope.
         """
         factory = PDFEngineFactory(
-            self.filepath, self.engine, self.workers,
-            structured=not self.native, extraction_config=self._extraction_config,
+            self.filepath,
+            self.engine,
+            self.workers,
+            structured=not self.native,
+            extraction_config=self._extraction_config,
         )
         if self._engine_role == "reader":
             return factory.create_reader()

--- a/src/datagrunt/pdf_api/_engine_backed.py
+++ b/src/datagrunt/pdf_api/_engine_backed.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from pathlib import Path
 
 from datagrunt.core import PDFComponents, PDFEngineFactory
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 
 
 class _PDFEngineBacked(PDFComponents):
@@ -18,7 +19,7 @@ class _PDFEngineBacked(PDFComponents):
 
     _engine_role = None  # "reader" or "writer"
 
-    def __init__(self, filepath, engine="pdfium", workers=1, native=False):
+    def __init__(self, filepath, engine="pdfium", workers=1, native=False, *, min_image_dimension=None):
         """Initialize a PDF reader/writer.
 
         Args:
@@ -32,6 +33,9 @@ class _PDFEngineBacked(PDFComponents):
             native (bool, default False): pdfium only -- when True, emit the lean
                 native schema instead of the unified element schema. Ignored by
                 the pymupdf engine.
+            min_image_dimension (int, optional, keyword-only): Minimum embedded-image
+                pixel size (either side) to keep; smaller images are dropped as
+                layout artifacts. Defaults to 40. Use 0 to keep every image.
         """
         if not isinstance(filepath, dict):
             filepath = Path(filepath)
@@ -39,6 +43,13 @@ class _PDFEngineBacked(PDFComponents):
         self.engine = engine.lower().replace(" ", "")
         self.workers = workers
         self.native = native
+        overrides = {
+            k: v
+            for k, v in {"min_image_dimension": min_image_dimension}.items()
+            if v is not None
+        }
+        # Validates immediately (fail-fast at construction).
+        self._extraction_config = _PDFExtractionConfig(**overrides)
 
     @cached_property
     def _engine(self):
@@ -48,7 +59,10 @@ class _PDFEngineBacked(PDFComponents):
         memoizes internally) instead of re-parsing the PDF on every call.
         Released when this object goes out of scope.
         """
-        factory = PDFEngineFactory(self.filepath, self.engine, self.workers, structured=not self.native)
+        factory = PDFEngineFactory(
+            self.filepath, self.engine, self.workers,
+            structured=not self.native, extraction_config=self._extraction_config,
+        )
         if self._engine_role == "reader":
             return factory.create_reader()
         if self._engine_role == "writer":

--- a/src/datagrunt/pdf_api/pdfreader.py
+++ b/src/datagrunt/pdf_api/pdfreader.py
@@ -10,7 +10,11 @@ from datagrunt.pdf_api._engine_backed import _PDFEngineBacked
 
 
 class PDFReader(_PDFEngineBacked):
-    """Class to unify the interface for reading and parsing PDF files."""
+    """Class to unify the interface for reading and parsing PDF files.
+
+    Pass ``min_image_dimension`` (keyword-only) to control the minimum embedded
+    image pixel size kept during extraction (default 40; 0 keeps everything).
+    """
 
     _engine_role = "reader"
 

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -9,7 +9,11 @@ from datagrunt.pdf_api._engine_backed import _PDFEngineBacked
 
 
 class PDFWriter(_PDFEngineBacked):
-    """Class to unify the interface for writing parsed PDF output."""
+    """Class to unify the interface for writing parsed PDF output.
+
+    Pass ``min_image_dimension`` (keyword-only) to control the minimum embedded
+    image pixel size kept during extraction (default 40; 0 keeps everything).
+    """
 
     _engine_role = "writer"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,6 +269,23 @@ def small_image_pdf(tmp_path):
 
 
 @pytest.fixture
+def multipage_small_image_pdf(tmp_path):
+    """Create a 2-page PDF; each page's only image is below the 40px threshold."""
+    import pymupdf
+
+    doc = pymupdf.open()
+    for _ in range(2):
+        page = doc.new_page(width=612, height=792)
+        pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 20, 20))
+        pix.set_rect(pix.irect, (0, 0, 255))
+        page.insert_image(pymupdf.Rect(72, 72, 92, 92), stream=pix.tobytes("png"))
+    pdf_path = tmp_path / "multipage_small_image.pdf"
+    doc.save(str(pdf_path))
+    doc.close()
+    return str(pdf_path)
+
+
+@pytest.fixture
 def tesseract_available():
     """Return True if the tesseract system binary is on PATH."""
     return shutil.which("tesseract") is not None

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_extraction_config.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_extraction_config.py
@@ -1,0 +1,43 @@
+"""Tests for the private _PDFExtractionConfig extraction tunables."""
+
+import pickle
+
+import pytest
+
+from datagrunt.core.pdf_io.extraction.config import (
+    _DEFAULT_MIN_IMAGE_DIMENSION,
+    _PDFExtractionConfig,
+)
+
+
+class TestPDFExtractionConfig:
+    def test_default_matches_legacy_constant(self):
+        assert _DEFAULT_MIN_IMAGE_DIMENSION == 40
+        assert _PDFExtractionConfig().min_image_dimension == 40
+
+    def test_accepts_custom_value(self):
+        assert _PDFExtractionConfig(min_image_dimension=15).min_image_dimension == 15
+
+    def test_zero_is_allowed_disables_filter(self):
+        assert _PDFExtractionConfig(min_image_dimension=0).min_image_dimension == 0
+
+    def test_negative_raises_value_error(self):
+        with pytest.raises(ValueError):
+            _PDFExtractionConfig(min_image_dimension=-1)
+
+    def test_float_raises_type_error(self):
+        with pytest.raises(TypeError):
+            _PDFExtractionConfig(min_image_dimension=12.5)
+
+    def test_bool_raises_type_error(self):
+        with pytest.raises(TypeError):
+            _PDFExtractionConfig(min_image_dimension=True)
+
+    def test_is_frozen(self):
+        cfg = _PDFExtractionConfig()
+        with pytest.raises(Exception):
+            cfg.min_image_dimension = 99  # frozen → FrozenInstanceError
+
+    def test_is_picklable_and_round_trips(self):
+        cfg = _PDFExtractionConfig(min_image_dimension=15)
+        assert pickle.loads(pickle.dumps(cfg)) == cfg

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_backend.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_backend.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.pdfium_backend import PdfiumBackend
 from datagrunt.core.pdf_io.extraction.shapes import ImageBlock, OcrBlock, PageAnalysis, TextBlock
 
@@ -63,3 +64,22 @@ class TestPdfiumBackend:
             backend.extract_page(0)
 
         assert count["n"] == 1
+
+
+class TestPdfiumBackendImageConfig:
+    def test_default_drops_small_image(self, small_image_pdf):
+        assert PdfiumBackend(small_image_pdf).extract_images(0) == []
+
+    def test_lowered_threshold_keeps_small_image(self, small_image_pdf):
+        backend = PdfiumBackend(small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10))
+        assert len(backend.extract_images(0)) == 1
+
+    def test_raised_threshold_drops_large_image(self, sample_pdf):
+        backend = PdfiumBackend(sample_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=150))
+        assert backend.extract_images(0) == []
+
+    def test_extract_page_honors_config(self, small_image_pdf):
+        backend = PdfiumBackend(small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10))
+        with backend:
+            _analysis, _text, images = backend.extract_page(0)
+        assert len(images) == 1

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_document.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_document.py
@@ -95,6 +95,24 @@ class TestRotatedPageCoordinates:
             assert 0 <= box.x and box.x + box.w <= page_width, f"image x span out of [0,{page_width}] (rot {rotation})"
 
 
+def test_image_items_threshold_keeps_small_image_when_lowered(small_image_pdf):
+    """small_image_pdf holds a 20px image: dropped at default 40, kept at 10."""
+    with PdfiumDocument(small_image_pdf) as doc:
+        with doc.page(0) as page:
+            assert len(list(page.image_items())) == 0
+        with doc.page(0) as page:
+            assert len(list(page.image_items(min_image_dimension=10))) == 1
+
+
+def test_image_items_threshold_drops_large_image_when_raised(sample_pdf):
+    """sample_pdf holds a 100px image: kept at default 40, dropped at 150."""
+    with PdfiumDocument(sample_pdf) as doc:
+        with doc.page(0) as page:
+            assert len(list(page.image_items())) == 1
+        with doc.page(0) as page:
+            assert len(list(page.image_items(min_image_dimension=150))) == 0
+
+
 class TestUnrotatedCoordinatesRegressionGuard:
     """Lock the rotation-0 coordinates so the rotation fix can't drift them.
 

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
@@ -1,5 +1,6 @@
 """Tests for PdfiumNativeReader (native pdfium schema)."""
 
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.pdfium_native import PdfiumNativeReader
 
 
@@ -86,3 +87,14 @@ class TestPdfiumNativeReader:
         assert "\\# rm -rf is not a heading" in md
         assert "\\- not a list" in md
         assert not md.lstrip().startswith("# ")
+
+
+def test_native_default_drops_small_image(small_image_pdf):
+    page = PdfiumNativeReader(small_image_pdf).parse_page(0)
+    assert page["images"] == []
+
+
+def test_native_lowered_threshold_keeps_small_image(small_image_pdf):
+    reader = PdfiumNativeReader(small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10))
+    page = reader.parse_page(0)
+    assert len(page["images"]) == 1

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pymupdf_backend.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pymupdf_backend.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
 from datagrunt.core.pdf_io.extraction.shapes import ImageBlock, PageAnalysis, TextBlock
 
@@ -88,6 +89,25 @@ class TestPyMuPDFBackend:
         assert (round(blue.bbox.x, 1), round(blue.bbox.y, 1)) == blue_corner
         assert (round(green.bbox.x, 1), round(green.bbox.y, 1)) == green_corner
         assert all(im.bbox.w > 0 and im.bbox.h > 0 for im in images)
+
+
+class TestPyMuPDFBackendImageConfig:
+    def test_default_drops_small_image(self, small_image_pdf):
+        with PyMuPDFBackend(small_image_pdf) as backend:
+            _analysis, _text, images = backend.extract_page(0)
+        assert images == []
+
+    def test_lowered_threshold_keeps_small_image(self, small_image_pdf):
+        backend = PyMuPDFBackend(small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10))
+        with backend:
+            _analysis, _text, images = backend.extract_page(0)
+        assert len(images) == 1
+
+    def test_raised_threshold_drops_large_image(self, sample_pdf):
+        backend = PyMuPDFBackend(sample_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=150))
+        with backend:
+            _analysis, _text, images = backend.extract_page(0)
+        assert images == []
 
 
 def test_pymupdf_extract_page_matches_primitives(sample_pdf):

--- a/tests/core_tests/pdf_io_tests/test_engines.py
+++ b/tests/core_tests/pdf_io_tests/test_engines.py
@@ -446,6 +446,49 @@ class TestPDFWriterPdfiumStructured:
         assert all(os.path.isfile(p) for p in paths)
 
 
+class TestExtractionConfigThreaded:
+    """extraction_config is forwarded through engines and their sequential paths."""
+
+    def _image_count(self, doc):
+        return sum(
+            1
+            for page in doc["document"]["pages"]
+            for e in page.get("elements", [])
+            if e.get("type") == "image"
+        )
+
+    def test_pymupdf_engine_threads_config(self, small_image_pdf):
+        from datagrunt.core.pdf_io.engines import PDFReaderPyMuPDFEngine
+        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
+
+        eng = PDFReaderPyMuPDFEngine(
+            small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10)
+        )
+        assert self._image_count(eng.to_dicts()) == 1
+
+    def test_pdfium_structured_engine_threads_config(self, small_image_pdf):
+        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
+        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
+
+        eng = PDFReaderPdfiumEngine(
+            small_image_pdf, workers=1, structured=True,
+            extraction_config=_PDFExtractionConfig(min_image_dimension=10),
+        )
+        assert self._image_count(eng.to_dicts()) == 1
+
+    def test_pdfium_native_engine_threads_config(self, small_image_pdf):
+        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
+        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
+
+        eng = PDFReaderPdfiumEngine(
+            small_image_pdf, workers=1, structured=False,
+            extraction_config=_PDFExtractionConfig(min_image_dimension=10),
+        )
+        doc = eng.to_dicts()
+        images = [img for p in doc["document"]["pages"] for img in p["images"]]
+        assert len(images) == 1
+
+
 class TestPDFReaderParseSharedAcrossConversions:
     """to_dataframe + to_arrow_table on one reader must parse the PDF once."""
 

--- a/tests/core_tests/pdf_io_tests/test_engines.py
+++ b/tests/core_tests/pdf_io_tests/test_engines.py
@@ -462,9 +462,6 @@ class TestProcessPoolThreadsConfig:
 
     def test_pdfium_structured_process_pool_threads_config(self, multipage_small_image_pdf):
         """workers>1 uses the process pool; the frozen config must survive pickling."""
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
-
         eng = PDFReaderPdfiumEngine(
             multipage_small_image_pdf, workers=2, structured=True,
             extraction_config=_PDFExtractionConfig(min_image_dimension=10),

--- a/tests/core_tests/pdf_io_tests/test_engines.py
+++ b/tests/core_tests/pdf_io_tests/test_engines.py
@@ -9,10 +9,23 @@ import pytest
 
 from datagrunt.core.pdf_io.engines import (
     PDFEngineProperties,
+    PDFReaderPdfiumEngine,
     PDFReaderPyMuPDFEngine,
+    PDFWriterPdfiumEngine,
     PDFWriterPyMuPDFEngine,
     set_export_filename,
 )
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
+
+
+def _image_count(doc):
+    """Count image elements in the unified document schema."""
+    return sum(
+        1
+        for page in doc["document"]["pages"]
+        for e in page.get("elements", [])
+        if e.get("type") == "image"
+    )
 
 
 class TestSetExportFilename:
@@ -304,8 +317,6 @@ class TestPDFReaderPdfiumEngine:
     """Test suite for the PDFium reader engine."""
 
     def test_to_dicts_native_schema(self, sample_pdf):
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-
         doc = PDFReaderPdfiumEngine(sample_pdf).to_dicts()
         assert doc["document"]["page_count"] == 1
         page = doc["document"]["pages"][0]
@@ -321,15 +332,11 @@ class TestPDFReaderPdfiumEngine:
         assert "Quarterly Report" in page["text"]
 
     def test_get_sample_returns_first_page(self, sample_pdf):
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-
         page = PDFReaderPdfiumEngine(sample_pdf).get_sample()
         assert page["page_number"] == 1
 
     def test_to_dataframe_has_rows(self, sample_pdf):
         import polars as pl
-
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
 
         df = PDFReaderPdfiumEngine(sample_pdf).to_dataframe()
         assert isinstance(df, pl.DataFrame)
@@ -339,21 +346,15 @@ class TestPDFReaderPdfiumEngine:
     def test_to_arrow_table_has_rows(self, sample_pdf):
         import pyarrow as pa
 
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-
         table = PDFReaderPdfiumEngine(sample_pdf).to_arrow_table()
         assert isinstance(table, pa.Table)
         assert table.num_rows > 0
 
     def test_missing_file_raises(self):
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-
         with pytest.raises(FileNotFoundError):
             PDFReaderPdfiumEngine("nope.pdf")
 
     def test_to_dicts_multipage_ordered(self, multipage_pdf):
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-
         doc = PDFReaderPdfiumEngine(multipage_pdf).to_dicts()
         pages = doc["document"]["pages"]
         assert doc["document"]["page_count"] == 3
@@ -368,8 +369,6 @@ class TestPDFWriterPdfiumEngine:
     def test_write_json(self, sample_pdf, tmp_path):
         import json
 
-        from datagrunt.core.pdf_io.engines import PDFWriterPdfiumEngine
-
         out = tmp_path / "doc.json"
         result = PDFWriterPdfiumEngine(sample_pdf).write_json(export_filename=str(out))
         assert result == str(out)
@@ -377,8 +376,6 @@ class TestPDFWriterPdfiumEngine:
         assert data["document"]["page_count"] == 1
 
     def test_write_json_newline_delimited(self, sample_pdf, tmp_path):
-        from datagrunt.core.pdf_io.engines import PDFWriterPdfiumEngine
-
         out = tmp_path / "doc.jsonl"
         result = PDFWriterPdfiumEngine(sample_pdf).write_json_newline_delimited(export_filename=str(out))
         assert result == str(out)
@@ -387,8 +384,6 @@ class TestPDFWriterPdfiumEngine:
 
     def test_extract_images_returns_paths(self, sample_pdf, tmp_path):
         import os
-
-        from datagrunt.core.pdf_io.engines import PDFWriterPdfiumEngine
 
         out = tmp_path / "imgs"
         paths = PDFWriterPdfiumEngine(sample_pdf).extract_images(output_dir=str(out))
@@ -400,23 +395,17 @@ class TestPDFReaderPdfiumStructured:
     """pdfium engine in structured mode emits the unified element schema."""
 
     def test_structured_to_dicts_unified_schema(self, sample_pdf):
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-
         doc = PDFReaderPdfiumEngine(sample_pdf, structured=True).to_dicts()
         assert "total_pages" in doc["document"]  # unified envelope key
         page = doc["document"]["pages"][0]
         assert set(page.keys()) == {"page_number", "width", "height", "classification", "elements"}
 
     def test_default_is_native_schema(self, sample_pdf):
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-
         page = PDFReaderPdfiumEngine(sample_pdf).to_dicts()["document"]["pages"][0]
         assert "text_objects" in page  # native schema unchanged when structured=False
 
     def test_structured_dataframe(self, sample_pdf):
         import polars as pl
-
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
 
         df = PDFReaderPdfiumEngine(sample_pdf, structured=True).to_dataframe()
         assert isinstance(df, pl.DataFrame)
@@ -428,8 +417,6 @@ class TestPDFWriterPdfiumStructured:
     def test_structured_write_json_unified(self, sample_pdf, tmp_path):
         import json
 
-        from datagrunt.core.pdf_io.engines import PDFWriterPdfiumEngine
-
         out = tmp_path / "doc.json"
         PDFWriterPdfiumEngine(sample_pdf, structured=True).write_json(export_filename=str(out))
         data = json.loads(out.read_text())
@@ -439,8 +426,6 @@ class TestPDFWriterPdfiumStructured:
     def test_structured_extract_images(self, sample_pdf, tmp_path):
         import os
 
-        from datagrunt.core.pdf_io.engines import PDFWriterPdfiumEngine
-
         paths = PDFWriterPdfiumEngine(sample_pdf, structured=True).extract_images(output_dir=str(tmp_path))
         assert len(paths) >= 1
         assert all(os.path.isfile(p) for p in paths)
@@ -449,37 +434,20 @@ class TestPDFWriterPdfiumStructured:
 class TestExtractionConfigThreaded:
     """extraction_config is forwarded through engines and their sequential paths."""
 
-    def _image_count(self, doc):
-        return sum(
-            1
-            for page in doc["document"]["pages"]
-            for e in page.get("elements", [])
-            if e.get("type") == "image"
-        )
-
     def test_pymupdf_engine_threads_config(self, small_image_pdf):
-        from datagrunt.core.pdf_io.engines import PDFReaderPyMuPDFEngine
-        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
-
         eng = PDFReaderPyMuPDFEngine(
             small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10)
         )
-        assert self._image_count(eng.to_dicts()) == 1
+        assert _image_count(eng.to_dicts()) == 1
 
     def test_pdfium_structured_engine_threads_config(self, small_image_pdf):
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
-
         eng = PDFReaderPdfiumEngine(
             small_image_pdf, workers=1, structured=True,
             extraction_config=_PDFExtractionConfig(min_image_dimension=10),
         )
-        assert self._image_count(eng.to_dicts()) == 1
+        assert _image_count(eng.to_dicts()) == 1
 
     def test_pdfium_native_engine_threads_config(self, small_image_pdf):
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
-
         eng = PDFReaderPdfiumEngine(
             small_image_pdf, workers=1, structured=False,
             extraction_config=_PDFExtractionConfig(min_image_dimension=10),
@@ -487,16 +455,6 @@ class TestExtractionConfigThreaded:
         doc = eng.to_dicts()
         images = [img for p in doc["document"]["pages"] for img in p["images"]]
         assert len(images) == 1
-
-
-def _image_count(doc):
-    """Count image elements in the unified document schema."""
-    return sum(
-        1
-        for page in doc["document"]["pages"]
-        for e in page.get("elements", [])
-        if e.get("type") == "image"
-    )
 
 
 class TestProcessPoolThreadsConfig:
@@ -514,14 +472,13 @@ class TestProcessPoolThreadsConfig:
         assert _image_count(eng.to_dicts()) == 2  # both pages' 20px images kept
 
     def test_pdfium_native_process_pool_threads_config(self, multipage_small_image_pdf):
-        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
-        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
-
+        """workers>1 native path: the frozen config must survive pickling into the child."""
         eng = PDFReaderPdfiumEngine(
             multipage_small_image_pdf, workers=2, structured=False,
             extraction_config=_PDFExtractionConfig(min_image_dimension=10),
         )
         doc = eng.to_dicts()
+        # native schema exposes images under p["images"], not the unified "elements" list
         images = [img for p in doc["document"]["pages"] for img in p["images"]]
         assert len(images) == 2
 

--- a/tests/core_tests/pdf_io_tests/test_engines.py
+++ b/tests/core_tests/pdf_io_tests/test_engines.py
@@ -20,12 +20,7 @@ from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 
 def _image_count(doc):
     """Count image elements in the unified document schema."""
-    return sum(
-        1
-        for page in doc["document"]["pages"]
-        for e in page.get("elements", [])
-        if e.get("type") == "image"
-    )
+    return sum(1 for page in doc["document"]["pages"] for e in page.get("elements", []) if e.get("type") == "image")
 
 
 class TestSetExportFilename:
@@ -435,21 +430,23 @@ class TestExtractionConfigThreaded:
     """extraction_config is forwarded through engines and their sequential paths."""
 
     def test_pymupdf_engine_threads_config(self, small_image_pdf):
-        eng = PDFReaderPyMuPDFEngine(
-            small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10)
-        )
+        eng = PDFReaderPyMuPDFEngine(small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10))
         assert _image_count(eng.to_dicts()) == 1
 
     def test_pdfium_structured_engine_threads_config(self, small_image_pdf):
         eng = PDFReaderPdfiumEngine(
-            small_image_pdf, workers=1, structured=True,
+            small_image_pdf,
+            workers=1,
+            structured=True,
             extraction_config=_PDFExtractionConfig(min_image_dimension=10),
         )
         assert _image_count(eng.to_dicts()) == 1
 
     def test_pdfium_native_engine_threads_config(self, small_image_pdf):
         eng = PDFReaderPdfiumEngine(
-            small_image_pdf, workers=1, structured=False,
+            small_image_pdf,
+            workers=1,
+            structured=False,
             extraction_config=_PDFExtractionConfig(min_image_dimension=10),
         )
         doc = eng.to_dicts()
@@ -463,7 +460,9 @@ class TestProcessPoolThreadsConfig:
     def test_pdfium_structured_process_pool_threads_config(self, multipage_small_image_pdf):
         """workers>1 uses the process pool; the frozen config must survive pickling."""
         eng = PDFReaderPdfiumEngine(
-            multipage_small_image_pdf, workers=2, structured=True,
+            multipage_small_image_pdf,
+            workers=2,
+            structured=True,
             extraction_config=_PDFExtractionConfig(min_image_dimension=10),
         )
         assert _image_count(eng.to_dicts()) == 2  # both pages' 20px images kept
@@ -471,7 +470,9 @@ class TestProcessPoolThreadsConfig:
     def test_pdfium_native_process_pool_threads_config(self, multipage_small_image_pdf):
         """workers>1 native path: the frozen config must survive pickling into the child."""
         eng = PDFReaderPdfiumEngine(
-            multipage_small_image_pdf, workers=2, structured=False,
+            multipage_small_image_pdf,
+            workers=2,
+            structured=False,
             extraction_config=_PDFExtractionConfig(min_image_dimension=10),
         )
         doc = eng.to_dicts()

--- a/tests/core_tests/pdf_io_tests/test_engines.py
+++ b/tests/core_tests/pdf_io_tests/test_engines.py
@@ -489,6 +489,43 @@ class TestExtractionConfigThreaded:
         assert len(images) == 1
 
 
+def _image_count(doc):
+    """Count image elements in the unified document schema."""
+    return sum(
+        1
+        for page in doc["document"]["pages"]
+        for e in page.get("elements", [])
+        if e.get("type") == "image"
+    )
+
+
+class TestProcessPoolThreadsConfig:
+    """workers>1 uses a ProcessPoolExecutor; the frozen config must survive pickling."""
+
+    def test_pdfium_structured_process_pool_threads_config(self, multipage_small_image_pdf):
+        """workers>1 uses the process pool; the frozen config must survive pickling."""
+        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
+        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
+
+        eng = PDFReaderPdfiumEngine(
+            multipage_small_image_pdf, workers=2, structured=True,
+            extraction_config=_PDFExtractionConfig(min_image_dimension=10),
+        )
+        assert _image_count(eng.to_dicts()) == 2  # both pages' 20px images kept
+
+    def test_pdfium_native_process_pool_threads_config(self, multipage_small_image_pdf):
+        from datagrunt.core.pdf_io.engines import PDFReaderPdfiumEngine
+        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
+
+        eng = PDFReaderPdfiumEngine(
+            multipage_small_image_pdf, workers=2, structured=False,
+            extraction_config=_PDFExtractionConfig(min_image_dimension=10),
+        )
+        doc = eng.to_dicts()
+        images = [img for p in doc["document"]["pages"] for img in p["images"]]
+        assert len(images) == 2
+
+
 class TestPDFReaderParseSharedAcrossConversions:
     """to_dataframe + to_arrow_table on one reader must parse the PDF once."""
 

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -352,6 +352,27 @@ class TestDropLayoutTables:
         assert len(document["document"]["pages"][0]["elements"]) == 1
 
 
+class TestDocumentAssemblerConfig:
+    """DocumentAssembler accepts extraction_config and threads it through."""
+
+    def test_assembler_default_backend_receives_config(self, small_image_pdf):
+        """The default (pymupdf) backend honors a lowered threshold via the assembler."""
+        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
+
+        assembler = pdfcomponents.DocumentAssembler(
+            small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10)
+        )
+        page = assembler.parse_page(0)
+        image_elems = [e for e in page["elements"] if e.get("type") == "image"]
+        assert len(image_elems) == 1
+
+    def test_assembler_default_drops_small_image(self, small_image_pdf):
+        """Default config (40px) drops the 20px test image."""
+        page = pdfcomponents.DocumentAssembler(small_image_pdf).parse_page(0)
+        image_elems = [e for e in page["elements"] if e.get("type") == "image"]
+        assert image_elems == []
+
+
 class TestParsePageBackend:
     """DocumentAssembler.parse_page consumes an ExtractionBackend + table extractor."""
 

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -7,6 +7,7 @@ import pytest
 
 from datagrunt.core.file_io import FileProperties
 from datagrunt.core.pdf_io import pdfcomponents
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 
 # The public FileProperties surface that virtual-mode (JSON/dict) PDFComponents
 # must mirror. The cached_property flags are discovered dynamically, so a NEW
@@ -357,8 +358,6 @@ class TestDocumentAssemblerConfig:
 
     def test_assembler_default_backend_receives_config(self, small_image_pdf):
         """The default (pymupdf) backend honors a lowered threshold via the assembler."""
-        from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
-
         assembler = pdfcomponents.DocumentAssembler(
             small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10)
         )
@@ -367,7 +366,7 @@ class TestDocumentAssemblerConfig:
         assert len(image_elems) == 1
 
     def test_assembler_default_drops_small_image(self, small_image_pdf):
-        """Default config (40px) drops the 20px test image."""
+        """Default config (40px threshold) drops the 20px test image."""
         page = pdfcomponents.DocumentAssembler(small_image_pdf).parse_page(0)
         image_elems = [e for e in page["elements"] if e.get("type") == "image"]
         assert image_elems == []

--- a/tests/pdf_api_tests/test_pdfreader.py
+++ b/tests/pdf_api_tests/test_pdfreader.py
@@ -379,22 +379,12 @@ class TestPDFReaderMinImageDimension:
 
     def test_min_image_dimension_lowered_keeps_small_image(self, small_image_pdf):
         doc = PDFReader(small_image_pdf, min_image_dimension=10).to_dicts()
-        images = [
-            e
-            for p in doc["document"]["pages"]
-            for e in p.get("elements", [])
-            if e.get("type") == "image"
-        ]
+        images = [e for p in doc["document"]["pages"] for e in p.get("elements", []) if e.get("type") == "image"]
         assert len(images) == 1
 
     def test_min_image_dimension_default_drops_small_image(self, small_image_pdf):
         doc = PDFReader(small_image_pdf).to_dicts()
-        images = [
-            e
-            for p in doc["document"]["pages"]
-            for e in p.get("elements", [])
-            if e.get("type") == "image"
-        ]
+        images = [e for p in doc["document"]["pages"] for e in p.get("elements", []) if e.get("type") == "image"]
         assert images == []
 
     def test_min_image_dimension_invalid_raises_at_construction(self, small_image_pdf):

--- a/tests/pdf_api_tests/test_pdfreader.py
+++ b/tests/pdf_api_tests/test_pdfreader.py
@@ -372,3 +372,35 @@ class TestPDFReaderJsonAndDictInputs:
         df = reader.to_dataframe()
         assert df.height == 2
         assert list(df["content"]) == ["Header Text", "Hello body"]
+
+
+class TestPDFReaderMinImageDimension:
+    """Tests for the keyword-only min_image_dimension parameter on PDFReader."""
+
+    def test_min_image_dimension_lowered_keeps_small_image(self, small_image_pdf):
+        doc = PDFReader(small_image_pdf, min_image_dimension=10).to_dicts()
+        images = [
+            e
+            for p in doc["document"]["pages"]
+            for e in p.get("elements", [])
+            if e.get("type") == "image"
+        ]
+        assert len(images) == 1
+
+    def test_min_image_dimension_default_drops_small_image(self, small_image_pdf):
+        doc = PDFReader(small_image_pdf).to_dicts()
+        images = [
+            e
+            for p in doc["document"]["pages"]
+            for e in p.get("elements", [])
+            if e.get("type") == "image"
+        ]
+        assert images == []
+
+    def test_min_image_dimension_invalid_raises_at_construction(self, small_image_pdf):
+        with pytest.raises(ValueError):
+            PDFReader(small_image_pdf, min_image_dimension=-1)
+
+    def test_min_image_dimension_is_keyword_only(self, small_image_pdf):
+        with pytest.raises(TypeError):
+            PDFReader(small_image_pdf, "pdfium", 1, False, 10)  # 5th positional rejected

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -466,3 +466,17 @@ class TestPDFWriterJsonAndDictInputs:
         mdpath = writer.write_markdown("native_out.md")
         with open(mdpath) as f:
             assert "Hello native body" in f.read()
+
+
+class TestPDFWriterMinImageDimension:
+    """Tests for the keyword-only min_image_dimension parameter on PDFWriter."""
+
+    def test_writer_min_image_dimension_keeps_small_image(self, small_image_pdf, tmp_path):
+        out = tmp_path / "out.json"
+        images_dir = tmp_path / "imgs"
+        PDFWriter(small_image_pdf, min_image_dimension=10).write_json(
+            export_filename=str(out), image_output_dir=str(images_dir)
+        )
+        assert out.exists()
+        # the 20px image is written because the threshold was lowered
+        assert any(images_dir.glob("*")) if images_dir.exists() else False

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -479,4 +479,5 @@ class TestPDFWriterMinImageDimension:
         )
         assert out.exists()
         # the 20px image is written because the threshold was lowered
-        assert any(images_dir.glob("*")) if images_dir.exists() else False
+        assert images_dir.exists(), "image_output_dir was not created"
+        assert any(images_dir.glob("*")), "no image files written to image_output_dir"


### PR DESCRIPTION
## Summary

Makes the minimum embedded-image dimension kept during PDF extraction a public, per-instance knob. Previously it was hardcoded as `40`px and unreachable from the public API — and defined in **two divergent places** (a module constant in `pdfium_document.py` and a bare literal in `pymupdf_backend.py::_image_block`). This exposes a single keyword-only argument and unifies both sites against one source of truth.

```python
from datagrunt import PDFReader

# keep images >= 15px (e.g. small logos / icons / signatures)
PDFReader("scan.pdf", min_image_dimension=15).to_dicts(image_output_dir="imgs/")

# "set once, apply to many" for a pipeline:
opts = {"min_image_dimension": 15}
PDFReader(a, **opts); PDFReader(b, **opts)
```

## Design

- **Public surface:** `min_image_dimension` is **keyword-only** on `PDFReader`/`PDFWriter` (added once on the shared `_PDFEngineBacked`). Default `None` → internal default `40` → **behavior byte-for-byte unchanged**. Invalid values (bool, non-int, negative) **fail fast at construction**; `0` disables the filter.
- **Internals:** a private, frozen, picklable `_PDFExtractionConfig` (`core/pdf_io/extraction/config.py`) carries the value from the kwarg through the engine factory → reader/writer engines → **process-pool workers** → extraction backends. It is never exported — no new public symbol.
- **Unification:** both formerly-hardcoded `40` thresholds now derive from `_DEFAULT_MIN_IMAGE_DIMENSION`.
- Pure Python (no Rust, no parity-suite changes). datagrunt's per-page error isolation, automatic resource lifecycle, and "preserve, not transform" invariants are untouched.

## Testing

- New tests cover: config validation incl. **pickle round-trip**; all three backends (pdfium structured, pdfium native, pymupdf) at lowered + raised thresholds; the public API on both `PDFReader` and `PDFWriter`; fail-fast validation at construction; and a **`workers>1` process-pool regression guard** (a 2-page small-image fixture, asserting the frozen config survives pickling into child processes — 0→2 image count).
- Full suite green on **both backends**: `uv run pytest tests/ -q` and `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` → **1285 passed**. `ruff check` clean.
- Built via TDD (failing test first per task), with per-task spec+quality reviews and a final whole-branch review.

## Scope

OCR render DPI and page-to-image render DPI were intentionally deferred to keep this focused; `_PDFExtractionConfig` is the extension point for them. Tracked in #246 and #247.

Closes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
