### PR TITLE
feat(parquet): add ParquetReader and ParquetWriter [minor]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Welcome To Datagrunt
 
-Datagrunt is a Python library designed to simplify the way you work with CSV, Excel, and PDF files. It provides a streamlined approach to reading, processing, and transforming your data into various formats, making data manipulation efficient and intuitive.
+Datagrunt is a Python library designed to simplify the way you work with CSV, Excel, Parquet, and PDF files. It provides a streamlined approach to reading, processing, and transforming your data into various formats, making data manipulation efficient and intuitive.
 
 ## Why Datagrunt?
 
-Born out of real-world frustration, Datagrunt eliminates the need for repetitive coding when handling CSV, Excel, and PDF files. Whether you're a data analyst, data engineer, or data scientist, Datagrunt empowers you to focus on insights, not tedious data wrangling.
+Born out of real-world frustration, Datagrunt eliminates the need for repetitive coding when handling CSV, Excel, Parquet, and PDF files. Whether you're a data analyst, data engineer, or data scientist, Datagrunt empowers you to focus on insights, not tedious data wrangling.
 
 ### What Datagrunt Is Not
-Datagrunt is not an extension of or a replacement for DuckDB, Polars, or PyArrow, nor is it a comprehensive data processing solution. Instead, it's designed to simplify the way you work with CSV, Excel, and PDF files — solving the pain point of inferring delimiters when a CSV structure is unknown, reading Excel workbooks sheet by sheet, and turning PDFs into structured, queryable data. Datagrunt provides an easy way to convert CSV and Excel files to dataframes and export them to various formats, and to extract text, tables, and images from PDFs. One of Datagrunt's value propositions is its relative simplicity and ease of use.
+Datagrunt is not an extension of or a replacement for DuckDB, Polars, or PyArrow, nor is it a comprehensive data processing solution. Instead, it's designed to simplify the way you work with CSV, Excel, Parquet, and PDF files — solving the pain point of inferring delimiters when a CSV structure is unknown, reading Excel workbooks sheet by sheet, reading and converting columnar Parquet data, and turning PDFs into structured, queryable data. Datagrunt provides an easy way to convert CSV, Excel, and Parquet files to dataframes and export them to various formats, and to extract text, tables, and images from PDFs. One of Datagrunt's value propositions is its relative simplicity and ease of use.
 
 ## Key Features
 
@@ -15,8 +15,9 @@ Datagrunt is not an extension of or a replacement for DuckDB, Polars, or PyArrow
 - **Rust-Accelerated Core (v4.0+):** CSV delimiter and dialect inference run in a bundled Rust extension (`datagrunt._native`) for multiple-times-faster scanning of large files. The native engine is the default and is required on supported platforms (it ships as a prebuilt wheel). A byte-for-byte-equivalent pure-Python implementation lives alongside it as the differential-parity oracle — validated against the Rust engine in CI and selectable via a hidden diagnostics toggle — so results are identical no matter which path runs.
 - **Path Object Support:** Full support for both string paths and `pathlib.Path` objects for modern, cross-platform file handling.
 - **Multiple Processing Engines:** Choose from three powerful engines - [DuckDB](https://duckdb.org), [Polars](https://pola.rs), and [PyArrow](https://arrow.apache.org/docs/python/) - to handle your data processing needs.
-- **Flexible Data Transformation:** Easily convert your processed CSV and Excel data into various formats including CSV, Excel, JSON, JSONL, and Parquet.
+- **Flexible Data Transformation:** Easily convert your processed CSV, Excel, and Parquet data into various formats including CSV, Excel, JSON, JSONL, and Parquet.
 - **Excel Reading & Writing:** Read `.xlsx`/`.xls` workbooks sheet by sheet into DataFrames, dicts, Arrow, or SQL, and export any sheet (or all of them) to CSV, JSON, JSONL, Parquet, or Excel.
+- **Parquet Reading & Writing:** Read `.parquet` files into DataFrames, dicts, Arrow tables, or SQL, and export to CSV, JSON, JSONL, Parquet, or Excel. Backed by a single Polars engine with full `read_options`/`write_options` passthrough.
 - **Robust by Default:** Fail-fast validation with clear errors (invalid engine names, missing paths, directories, encrypted PDFs), graceful handling of empty files, no `UnicodeDecodeError` when constructing a reader over a non-UTF-8 file, and sane comment semantics — only leading `#` lines are treated as comments, so `#`-prefixed data rows such as hex colors are preserved on all engines.
 - **PDF Parsing & OCR:** Extract text, tables, and images from PDF files as dicts, DataFrames, or JSON, with optional [Tesseract](https://github.com/tesseract-ocr/tesseract) OCR for scanned pages. Powered by the permissively-licensed **PDFium** engine by default, with **PyMuPDF** available as an alternative.
 - **Pythonic API:** Enjoy a clean and intuitive API that integrates seamlessly into your existing Python workflows.
@@ -201,6 +202,45 @@ controlled via `sheet=`).
 exactly as the CSV API does. Values beginning with `=`, `+`, `-`, `@` are
 written verbatim — sanitize at the application layer if your source is
 untrusted and the output may be opened in a spreadsheet (CWE-1236).
+
+## Reading and writing Parquet
+
+`ParquetReader` and `ParquetWriter` work with `.parquet` files as a
+**single-table columnar format** — there are no sheets and no `engine` argument.
+Reading is backed by a single canonical Polars engine. A non-Parquet or missing
+path is rejected at construction (`ValueError` / `FileNotFoundError`).
+
+```python
+from datagrunt import ParquetReader, ParquetWriter
+
+reader = ParquetReader("data.parquet")
+reader.get_sample()                          # first rows as a Polars DataFrame
+reader.to_dataframe()                        # full file as a Polars DataFrame
+reader.to_arrow_table()                      # Apache Arrow Table
+reader.to_dicts()                            # list of row dicts
+reader.query_data(f"SELECT * FROM {reader.db_table} LIMIT 5")
+
+# Pass read_options straight through to pl.read_parquet (only "source" is reserved):
+reader_subset = ParquetReader("data.parquet", columns=["id", "name"], n_rows=1000)
+```
+
+```python
+writer = ParquetWriter("data.parquet")
+writer.write_csv("out.csv")
+writer.write_json("out.json")
+writer.write_json_newline_delimited("out.jsonl")
+writer.write_parquet("out.parquet")
+writer.write_excel("out.xlsx")
+
+# write_options are forwarded to the Polars writer:
+writer.write_parquet("recompressed.parquet", compression="zstd")
+```
+
+`normalize_columns=True` normalizes column names exactly as the CSV and Excel
+APIs do. Empty or blank source files return empty results from reader methods
+and produce 0-byte output files from writer methods. Values beginning with `=`,
+`+`, `-`, `@` are written verbatim — sanitize at the application layer if your
+source is untrusted and the output may be opened in a spreadsheet (CWE-1236).
 
 ## PDF parsing
 

--- a/src/datagrunt/__init__.py
+++ b/src/datagrunt/__init__.py
@@ -1,7 +1,7 @@
 """
 Datagrunt
 
-A Python library designed to simplify the way you work with CSV and PDF files. This
+A Python library designed to simplify the way you work with CSV, Excel, Parquet, and PDF files. This
 module provides inferred CSV delimiters and helper methods for reading and
 writing CSV files.
 
@@ -31,6 +31,7 @@ __license__ = "MIT"
 # the package level
 from datagrunt.csv_api import CSVReader, CSVWriter
 from datagrunt.excel_api import ExcelReader, ExcelWriter
+from datagrunt.parquet_api import ParquetReader, ParquetWriter
 from datagrunt.pdf_api import PDFReader, PDFWriter
 
 # You can define __all__ to specify what gets imported with "from package
@@ -40,6 +41,8 @@ __all__ = [
     "CSVWriter",
     "ExcelReader",
     "ExcelWriter",
+    "ParquetReader",
+    "ParquetWriter",
     "PDFReader",
     "PDFWriter",
 ]

--- a/src/datagrunt/core/__init__.py
+++ b/src/datagrunt/core/__init__.py
@@ -26,6 +26,13 @@ from datagrunt.core.excel_io import (
     ExcelWriterEngine,
 )
 from datagrunt.core.file_io import FileProperties
+from datagrunt.core.parquet_io import (
+    ParquetComponents,
+    ParquetEngineFactory,
+    ParquetEngineProperties,
+    ParquetReaderEngine,
+    ParquetWriterEngine,
+)
 from datagrunt.core.pdf_io import (
     DocumentAssembler,
     ExtractionBackend,
@@ -70,6 +77,12 @@ __all__ = [
     "ExcelWriterEngine",
     # File IO
     "FileProperties",
+    # Parquet IO
+    "ParquetComponents",
+    "ParquetEngineFactory",
+    "ParquetEngineProperties",
+    "ParquetReaderEngine",
+    "ParquetWriterEngine",
     # PDF IO
     "PDFComponents",
     "DocumentAssembler",

--- a/src/datagrunt/core/file_io/fileproperties.py
+++ b/src/datagrunt/core/file_io/fileproperties.py
@@ -40,6 +40,11 @@ class FileExtensions:
         return ["pdf"]
 
     @cached_property
+    def parquet_extensions(self):
+        """Define Parquet extensions."""
+        return ["parquet"]
+
+    @cached_property
     def excel_extensions(self):
         """Define Excel extensions."""
         return ["xlsx", "xlsm", "xlsb", "xltx", "xltm", "xls", "xlt"]
@@ -278,6 +283,11 @@ class FileProperties:
     def is_apache(self):
         """Check if the file is an Apache formatted file."""
         return self.extension_string.lower() in self._ext.apache_extensions
+
+    @cached_property
+    def is_parquet(self):
+        """Check if the file is a Parquet file."""
+        return self.extension_string.lower() in self._ext.parquet_extensions
 
     @cached_property
     def is_empty(self):

--- a/src/datagrunt/core/parquet_io/__init__.py
+++ b/src/datagrunt/core/parquet_io/__init__.py
@@ -1,0 +1,25 @@
+"""Initializes the Parquet IO core module."""
+
+from datagrunt.core.parquet_io.engines import (
+    ParquetEngineProperties,
+    ParquetReaderEngine,
+    ParquetWriterEngine,
+    set_parquet_export_filename,
+)
+from datagrunt.core.parquet_io.factories import ParquetEngineFactory
+from datagrunt.core.parquet_io.parquetcomponents import (
+    ParquetComponents,
+    normalize_parquet_columns,
+    parquet_table_name,
+)
+
+__all__ = [
+    "ParquetComponents",
+    "ParquetEngineFactory",
+    "ParquetEngineProperties",
+    "ParquetReaderEngine",
+    "ParquetWriterEngine",
+    "normalize_parquet_columns",
+    "parquet_table_name",
+    "set_parquet_export_filename",
+]

--- a/src/datagrunt/core/parquet_io/engines.py
+++ b/src/datagrunt/core/parquet_io/engines.py
@@ -1,0 +1,156 @@
+"""Polars-backed engines for the Parquet subsystem."""
+
+# standard library
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+from typing import ClassVar
+
+# third party libraries
+import duckdb
+import polars as pl
+
+# local libraries
+from datagrunt.core.parquet_io.parquetcomponents import (
+    ParquetComponents,
+    normalize_parquet_columns,
+    parquet_table_name,
+)
+
+
+@dataclass
+class ParquetEngineProperties:
+    """Default output filenames and tuning constants for Parquet engines."""
+
+    filepath: Path
+    dataframe_sample_rows: ClassVar[int] = 20
+    csv_export_filename: str = "output.csv"
+    excel_export_filename: str = "output.xlsx"
+    json_export_filename: str = "output.json"
+    json_newline_export_filename: str = "output.jsonl"
+    parquet_export_filename: str = "output.parquet"
+
+
+def _resolve_normalize(instance_value, per_call_value):
+    """Return the per-call override when given, else the instance default."""
+    return instance_value if per_call_value is None else per_call_value
+
+
+def _freeze(value):
+    """Recursively convert dicts/lists into a hashable key for caching."""
+    if isinstance(value, dict):
+        return tuple(sorted((k, _freeze(v)) for k, v in value.items()))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(v) for v in value)
+    return value
+
+
+def set_parquet_export_filename(default_filename, export_filename=None):
+    """Return ``export_filename`` if provided (non-blank), else the default.
+
+    Raises:
+        ValueError: If ``export_filename`` is a non-``None`` empty/whitespace string.
+    """
+    if export_filename is not None:
+        if not export_filename.strip():
+            raise ValueError(
+                f"out_filename must not be empty or whitespace-only; "
+                f"got {export_filename!r}. Pass None to use the default."
+            )
+        return export_filename
+    return default_filename
+
+
+# Keys that select the source — controlled by the engine, never the caller.
+_RESERVED_READ_OPTIONS = ("source",)
+
+
+class ParquetReaderEngine:
+    """Read a Parquet file into a Polars frame and convert/query it.
+
+    Parses each (normalize, read_options) combination at most once and caches
+    the frame. Holds a DuckDB connection only when ``query_data`` is used; it is
+    opened lazily and released by ``close()``.
+
+    ``**read_options`` are forwarded verbatim to ``pl.read_parquet`` (``columns``,
+    ``n_rows``, ``row_index_name``, etc.). Constructor options are defaults;
+    per-call options merge over them.
+    """
+
+    def __init__(self, filepath, normalize_columns=False, **read_options):
+        self.filepath = Path(filepath)
+        self.normalize_columns = normalize_columns
+        self._read_options = read_options
+        self._components = ParquetComponents(self.filepath)
+        self._frame_cache = {}
+        self._connection = None
+
+    @cached_property
+    def db_table(self):
+        """Stable table name used by ``query_data`` registration."""
+        return parquet_table_name(self.filepath)
+
+    def _merge_read_options(self, call_options):
+        """Merge constructor + per-call options; reject reserved keys."""
+        merged = {**self._read_options, **call_options}
+        reserved = [k for k in _RESERVED_READ_OPTIONS if k in merged]
+        if reserved:
+            raise ValueError(
+                f"The source path is controlled via the constructor; do not pass {reserved} as read options."
+            )
+        return merged
+
+    def _read_frame(self, normalize_columns, read_options):
+        """Return the cached frame for (normalize, read_options)."""
+        resolved_normalize = _resolve_normalize(self.normalize_columns, normalize_columns)
+        merged_options = self._merge_read_options(read_options)
+        key = (resolved_normalize, _freeze(merged_options))
+        if key not in self._frame_cache:
+            df = pl.read_parquet(self.filepath, **merged_options)
+            if resolved_normalize:
+                mapping = dict(zip(df.columns, normalize_parquet_columns(df.columns)))
+                df = df.rename(mapping)
+            self._frame_cache[key] = df
+        return self._frame_cache[key]
+
+    def get_sample(self, normalize_columns=None, **read_options):
+        """Return the leading sample rows as a Polars frame."""
+        return self._read_frame(normalize_columns, read_options).head(
+            ParquetEngineProperties.dataframe_sample_rows
+        )
+
+    def to_dataframe(self, normalize_columns=None, **read_options):
+        """Return the file as a Polars DataFrame."""
+        return self._read_frame(normalize_columns, read_options)
+
+    def to_arrow_table(self, normalize_columns=None, **read_options):
+        """Return the file as a PyArrow Table."""
+        return self._read_frame(normalize_columns, read_options).to_arrow()
+
+    def to_dicts(self, normalize_columns=None, **read_options):
+        """Return the file as a list of row dicts."""
+        return self._read_frame(normalize_columns, read_options).to_dicts()
+
+    def query_data(self, sql_query, normalize_columns=None, **read_options):
+        """Register the frame under ``db_table`` and run SQL.
+
+        Security:
+            ``sql_query`` runs verbatim against the in-memory session — a
+            SQL-injection vector if built from untrusted input. Validate /
+            parameterize at the application layer.
+
+        Returns:
+            A live ``DuckDBPyRelation``. Re-registering replaces the prior
+            table, so the table name stays stable across calls.
+        """
+        df = self._read_frame(normalize_columns, read_options)
+        if self._connection is None:
+            self._connection = duckdb.connect(":memory:")
+        self._connection.register(self.db_table, df.to_arrow())
+        return self._connection.sql(sql_query)
+
+    def close(self):
+        """Release the DuckDB connection if one was opened. Idempotent."""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/src/datagrunt/core/parquet_io/engines.py
+++ b/src/datagrunt/core/parquet_io/engines.py
@@ -154,3 +154,53 @@ class ParquetReaderEngine:
         if self._connection is not None:
             self._connection.close()
             self._connection = None
+
+
+class ParquetWriterEngine:
+    """Export a Parquet file to CSV/JSON/JSONL/Parquet/Excel via Polars."""
+
+    # Map format key -> (default filename attr, Polars writer method name).
+    _SINGLE_TABLE_WRITERS = {
+        "csv": ("csv_export_filename", "write_csv"),
+        "json": ("json_export_filename", "write_json"),
+        "jsonl": ("json_newline_export_filename", "write_ndjson"),
+        "parquet": ("parquet_export_filename", "write_parquet"),
+        "excel": ("excel_export_filename", "write_excel"),
+    }
+
+    def __init__(self, filepath, normalize_columns=False, **read_options):
+        self.filepath = Path(filepath)
+        self.normalize_columns = normalize_columns
+        self._reader = ParquetReaderEngine(self.filepath, normalize_columns=normalize_columns, **read_options)
+
+    def close(self):
+        """Release any resources held by the backing reader engine."""
+        self._reader.close()
+
+    def _write(self, fmt, out_filename, normalize_columns, write_options):
+        """Shared dispatch for all public write_* methods."""
+        default_attr, writer_method = self._SINGLE_TABLE_WRITERS[fmt]
+        default_filename = getattr(ParquetEngineProperties, default_attr)
+        filename = set_parquet_export_filename(default_filename, out_filename)
+        df = self._reader.to_dataframe(normalize_columns)
+        getattr(df, writer_method)(filename, **write_options)
+
+    def write_csv(self, out_filename=None, normalize_columns=None, **write_options):
+        """Export to CSV."""
+        self._write("csv", out_filename, normalize_columns, write_options)
+
+    def write_json(self, out_filename=None, normalize_columns=None, **write_options):
+        """Export to JSON."""
+        self._write("json", out_filename, normalize_columns, write_options)
+
+    def write_json_newline_delimited(self, out_filename=None, normalize_columns=None, **write_options):
+        """Export to newline-delimited JSON."""
+        self._write("jsonl", out_filename, normalize_columns, write_options)
+
+    def write_parquet(self, out_filename=None, normalize_columns=None, **write_options):
+        """Export to Parquet (re-encode; ``compression=`` etc. pass through)."""
+        self._write("parquet", out_filename, normalize_columns, write_options)
+
+    def write_excel(self, out_filename=None, normalize_columns=None, **write_options):
+        """Export to .xlsx."""
+        self._write("excel", out_filename, normalize_columns, write_options)

--- a/src/datagrunt/core/parquet_io/engines.py
+++ b/src/datagrunt/core/parquet_io/engines.py
@@ -115,9 +115,7 @@ class ParquetReaderEngine:
 
     def get_sample(self, normalize_columns=None, **read_options):
         """Return the leading sample rows as a Polars frame."""
-        return self._read_frame(normalize_columns, read_options).head(
-            ParquetEngineProperties.dataframe_sample_rows
-        )
+        return self._read_frame(normalize_columns, read_options).head(ParquetEngineProperties.dataframe_sample_rows)
 
     def to_dataframe(self, normalize_columns=None, **read_options):
         """Return the file as a Polars DataFrame."""

--- a/src/datagrunt/core/parquet_io/factories.py
+++ b/src/datagrunt/core/parquet_io/factories.py
@@ -1,0 +1,38 @@
+"""Factory for creating Parquet reader and writer engine instances."""
+
+# standard library
+from pathlib import Path
+
+# local libraries
+from datagrunt.core.parquet_io.engines import ParquetReaderEngine, ParquetWriterEngine
+
+
+class ParquetEngineFactory:
+    """Create the canonical Polars-backed Parquet engines."""
+
+    def __init__(self, filepath, normalize_columns=False, **read_options):
+        """Initialize the factory.
+
+        Args:
+            filepath (str or Path): Path to the Parquet file.
+            normalize_columns (bool): Instance-level normalization forwarded to
+                the engines this factory creates.
+            **read_options: Polars ``read_parquet`` options forwarded to the
+                engines this factory creates.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
+        self.filepath = Path(filepath)
+        self.normalize_columns = normalize_columns
+        self.read_options = read_options
+        if not self.filepath.exists():
+            raise FileNotFoundError(f"Parquet file not found: {self.filepath}")
+
+    def create_reader(self):
+        """Return a new ``ParquetReaderEngine``."""
+        return ParquetReaderEngine(self.filepath, normalize_columns=self.normalize_columns, **self.read_options)
+
+    def create_writer(self):
+        """Return a new ``ParquetWriterEngine``."""
+        return ParquetWriterEngine(self.filepath, normalize_columns=self.normalize_columns, **self.read_options)

--- a/src/datagrunt/core/parquet_io/parquetcomponents.py
+++ b/src/datagrunt/core/parquet_io/parquetcomponents.py
@@ -1,0 +1,50 @@
+"""Shared Parquet components: file validation, normalization, table naming."""
+
+# standard library
+import re
+from pathlib import Path
+
+# local libraries
+from datagrunt.core.csv_io import _compute
+from datagrunt.core.file_io import FileProperties
+
+
+def normalize_parquet_columns(columns):
+    """Normalize Parquet column names via the shared compute backend.
+
+    Reuses the same ``normalize_columns`` implementation as the CSV subsystem so
+    Parquet column normalization is byte-for-byte identical (lowercase,
+    non-alphanumeric runs collapsed to ``_``, leading-digit prefix, then
+    collision-safe uniquification).
+    """
+    return _compute.backend().normalize_columns(list(columns))
+
+
+def parquet_table_name(filepath):
+    """Return a deterministic, SQL-safe table name for a Parquet file.
+
+    ``query_data`` registers the file's single table under this name, so callers
+    can always reference ``reader.db_table``.
+    """
+    safe = re.sub(r"[^0-9a-zA-Z_]", "_", Path(filepath).stem)
+    return f"tbl_{safe}"
+
+
+class ParquetComponents(FileProperties):
+    """Combine file properties with Parquet-specific validation."""
+
+    def __init__(self, filepath):
+        """Initialize and validate the path points at a Parquet file.
+
+        Args:
+            filepath (str or Path): Path to the Parquet file.
+
+        Raises:
+            ValueError: If the file extension is not ``.parquet``.
+        """
+        super().__init__(filepath)  # validates existence; sets self._ext
+        if not self.is_parquet:
+            raise ValueError(
+                f"'{self.filepath}' is not a Parquet file. "
+                f"Expected one of: {', '.join(sorted(self._ext.parquet_extensions))}."
+            )

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -550,6 +550,7 @@ class PDFComponents(FileProperties):
         self.is_pdf = False
         self.is_excel = False
         self.is_apache = False
+        self.is_parquet = False
         self.is_large = False
         self.is_tabular = False
         self.is_tsv = False

--- a/src/datagrunt/parquet_api/__init__.py
+++ b/src/datagrunt/parquet_api/__init__.py
@@ -1,4 +1,5 @@
 # Import key classes that should be available at the package level
 from datagrunt.parquet_api.parquetreader import ParquetReader
+from datagrunt.parquet_api.parquetwriter import ParquetWriter
 
-__all__ = ["ParquetReader"]
+__all__ = ["ParquetReader", "ParquetWriter"]

--- a/src/datagrunt/parquet_api/__init__.py
+++ b/src/datagrunt/parquet_api/__init__.py
@@ -1,0 +1,4 @@
+# Import key classes that should be available at the package level
+from datagrunt.parquet_api.parquetreader import ParquetReader
+
+__all__ = ["ParquetReader"]

--- a/src/datagrunt/parquet_api/_engine_backed.py
+++ b/src/datagrunt/parquet_api/_engine_backed.py
@@ -1,0 +1,42 @@
+"""Shared engine lifecycle for the Parquet public API (ParquetReader/Writer)."""
+
+from functools import cached_property
+
+from datagrunt.core import ParquetComponents, ParquetEngineFactory
+
+
+class _ParquetEngineBacked(ParquetComponents):
+    """Engine ownership + lifecycle shared by ParquetReader and ParquetWriter.
+
+    Owns the single cached engine plus optional ``close()``/context-manager
+    semantics. Subclasses set ``_engine_role`` to choose the factory builder.
+    """
+
+    _engine_role = None  # "reader" or "writer"
+
+    def __init__(self, filepath, normalize_columns=False, **read_options):
+        self.normalize_columns = normalize_columns
+        self._read_options = read_options
+        super().__init__(filepath)  # validates Parquet extension
+
+    @cached_property
+    def _engine(self):
+        """Build this object's engine once and reuse it (released on GC)."""
+        factory = ParquetEngineFactory(self.filepath, normalize_columns=self.normalize_columns, **self._read_options)
+        if self._engine_role == "reader":
+            return factory.create_reader()
+        return factory.create_writer()
+
+    def close(self):
+        """Release the engine's DuckDB connection if one was built. Idempotent."""
+        engine = self.__dict__.get("_engine")
+        if engine is not None:
+            engine.close()
+
+    def __enter__(self):
+        """Enter a ``with`` block, returning this object."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Release the engine on leaving the block; lets exceptions propagate."""
+        self.close()

--- a/src/datagrunt/parquet_api/parquetreader.py
+++ b/src/datagrunt/parquet_api/parquetreader.py
@@ -1,0 +1,79 @@
+"""Module for reading Parquet files into in-memory Python objects."""
+
+# standard library
+from pathlib import Path
+
+# third party libraries
+import polars as pl
+import pyarrow as pa
+
+# local libraries
+from datagrunt.parquet_api._engine_backed import _ParquetEngineBacked
+
+
+class ParquetReader(_ParquetEngineBacked):
+    """Read Parquet files into Polars / PyArrow / dict objects, or query via SQL."""
+
+    _engine_role = "reader"
+
+    def __init__(self, filepath: str | Path, normalize_columns: bool = False, **read_options) -> None:
+        """Initialize the Parquet Reader.
+
+        Args:
+            filepath (str or Path): Path to the Parquet file to read.
+            normalize_columns (bool): Normalize column names for every operation
+                on this reader. A per-call ``normalize_columns`` overrides it.
+            **read_options: Polars ``read_parquet`` options applied to every read
+                (e.g. ``columns=[...]``, ``n_rows=100``). Per-call options
+                override these. The reserved key ``source`` is not allowed.
+        """
+        super().__init__(filepath, normalize_columns=normalize_columns, **read_options)
+
+    @property
+    def db_table(self) -> str:
+        """The DuckDB table name ``query_data`` registers the file under."""
+        return self._engine.db_table
+
+    def get_sample(self, normalize_columns: bool | None = None, **read_options) -> pl.DataFrame:
+        """Return the leading sample rows (empty frame if empty/blank)."""
+        if self.is_empty or self.is_blank:
+            return pl.DataFrame()
+        return self._engine.get_sample(normalize_columns, **read_options)
+
+    def to_dataframe(self, normalize_columns: bool | None = None, **read_options) -> pl.DataFrame:
+        """Convert to a Polars DataFrame (empty frame if empty/blank)."""
+        if self.is_empty or self.is_blank:
+            return pl.DataFrame()
+        return self._engine.to_dataframe(normalize_columns, **read_options)
+
+    def to_arrow_table(self, normalize_columns: bool | None = None, **read_options) -> pa.Table:
+        """Convert to a PyArrow Table (empty table if empty/blank)."""
+        if self.is_empty or self.is_blank:
+            return pa.Table.from_pydict({})
+        return self._engine.to_arrow_table(normalize_columns, **read_options)
+
+    def to_dicts(self, normalize_columns: bool | None = None, **read_options) -> list:
+        """Convert to a list of row dicts (empty list if empty/blank)."""
+        if self.is_empty or self.is_blank:
+            return []
+        return self._engine.to_dicts(normalize_columns, **read_options)
+
+    def query_data(self, sql_query: str, normalize_columns: bool | None = None, **read_options):
+        """Query the file via DuckDB.
+
+        Security:
+            ``sql_query`` is executed verbatim against the in-memory session.
+            Concatenating untrusted input is a SQL-injection vector; validate /
+            parameterize and sandbox at the application layer.
+
+        Returns:
+            A DuckDB ``DuckDBPyRelation``; an empty ``list`` for empty/blank
+            files.
+
+        Example:
+            pq = ParquetReader('data.parquet')
+            pq.query_data(f"SELECT * FROM {pq.db_table}")
+        """
+        if self.is_empty or self.is_blank:
+            return []
+        return self._engine.query_data(sql_query, normalize_columns, **read_options)

--- a/src/datagrunt/parquet_api/parquetwriter.py
+++ b/src/datagrunt/parquet_api/parquetwriter.py
@@ -1,0 +1,83 @@
+"""Module for writing Parquet files to other file formats."""
+
+# standard library
+from pathlib import Path
+
+# local libraries
+from datagrunt.core import ParquetEngineProperties
+from datagrunt.core.parquet_io import set_parquet_export_filename
+from datagrunt.parquet_api._engine_backed import _ParquetEngineBacked
+
+
+class ParquetWriter(_ParquetEngineBacked):
+    """Convert Parquet files to CSV/JSON/JSONL/Parquet/Excel.
+
+    Security:
+        Values are written verbatim — datagrunt preserves data, it does not
+        sanitize it. For spreadsheet-interpreted formats (``write_csv`` and
+        ``write_excel``), a value beginning with ``=``, ``+``, ``-``, ``@`` (or
+        a leading tab/carriage return) is treated as a FORMULA when opened in a
+        spreadsheet application (CWE-1236). Sanitize at the application layer if
+        your source data is untrusted; datagrunt will not mutate values for you.
+    """
+
+    _engine_role = "writer"
+
+    def __init__(self, filepath: str | Path, normalize_columns: bool = False, **read_options) -> None:
+        """Initialize the Parquet Writer.
+
+        Args:
+            filepath (str or Path): Path to the Parquet file to read.
+            normalize_columns (bool): Normalize column names in every file this
+                writer exports. A per-call argument overrides it.
+            **read_options: Polars ``read_parquet`` options applied when reading
+                the source before export (per-call options override these).
+        """
+        super().__init__(filepath, normalize_columns=normalize_columns, **read_options)
+
+    def _write_empty_output(self, default_filename, out_filename=None):
+        """Write a single 0-byte file for an empty/blank source."""
+        filename = set_parquet_export_filename(default_filename, out_filename)
+        Path(filename).write_bytes(b"")
+
+    def write_csv(
+        self, out_filename: str | None = None, normalize_columns: bool | None = None, **write_options
+    ) -> None:
+        """Export to CSV."""
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(ParquetEngineProperties.csv_export_filename, out_filename)
+        return self._engine.write_csv(out_filename, normalize_columns=normalize_columns, **write_options)
+
+    def write_json(
+        self, out_filename: str | None = None, normalize_columns: bool | None = None, **write_options
+    ) -> None:
+        """Export to JSON."""
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(ParquetEngineProperties.json_export_filename, out_filename)
+        return self._engine.write_json(out_filename, normalize_columns=normalize_columns, **write_options)
+
+    def write_json_newline_delimited(
+        self, out_filename: str | None = None, normalize_columns: bool | None = None, **write_options
+    ) -> None:
+        """Export to newline-delimited JSON."""
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(ParquetEngineProperties.json_newline_export_filename, out_filename)
+        return self._engine.write_json_newline_delimited(
+            out_filename, normalize_columns=normalize_columns, **write_options
+        )
+
+    def write_parquet(
+        self, out_filename: str | None = None, normalize_columns: bool | None = None, **write_options
+    ) -> None:
+        """Export to Parquet (re-encode; ``compression=`` etc. pass through)."""
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(ParquetEngineProperties.parquet_export_filename, out_filename)
+        return self._engine.write_parquet(out_filename, normalize_columns=normalize_columns, **write_options)
+
+    def write_excel(
+        self, out_filename: str | None = None, normalize_columns: bool | None = None, **write_options
+    ) -> None:
+        """Export to .xlsx."""
+        if self.is_empty or self.is_blank:
+            return self._write_empty_output(ParquetEngineProperties.excel_export_filename, out_filename)
+        return self._engine.write_excel(out_filename, normalize_columns=normalize_columns, **write_options)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -319,3 +319,43 @@ def empty_xlsx(tmp_path):
 def nonexistent_xlsx(tmp_path):
     """Return a path to an .xlsx that does not exist."""
     return str(tmp_path / "missing.xlsx")
+
+
+@pytest.fixture
+def sample_parquet(tmp_path):
+    """Create a small Parquet file with clean and messy column names."""
+    import polars as pl
+
+    path = tmp_path / "test.parquet"
+    pl.DataFrame(
+        {
+            "name": ["John", "Jane", "Amir", "Mei"],
+            "age": [30, 25, 41, 38],
+            "city": ["New York", "Boston", "Cairo", "Taipei"],
+        }
+    ).write_parquet(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def messy_parquet(tmp_path):
+    """Create a Parquet file with non-normalized column names."""
+    import polars as pl
+
+    path = tmp_path / "messy.parquet"
+    pl.DataFrame({"First Name!": ["x", "y"], "#Age@": [1, 2]}).write_parquet(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def empty_parquet(tmp_path):
+    """Create a 0-byte .parquet file."""
+    path = tmp_path / "empty.parquet"
+    path.touch()
+    return str(path)
+
+
+@pytest.fixture
+def nonexistent_parquet(tmp_path):
+    """Return a path to a .parquet that does not exist."""
+    return str(tmp_path / "missing.parquet")

--- a/tests/core_tests/file_io_tests/test_fileproperties.py
+++ b/tests/core_tests/file_io_tests/test_fileproperties.py
@@ -91,6 +91,17 @@ class TestFileProperties:
         assert not pdf_file.is_structured
         assert not pdf_file.is_semi_structured
 
+    def test_is_parquet(self, sample_files):
+        """Parquet detection is exact and does not widen to avro."""
+        parquet_file = FileProperties(sample_files["test.parquet"])
+        csv_file = FileProperties(sample_files["data.csv"])
+        xlsx_file = FileProperties(sample_files["test.xlsx"])
+
+        assert parquet_file.is_parquet
+        assert parquet_file.is_apache  # back-compat: still apache
+        assert not csv_file.is_parquet
+        assert not xlsx_file.is_parquet
+
 
 class TestBlankFileBinaryDetection:
     """is_blank must not misclassify binary/invalid-UTF-8 files as blank (#146).

--- a/tests/core_tests/parquet_io_tests/test_parquet_components.py
+++ b/tests/core_tests/parquet_io_tests/test_parquet_components.py
@@ -1,5 +1,6 @@
 """Tests for Parquet components and helpers."""
 
+import polars as pl
 import pytest
 
 from datagrunt.core.parquet_io.parquetcomponents import (
@@ -27,3 +28,9 @@ def test_components_accepts_parquet(sample_parquet):
 def test_components_rejects_non_parquet(sample_files):
     with pytest.raises(ValueError, match="not a Parquet file"):
         ParquetComponents(sample_files["data.csv"])
+
+
+def test_parquet_table_name_sanitizes_special_chars(tmp_path):
+    path = tmp_path / "my data-file!.parquet"
+    pl.DataFrame({"a": [1]}).write_parquet(str(path))
+    assert parquet_table_name(str(path)) == "tbl_my_data_file_"

--- a/tests/core_tests/parquet_io_tests/test_parquet_components.py
+++ b/tests/core_tests/parquet_io_tests/test_parquet_components.py
@@ -1,0 +1,29 @@
+"""Tests for Parquet components and helpers."""
+
+import pytest
+
+from datagrunt.core.parquet_io.parquetcomponents import (
+    ParquetComponents,
+    normalize_parquet_columns,
+    parquet_table_name,
+)
+
+
+def test_normalize_parquet_columns_matches_compute_backend():
+    assert normalize_parquet_columns(["First Name!", "#Age@"]) == ["first_name", "age"]
+
+
+def test_parquet_table_name_is_sql_safe(sample_parquet):
+    name = parquet_table_name(sample_parquet)
+    assert name.startswith("tbl_")
+    assert all(c.isalnum() or c == "_" for c in name)
+
+
+def test_components_accepts_parquet(sample_parquet):
+    components = ParquetComponents(sample_parquet)
+    assert components.is_parquet
+
+
+def test_components_rejects_non_parquet(sample_files):
+    with pytest.raises(ValueError, match="not a Parquet file"):
+        ParquetComponents(sample_files["data.csv"])

--- a/tests/core_tests/parquet_io_tests/test_parquet_engines.py
+++ b/tests/core_tests/parquet_io_tests/test_parquet_engines.py
@@ -99,3 +99,21 @@ def test_writer_normalize_columns(messy_parquet, tmp_path):
     out = str(tmp_path / "out.csv")
     ParquetWriterEngine(messy_parquet, normalize_columns=True).write_csv(out)
     assert pl.read_csv(out).columns == ["first_name", "age"]
+
+
+from datagrunt.core import (
+    ParquetEngineFactory,
+    ParquetReaderEngine as CoreReaderEngine,
+    ParquetWriterEngine as CoreWriterEngine,
+)
+
+
+def test_factory_creates_engines(sample_parquet):
+    factory = ParquetEngineFactory(sample_parquet)
+    assert isinstance(factory.create_reader(), CoreReaderEngine)
+    assert isinstance(factory.create_writer(), CoreWriterEngine)
+
+
+def test_factory_missing_file(nonexistent_parquet):
+    with pytest.raises(FileNotFoundError):
+        ParquetEngineFactory(nonexistent_parquet)

--- a/tests/core_tests/parquet_io_tests/test_parquet_engines.py
+++ b/tests/core_tests/parquet_io_tests/test_parquet_engines.py
@@ -1,11 +1,14 @@
 """Tests for the Parquet reader/writer engines."""
 
+from pathlib import Path
+
 import polars as pl
 import pyarrow as pa
 import pytest
 
 from datagrunt.core.parquet_io.engines import (
     ParquetReaderEngine,
+    ParquetWriterEngine,
     set_parquet_export_filename,
 )
 
@@ -65,3 +68,34 @@ def test_set_parquet_export_filename():
     assert set_parquet_export_filename("output.csv", "custom.csv") == "custom.csv"
     with pytest.raises(ValueError):
         set_parquet_export_filename("output.csv", "   ")
+
+
+def test_writer_exports_csv(sample_parquet, tmp_path):
+    out = str(tmp_path / "out.csv")
+    ParquetWriterEngine(sample_parquet).write_csv(out)
+    assert pl.read_csv(out).shape == (4, 3)
+
+
+def test_writer_exports_json_jsonl_excel(sample_parquet, tmp_path):
+    writer = ParquetWriterEngine(sample_parquet)
+    json_out = str(tmp_path / "out.json")
+    jsonl_out = str(tmp_path / "out.jsonl")
+    xlsx_out = str(tmp_path / "out.xlsx")
+    writer.write_json(json_out)
+    writer.write_json_newline_delimited(jsonl_out)
+    writer.write_excel(xlsx_out)
+    assert Path(json_out).stat().st_size > 0
+    assert Path(jsonl_out).stat().st_size > 0
+    assert pl.read_excel(xlsx_out).shape == (4, 3)
+
+
+def test_writer_parquet_round_trip_with_compression(sample_parquet, tmp_path):
+    out = str(tmp_path / "out.parquet")
+    ParquetWriterEngine(sample_parquet).write_parquet(out, compression="zstd")
+    assert pl.read_parquet(out).shape == (4, 3)
+
+
+def test_writer_normalize_columns(messy_parquet, tmp_path):
+    out = str(tmp_path / "out.csv")
+    ParquetWriterEngine(messy_parquet, normalize_columns=True).write_csv(out)
+    assert pl.read_csv(out).columns == ["first_name", "age"]

--- a/tests/core_tests/parquet_io_tests/test_parquet_engines.py
+++ b/tests/core_tests/parquet_io_tests/test_parquet_engines.py
@@ -1,0 +1,66 @@
+"""Tests for the Parquet reader/writer engines."""
+
+import polars as pl
+import pyarrow as pa
+import pytest
+
+from datagrunt.core.parquet_io.engines import (
+    ParquetReaderEngine,
+    set_parquet_export_filename,
+)
+
+
+def test_to_dataframe_round_trips(sample_parquet):
+    engine = ParquetReaderEngine(sample_parquet)
+    df = engine.to_dataframe()
+    assert df.shape == (4, 3)
+    assert df.columns == ["name", "age", "city"]
+
+
+def test_get_sample_caps_rows(sample_parquet):
+    engine = ParquetReaderEngine(sample_parquet)
+    sample = engine.get_sample()
+    assert sample.height <= 20
+
+
+def test_to_arrow_and_dicts(sample_parquet):
+    engine = ParquetReaderEngine(sample_parquet)
+    assert isinstance(engine.to_arrow_table(), pa.Table)
+    dicts = engine.to_dicts()
+    assert dicts[0]["name"] == "John"
+
+
+def test_normalize_columns_constructor(messy_parquet):
+    engine = ParquetReaderEngine(messy_parquet, normalize_columns=True)
+    assert engine.to_dataframe().columns == ["first_name", "age"]
+
+
+def test_normalize_columns_per_call_override(messy_parquet):
+    engine = ParquetReaderEngine(messy_parquet)
+    assert engine.to_dataframe(normalize_columns=True).columns == ["first_name", "age"]
+    assert engine.to_dataframe().columns == ["First Name!", "#Age@"]
+
+
+def test_read_options_forwarded(sample_parquet):
+    engine = ParquetReaderEngine(sample_parquet, columns=["name"])
+    assert engine.to_dataframe().columns == ["name"]
+
+
+def test_reserved_read_option_rejected(sample_parquet):
+    engine = ParquetReaderEngine(sample_parquet, source="bad")
+    with pytest.raises(ValueError, match="source"):
+        engine.to_dataframe()
+
+
+def test_query_data_uses_db_table(sample_parquet):
+    engine = ParquetReaderEngine(sample_parquet)
+    relation = engine.query_data(f"SELECT count(*) AS n FROM {engine.db_table}")
+    assert relation.pl()["n"][0] == 4
+    engine.close()
+
+
+def test_set_parquet_export_filename():
+    assert set_parquet_export_filename("output.csv") == "output.csv"
+    assert set_parquet_export_filename("output.csv", "custom.csv") == "custom.csv"
+    with pytest.raises(ValueError):
+        set_parquet_export_filename("output.csv", "   ")

--- a/tests/core_tests/parquet_io_tests/test_parquet_engines.py
+++ b/tests/core_tests/parquet_io_tests/test_parquet_engines.py
@@ -6,6 +6,15 @@ import polars as pl
 import pyarrow as pa
 import pytest
 
+from datagrunt.core import (
+    ParquetEngineFactory,
+)
+from datagrunt.core import (
+    ParquetReaderEngine as CoreReaderEngine,
+)
+from datagrunt.core import (
+    ParquetWriterEngine as CoreWriterEngine,
+)
 from datagrunt.core.parquet_io.engines import (
     ParquetReaderEngine,
     ParquetWriterEngine,
@@ -99,13 +108,6 @@ def test_writer_normalize_columns(messy_parquet, tmp_path):
     out = str(tmp_path / "out.csv")
     ParquetWriterEngine(messy_parquet, normalize_columns=True).write_csv(out)
     assert pl.read_csv(out).columns == ["first_name", "age"]
-
-
-from datagrunt.core import (
-    ParquetEngineFactory,
-    ParquetReaderEngine as CoreReaderEngine,
-    ParquetWriterEngine as CoreWriterEngine,
-)
 
 
 def test_factory_creates_engines(sample_parquet):

--- a/tests/core_tests/parquet_io_tests/test_parquet_engines.py
+++ b/tests/core_tests/parquet_io_tests/test_parquet_engines.py
@@ -17,10 +17,11 @@ def test_to_dataframe_round_trips(sample_parquet):
     assert df.columns == ["name", "age", "city"]
 
 
-def test_get_sample_caps_rows(sample_parquet):
-    engine = ParquetReaderEngine(sample_parquet)
-    sample = engine.get_sample()
-    assert sample.height <= 20
+def test_get_sample_caps_rows(tmp_path):
+    path = tmp_path / "big.parquet"
+    pl.DataFrame({"n": list(range(50))}).write_parquet(str(path))
+    engine = ParquetReaderEngine(str(path))
+    assert engine.get_sample().height == 20
 
 
 def test_to_arrow_and_dicts(sample_parquet):

--- a/tests/parquet_api_tests/test_parquetreader.py
+++ b/tests/parquet_api_tests/test_parquetreader.py
@@ -1,0 +1,54 @@
+"""Tests for the ParquetReader public class."""
+
+import pyarrow as pa
+import pytest
+
+from datagrunt.parquet_api.parquetreader import ParquetReader
+
+
+def test_to_dataframe(sample_parquet):
+    assert ParquetReader(sample_parquet).to_dataframe().shape == (4, 3)
+
+
+def test_get_sample(sample_parquet):
+    assert ParquetReader(sample_parquet).get_sample().height == 4
+
+
+def test_to_arrow_and_dicts(sample_parquet):
+    reader = ParquetReader(sample_parquet)
+    assert isinstance(reader.to_arrow_table(), pa.Table)
+    assert reader.to_dicts()[0]["name"] == "John"
+
+
+def test_normalize_columns(messy_parquet):
+    assert ParquetReader(messy_parquet, normalize_columns=True).to_dataframe().columns == ["first_name", "age"]
+
+
+def test_query_data(sample_parquet):
+    reader = ParquetReader(sample_parquet)
+    result = reader.query_data(f"SELECT count(*) AS n FROM {reader.db_table}")
+    assert result.pl()["n"][0] == 4
+
+
+def test_empty_returns_empty_objects(empty_parquet):
+    reader = ParquetReader(empty_parquet)
+    assert reader.to_dataframe().is_empty()
+    assert reader.to_dicts() == []
+    assert reader.get_sample().is_empty()
+    assert reader.to_arrow_table().num_rows == 0
+    assert reader.query_data("SELECT 1") == []
+
+
+def test_rejects_non_parquet(sample_files):
+    with pytest.raises(ValueError, match="not a Parquet file"):
+        ParquetReader(sample_files["data.csv"])
+
+
+def test_missing_file(nonexistent_parquet):
+    with pytest.raises(FileNotFoundError):
+        ParquetReader(nonexistent_parquet)
+
+
+def test_context_manager(sample_parquet):
+    with ParquetReader(sample_parquet) as reader:
+        reader.query_data(f"SELECT 1 FROM {reader.db_table}")

--- a/tests/parquet_api_tests/test_parquetreader.py
+++ b/tests/parquet_api_tests/test_parquetreader.py
@@ -52,3 +52,8 @@ def test_missing_file(nonexistent_parquet):
 def test_context_manager(sample_parquet):
     with ParquetReader(sample_parquet) as reader:
         reader.query_data(f"SELECT 1 FROM {reader.db_table}")
+
+
+def test_rejects_reserved_source_option(sample_parquet):
+    with pytest.raises(ValueError, match="source"):
+        ParquetReader(sample_parquet, source="bad").to_dataframe()

--- a/tests/parquet_api_tests/test_parquetwriter.py
+++ b/tests/parquet_api_tests/test_parquetwriter.py
@@ -1,0 +1,55 @@
+"""Tests for the ParquetWriter public class."""
+
+# standard library
+from pathlib import Path
+
+# external libraries
+import polars as pl
+
+# local libraries
+from datagrunt import CSVReader, ParquetReader, ParquetWriter
+
+
+def test_write_csv_round_trips_through_csvreader(sample_parquet, tmp_path):
+    out = str(tmp_path / "out.csv")
+    ParquetWriter(sample_parquet).write_csv(out)
+    assert CSVReader(out).to_dataframe().shape == (4, 3)
+
+
+def test_write_all_formats(sample_parquet, tmp_path):
+    writer = ParquetWriter(sample_parquet)
+    json_out = str(tmp_path / "o.json")
+    jsonl_out = str(tmp_path / "o.jsonl")
+    parquet_out = str(tmp_path / "o.parquet")
+    xlsx_out = str(tmp_path / "o.xlsx")
+    writer.write_json(json_out)
+    writer.write_json_newline_delimited(jsonl_out)
+    writer.write_parquet(parquet_out)
+    writer.write_excel(xlsx_out)
+    assert Path(json_out).stat().st_size > 0
+    assert Path(jsonl_out).stat().st_size > 0
+    assert pl.read_parquet(parquet_out).shape == (4, 3)
+    assert pl.read_excel(xlsx_out).shape == (4, 3)
+
+
+def test_write_parquet_compression_passthrough(sample_parquet, tmp_path):
+    out = str(tmp_path / "z.parquet")
+    ParquetWriter(sample_parquet).write_parquet(out, compression="zstd")
+    assert pl.read_parquet(out).shape == (4, 3)
+
+
+def test_normalize_columns(messy_parquet, tmp_path):
+    out = str(tmp_path / "n.csv")
+    ParquetWriter(messy_parquet, normalize_columns=True).write_csv(out)
+    assert pl.read_csv(out).columns == ["first_name", "age"]
+
+
+def test_empty_writes_zero_byte_file(empty_parquet, tmp_path):
+    out = str(tmp_path / "empty_out.csv")
+    ParquetWriter(empty_parquet).write_csv(out)
+    assert Path(out).stat().st_size == 0
+
+
+def test_reader_and_writer_top_level_import():
+    assert ParquetReader is not None
+    assert ParquetWriter is not None


### PR DESCRIPTION
## Summary

Adds first-class Parquet support to datagrunt, mirroring the Excel subsystem (`core/excel_io` + `excel_api`) adapted for Parquet's flat, single-table shape (no sheets). A single canonical Polars-backed engine; DuckDB is used only to back `query_data`. No new dependency — `polars` / `pyarrow` / `duckdb` are already core.

```python
from datagrunt import ParquetReader, ParquetWriter

r = ParquetReader("data.parquet")
r.get_sample(); r.to_dataframe(); r.to_arrow_table(); r.to_dicts()
r.query_data(f"SELECT * FROM {r.db_table} LIMIT 5")
r.to_dataframe(columns=["a", "b"], n_rows=100)   # **read_options -> pl.read_parquet

w = ParquetWriter("data.parquet")
w.write_csv("out.csv"); w.write_json("out.json"); w.write_json_newline_delimited("out.jsonl")
w.write_excel("out.xlsx")
w.write_parquet("recompressed.parquet", compression="zstd")  # **write_options -> Polars writer
```

## Design

- **Single Polars engine** (not multi-engine like CSV): Parquet reads uniformly, so a selectable backend adds surface area with no payoff.
- **No sheet dimension** — flat CSV-style API; reader/writer are a 1:1 mirror of the Excel public surface minus `sheet=`/`all_sheets=`/`.sheets`.
- **Preserve, not transform** — values verbatim; formula-injection (CWE-1236) documented on the writer for spreadsheet-interpreted formats (`write_csv`/`write_excel`), never mutated.
- **Automatic lifecycle** — engine cached on the public object, released by GC; lazy DuckDB connection; `close()`/`with` are optional early-release only.
- Column normalization delegates to the shared `_compute` backend (byte-identical to CSV/Excel; verified on both the Rust default and `DATAGRUNT_DISABLE_RUST=1` Python backend).
- Focused `is_parquet` / `parquet_extensions` added; existing `is_apache` / `apache_extensions` untouched (back-compat). Also mirrors `is_parquet=False` into `PDFComponents`' virtual-file-properties surface (kept the `is_*` parity sweep green).

## Out of scope (deferred)

Parquet metadata accessors (schema/row-groups/compression), lazy `scan_parquet`, partitioned-dataset reads, `avro`, and multi-engine reading.

## Testing

- New `tests/core_tests/parquet_io_tests/` (components, engines, factory) and `tests/parquet_api_tests/` (reader, writer), plus Parquet fixtures.
- Gate green: `uv run pytest tests/ -q` (Rust) **1392 passed**; `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` (Python) **1392 passed**; `ruff check` + `ruff format --check` clean.

Built via spec → plan → per-task TDD with per-task and final whole-branch (Opus) review.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)