### PR TITLE
feat: support consistent Polars kwargs pass-through in to-dataframe [minor]

### DIFF
--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -59,7 +59,7 @@ def _has_midfile_comments(filepath):
     return False
 
 
-def _polars_read_csv(filepath, delimiter, truncate_ragged_lines, n_rows=None):
+def _polars_read_csv(filepath, delimiter, truncate_ragged_lines, n_rows=None, **kwargs):
     """Read a CSV file with Polars using the parity-critical option set.
 
     All three Polars-backed read paths must agree on these parameters.
@@ -74,19 +74,21 @@ def _polars_read_csv(filepath, delimiter, truncate_ragged_lines, n_rows=None):
         truncate_ragged_lines: Whether to silently truncate rows with more
             fields than the header (lenient / ragged mode).
         n_rows: Maximum number of data rows to read, or ``None`` for all.
+        **kwargs: Direct native Polars options overrides.
 
     Returns:
         A Polars DataFrame with all columns kept as their raw string values
         (``infer_schema=False``).
     """
-    return pl.read_csv(
-        filepath,
-        separator=delimiter,
-        truncate_ragged_lines=truncate_ragged_lines,
-        infer_schema=False,
-        n_rows=n_rows,
-        skip_rows=_count_leading_comments(filepath),
-    )
+    options = {
+        "separator": delimiter,
+        "truncate_ragged_lines": truncate_ragged_lines,
+        "infer_schema": False,
+        "n_rows": n_rows,
+        "skip_rows": _count_leading_comments(filepath),
+    }
+    options.update(kwargs)
+    return pl.read_csv(filepath, **options)
 
 
 def _polars_read_to_string_arrow(filepath, delimiter, truncate_ragged_lines, n_rows=None):
@@ -320,13 +322,14 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
             normalize_columns,
         )
 
-    def to_dataframe(self, normalize_columns=None):
+    def to_dataframe(self, normalize_columns=None, **kwargs):
         """
         Converts CSV to a Polars dataframe.
 
         Args:
             normalize_columns (bool or None): Whether to normalize column
             names. ``None`` (default) inherits the instance-level setting.
+            **kwargs: Ignored keyword arguments (for consistent interface).
 
         Returns:
             A Polars dataframe.
@@ -441,12 +444,13 @@ class CSVReaderPolarsEngine(DataFrameDerivedReaderMixin, CSVBaseReaderEngine):
     Class to read CSV files and convert CSV files powered by Polars.
     """
 
-    def _create_dataframe(self, normalize_columns=False, sample=False):
+    def _create_dataframe(self, normalize_columns=False, sample=False, **kwargs):
         """Read the CSV into a Polars dataframe.
 
         Args:
             normalize_columns (bool): Whether to normalize column names.
             sample (bool): When True, read only the leading sample rows.
+            **kwargs: Overrides/options for Polars read_csv.
 
         Returns:
             A Polars dataframe.
@@ -458,11 +462,17 @@ class CSVReaderPolarsEngine(DataFrameDerivedReaderMixin, CSVBaseReaderEngine):
             )
         if self.lenient:
             _check_csv_ragged_and_warn(self.filepath, self.delimiter)
+
+        n_rows = kwargs.pop("n_rows", None)
+        if sample:
+            n_rows = CSVEngineProperties.dataframe_sample_rows
+
         df = _polars_read_csv(
             self.filepath,
             self.delimiter,
             self.lenient,
-            n_rows=CSVEngineProperties.dataframe_sample_rows if sample else None,
+            n_rows=n_rows,
+            **kwargs,
         )
         if normalize_columns:
             df = df.rename(CSVColumnNameNormalizer(self.filepath, columns=df.columns).columns_to_normalized_mapping)
@@ -482,18 +492,19 @@ class CSVReaderPolarsEngine(DataFrameDerivedReaderMixin, CSVBaseReaderEngine):
         resolved = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         return self._create_dataframe(resolved, sample=True)
 
-    def to_dataframe(self, normalize_columns=None):
+    def to_dataframe(self, normalize_columns=None, **kwargs):
         """
         Converts CSV to a Polars dataframe.
 
         Args:
             normalize_columns (bool or None): Whether to normalize column
             names. ``None`` (default) inherits the instance-level setting.
+            **kwargs: Keyword arguments passed to the Polars read_csv.
 
         Returns:
             A Polars dataframe.
         """
-        return self._create_dataframe(_resolve_normalize_columns(self.normalize_columns, normalize_columns))
+        return self._create_dataframe(_resolve_normalize_columns(self.normalize_columns, normalize_columns), **kwargs)
 
     def query_data(self, sql_query, normalize_columns=None):
         """
@@ -839,13 +850,14 @@ class CSVReaderPyArrowEngine(_PyArrowEngineMixin, CSVBaseReaderEngine):
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
         return _arrow_to_polars(self._create_table(normalize_columns, sample=True))
 
-    def to_dataframe(self, normalize_columns=None) -> pl.DataFrame:
+    def to_dataframe(self, normalize_columns=None, **kwargs) -> pl.DataFrame:
         """
         Converts CSV to a Polars dataframe.
 
         Args:
             normalize_columns (bool or None): Whether to normalize column
             names. ``None`` (default) inherits the instance-level setting.
+            **kwargs: Ignored keyword arguments (for consistent interface).
 
         Returns:
             A Polars dataframe.

--- a/src/datagrunt/core/excel_io/engines.py
+++ b/src/datagrunt/core/excel_io/engines.py
@@ -73,6 +73,15 @@ class ExcelReaderEngine:
     def __init__(self, filepath, normalize_columns=False, **read_options):
         self.filepath = Path(filepath)
         self.normalize_columns = normalize_columns
+        if "read_options" in read_options:
+            import warnings
+
+            warnings.warn(
+                "Passing 'read_options' as a dictionary is deprecated and will be removed in a future release. "
+                "Pass the options as keyword arguments directly instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._read_options = read_options
         self._components = ExcelComponents(self.filepath)
         self._frame_cache = {}
@@ -120,6 +129,15 @@ class ExcelReaderEngine:
 
     def to_dataframe(self, sheet=None, normalize_columns=None, **read_options):
         """Return a sheet as a Polars DataFrame."""
+        if "read_options" in read_options:
+            import warnings
+
+            warnings.warn(
+                "Passing 'read_options' as a dictionary is deprecated and will be removed in a future release. "
+                "Pass the options as keyword arguments directly instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self._read_sheet(sheet, normalize_columns, read_options)
 
     def to_arrow_table(self, sheet=None, normalize_columns=None, **read_options):

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -62,12 +62,13 @@ class CSVReader(_CSVEngineBacked):
             return self._return_empty_file_object(pl.DataFrame())
         return self._engine.get_sample(warn_per_call_normalize(normalize_columns))
 
-    def to_dataframe(self, normalize_columns: bool | None = None):
+    def to_dataframe(self, normalize_columns: bool | None = None, **kwargs):
         """Converts CSV to a dataframe.
 
         Args:
             normalize_columns (bool or None): Deprecated per-call override.
             ``None`` (default) inherits the constructor-level setting.
+            **kwargs: Keyword arguments passed to the Polars read_csv.
 
         Returns:
             A Polars DataFrame, or an empty ``pl.DataFrame()`` for empty/blank
@@ -75,7 +76,7 @@ class CSVReader(_CSVEngineBacked):
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pl.DataFrame())
-        return self._engine.to_dataframe(warn_per_call_normalize(normalize_columns))
+        return self._engine.to_dataframe(warn_per_call_normalize(normalize_columns), **kwargs)
 
     def to_arrow_table(self, normalize_columns: bool | None = None) -> pa.Table:
         """Converts CSV to a PyArrow table.

--- a/src/datagrunt/excel_api/excelreader.py
+++ b/src/datagrunt/excel_api/excelreader.py
@@ -29,6 +29,15 @@ class ExcelReader(_ExcelEngineBacked):
                 "n_rows": 100}``). Per-call options override these. The reserved
                 keys ``source``, ``sheet_id``, ``sheet_name`` are not allowed.
         """
+        if "read_options" in read_options:
+            import warnings
+
+            warnings.warn(
+                "Passing 'read_options' as a dictionary is deprecated and will be removed in a future release. "
+                "Pass the options as keyword arguments directly instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         super().__init__(filepath, normalize_columns=normalize_columns, **read_options)
 
     @property
@@ -46,6 +55,15 @@ class ExcelReader(_ExcelEngineBacked):
         """Convert a sheet to a Polars DataFrame (empty frame if empty/blank)."""
         if self.is_empty or self.is_blank:
             return pl.DataFrame()
+        if "read_options" in read_options:
+            import warnings
+
+            warnings.warn(
+                "Passing 'read_options' as a dictionary is deprecated and will be removed in a future release. "
+                "Pass the options as keyword arguments directly instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self._engine.to_dataframe(sheet, normalize_columns, **read_options)
 
     def to_arrow_table(self, sheet=None, normalize_columns: bool | None = None, **read_options) -> pa.Table:

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -491,3 +491,19 @@ class TestCSVReaderContextManager:
         reader.query_data(f"SELECT * FROM {reader.db_table} LIMIT 1")
 
         assert calls["n"] == 1
+
+
+class TestCSVReaderToDataframeKwargs:
+    """Test that CSVReader.to_dataframe() supports flat kwargs passed to Polars."""
+
+    def test_to_dataframe_kwargs_forwarding(self, sample_csv):
+        reader = CSVReader(sample_csv, engine="polars")
+        df = reader.to_dataframe(n_rows=1)
+        assert df.height == 1
+        assert list(df.columns) == ["name", "age", "city"]
+
+        # Test another Polars parameter: has_header=False
+        df_no_header = reader.to_dataframe(has_header=False)
+        # When has_header=False, the first row (the header names) becomes a data row.
+        assert df_no_header.height == 3
+        assert df_no_header.row(0) == ("name", "age", "city")

--- a/tests/excel_api_tests/test_excelreader.py
+++ b/tests/excel_api_tests/test_excelreader.py
@@ -92,3 +92,19 @@ def test_get_sample_empty_workbook_returns_empty_dataframe(empty_xlsx):
     sample = ExcelReader(empty_xlsx).get_sample()
     assert isinstance(sample, pl.DataFrame)
     assert sample.is_empty()
+
+
+def test_excelreader_to_dataframe_flat_kwargs(sample_xlsx):
+    """Verify that flat kwargs are passed to pl.read_excel."""
+    df = ExcelReader(sample_xlsx).to_dataframe(has_header=False)
+    assert df.height == 3  # Header is treated as data row
+    assert df.row(0) == ("name", "age", "city")
+
+
+def test_excelreader_to_dataframe_read_options_deprecation(sample_xlsx):
+    """Verify that passing read_options as a dict raises a DeprecationWarning."""
+    reader = ExcelReader(sample_xlsx)
+    with pytest.warns(DeprecationWarning, match="Passing 'read_options' as a dictionary is deprecated"):
+        df = reader.to_dataframe(read_options={"n_rows": 1})
+
+    assert df.height == 1

--- a/tests/parquet_api_tests/test_parquetreader.py
+++ b/tests/parquet_api_tests/test_parquetreader.py
@@ -57,3 +57,11 @@ def test_context_manager(sample_parquet):
 def test_rejects_reserved_source_option(sample_parquet):
     with pytest.raises(ValueError, match="source"):
         ParquetReader(sample_parquet, source="bad").to_dataframe()
+
+
+def test_parquetreader_to_dataframe_kwargs(sample_parquet):
+    """Verify that flat kwargs are forwarded to pl.read_parquet."""
+    reader = ParquetReader(sample_parquet)
+    df = reader.to_dataframe(n_rows=2)
+    assert df.height == 2
+    assert list(df.columns) == ["name", "age", "city"]


### PR DESCRIPTION
This PR adds flat kwargs forwarding to to_dataframe() for CSVReader, ExcelReader, and ParquetReader, allowing full native access to Polars APIs. It also deprecates the read_options dict in ExcelReader.