### PR TITLE
feat: support Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/tests/pdf_api_tests/test_engine_comparison.py
+++ b/tests/pdf_api_tests/test_engine_comparison.py
@@ -95,9 +95,16 @@ def _elements_by_type(doc: dict) -> dict:
 def _table_cells(doc: dict) -> list:
     cells = []
     for pg in doc.get("document", {}).get("pages", []):
+        page_tables = []
         for el in pg.get("elements", []):
             if el.get("type") == "table":
-                cells.append(el.get("content"))
+                pos = el.get("position", {})
+                x = pos.get("x", 0.0)
+                y = pos.get("y", 0.0)
+                page_tables.append((y, x, el.get("content")))
+        page_tables.sort(key=lambda t: (t[0], t[1]))
+        for _, _, content in page_tables:
+            cells.append(content)
     return cells
 
 


### PR DESCRIPTION
This PR adds the Python 3.14 classifier to pyproject.toml and fixes a layout-sorting non-determinism issue in the engine comparison test.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)