### PR TITLE
feat(pdf): render PDF pages to images (PDFWriter.render_pages_as_images)

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -66,6 +66,60 @@ def _parse_page_native_worker(
         return reader.parse_page(page_index, image_output_dir)
 
 
+# Image formats both writer engines (pdfium via PIL, pymupdf via Pixmap) can
+# emit. Restricting to this shared set keeps the two engines byte-compatible in
+# behavior and lets an unsupported request fail fast (see _normalize_image_format).
+_SUPPORTED_IMAGE_FORMATS = ("png", "jpg", "jpeg")
+_PIL_FORMAT_BY_EXT = {"png": "PNG", "jpg": "JPEG", "jpeg": "JPEG"}
+
+
+def _normalize_image_format(image_format: str) -> tuple:
+    """Return ``(file_extension, pil_format)`` for a requested image format.
+
+    PIL registers JPEG under ``"JPEG"`` (not ``"JPG"``), so ``"jpg"`` maps to the
+    ``"JPEG"`` save handler while keeping the caller's ``.jpg`` file extension on
+    disk. Only formats both engines can write are accepted; an unsupported
+    format is a caller bug and raises ``ValueError`` up front rather than
+    silently yielding an empty result (mirrors ``set_export_filename``).
+    """
+    ext = image_format.lower().lstrip(".")
+    if ext not in _SUPPORTED_IMAGE_FORMATS:
+        raise ValueError(
+            f"Unsupported image_format {image_format!r}. Supported formats: {', '.join(_SUPPORTED_IMAGE_FORMATS)}."
+        )
+    return ext, _PIL_FORMAT_BY_EXT[ext]
+
+
+def _render_pdfium_page_to_file(
+    page, directory: Path, pdf_name: str, page_index: int, dpi: int, ext: str, pil_format: str
+) -> str:
+    """Render one already-opened PDFium page to ``directory``; return its path.
+
+    Shared by the in-process sequential loop and the process-pool worker so the
+    render-and-save step lives in exactly one place (DRY within the PDF domain).
+    """
+    img = page.render_pil(dpi=dpi)
+    out_path = directory / f"{pdf_name}_page_{page_index + 1}.{ext}"
+    img.save(out_path, format=pil_format)
+    return str(out_path)
+
+
+def _render_page_worker(filepath_str: str, page_index: int, output_dir_str: str, dpi: int, image_format: str) -> str:
+    """Process worker function to render a single page to an image using PDFium."""
+    from pathlib import Path
+
+    from datagrunt.core.pdf_io.engines import _normalize_image_format, _render_pdfium_page_to_file
+    from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
+
+    filepath = Path(filepath_str)
+    directory = Path(output_dir_str)
+    pdf_name = filepath.stem
+    ext, pil_format = _normalize_image_format(image_format)
+    with PdfiumDocument(filepath) as doc:
+        with doc.page(page_index) as page:
+            return _render_pdfium_page_to_file(page, directory, pdf_name, page_index, dpi, ext, pil_format)
+
+
 def set_export_filename(default_filename, export_filename=None):
     """Return the export filename if explicitly provided, otherwise the default.
 
@@ -434,6 +488,11 @@ class PDFBaseWriterEngine(ABC):
             pdfcomponents.dedupe_document_images(document, directory)
         return pdfcomponents.collect_image_paths(document)
 
+    @abstractmethod
+    def render_pages_as_images(self, output_dir=None, dpi=300, image_format="png") -> list:
+        """Render each page of the PDF as an image and save to disk."""
+        pass
+
 
 class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
     """Write parsed PDF output (JSON + image files) using PyMuPDF."""
@@ -444,6 +503,45 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
                 self.filepath, workers=self.workers, extraction_config=self.extraction_config
             )
         return self._reader_engine
+
+    def render_pages_as_images(self, output_dir=None, dpi=300, image_format="png") -> list:
+        from datagrunt.core.pdf_io.extraction.pymupdf_backend import _import_pymupdf
+
+        if self.workers > 1:
+            logger.warning(
+                "PyMuPDF renders pages sequentially; the 'workers=%d' setting is ignored. "
+                "Use the pdfium engine for parallel rendering.",
+                self.workers,
+            )
+
+        # Validate the format before any filesystem side effects (fail fast).
+        ext, _ = _normalize_image_format(image_format)
+        pymupdf = _import_pymupdf()
+        directory = Path(output_dir if output_dir else "page_images")
+        directory.mkdir(parents=True, exist_ok=True)
+
+        written_paths = []
+        doc = pymupdf.open(self.filepath)
+        pdf_name = self.filepath.stem
+        try:
+            for idx in range(doc.page_count):
+                # Per-page error isolation: a page that fails to render is logged
+                # and skipped, never aborting the whole batch (project invariant).
+                try:
+                    page = doc[idx]
+                    zoom = dpi / 72.0
+                    mat = pymupdf.Matrix(zoom, zoom)
+                    pix = page.get_pixmap(matrix=mat)
+                    img_data = pix.tobytes(ext)
+                    out_path = directory / f"{pdf_name}_page_{idx + 1}.{ext}"
+                    with open(out_path, "wb") as f:
+                        f.write(img_data)
+                    written_paths.append(str(out_path))
+                except Exception as e:  # noqa: BLE001
+                    logger.warning("Page %d could not be rendered and was skipped: %s", idx + 1, e)
+        finally:
+            doc.close()
+        return written_paths
 
 
 class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
@@ -462,3 +560,60 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
                 extraction_config=self.extraction_config,
             )
         return self._reader_engine
+
+    def render_pages_as_images(self, output_dir=None, dpi=300, image_format="png") -> list:
+        # Validate the format before any filesystem side effects (fail fast).
+        ext, pil_format = _normalize_image_format(image_format)
+        directory = Path(output_dir if output_dir else "page_images")
+        directory.mkdir(parents=True, exist_ok=True)
+
+        with PdfiumDocument(self.filepath) as doc:
+            total_pages = len(doc)
+
+        if self.workers <= 1 or total_pages <= 1 or _is_distributed_env():
+            if self.workers > 1 and _is_distributed_env():
+                logger.warning(
+                    "Distributed environment detected. Defaulting to sequential "
+                    "PDFium execution to prevent multiprocessing overhead."
+                )
+            written_paths = []
+            pdf_name = self.filepath.stem
+            with PdfiumDocument(self.filepath) as doc:
+                for idx in range(total_pages):
+                    # Per-page error isolation: a page that fails to render is
+                    # logged and skipped, never aborting the whole batch.
+                    try:
+                        with doc.page(idx) as page:
+                            written_paths.append(
+                                _render_pdfium_page_to_file(page, directory, pdf_name, idx, dpi, ext, pil_format)
+                            )
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning("Page %d could not be rendered and was skipped: %s", idx + 1, e)
+            return written_paths
+        else:
+            from concurrent.futures import ProcessPoolExecutor, as_completed
+
+            paths_map = {}
+            with ProcessPoolExecutor(max_workers=self.workers) as executor:
+                futures = {
+                    executor.submit(
+                        _render_page_worker,
+                        str(self.filepath),
+                        idx,
+                        str(directory),
+                        dpi,
+                        image_format,
+                    ): idx
+                    for idx in range(total_pages)
+                }
+                for future in as_completed(futures):
+                    idx = futures[future]
+                    # Per-page error isolation applies to the parallel path too:
+                    # a worker that raises is logged and its page skipped, while
+                    # the successfully rendered pages are still returned in order.
+                    try:
+                        paths_map[idx] = future.result()
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning("Page %d could not be rendered and was skipped: %s", idx + 1, e)
+
+            return [paths_map[idx] for idx in sorted(paths_map.keys())]

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -5,6 +5,7 @@ import json
 
 # local libraries
 from datagrunt.core.pdf_io import pdfcomponents
+from datagrunt.core.pdf_io.engines import _normalize_image_format
 from datagrunt.pdf_api._engine_backed import _PDFEngineBacked
 
 
@@ -136,3 +137,37 @@ class PDFWriter(_PDFEngineBacked):
         if self.is_empty:
             return []
         return self._engine.extract_images(output_dir, dedupe)
+
+    def render_pages_as_images(self, output_dir=None, dpi=300, image_format="png"):
+        """Render each page of the PDF as an image and save to disk.
+
+        Args:
+            output_dir (optional, str): Output directory; defaults to page_images.
+            dpi (int, default 300): The resolution in DPI to render the pages.
+            image_format (str, default 'png'): The image format to save. One of
+                'png', 'jpg', or 'jpeg' (case-insensitive); other values raise
+                ValueError.
+
+        Returns:
+            list: Paths of the written page images, in page order. A page that
+            fails to render is logged and skipped rather than aborting the batch.
+
+        Raises:
+            ValueError: If ``image_format`` is unsupported, or if this writer was
+                constructed from a parsed-document dict/JSON (no source PDF to
+                rasterize).
+        """
+        # Validate the format up front so an unsupported value fails fast even
+        # for an empty/dict-backed writer, honoring the documented contract.
+        _normalize_image_format(image_format)
+        # Rendering rasterizes the source PDF's pages, which a parsed-document
+        # dict (or JSON) simply does not contain — fail clearly instead of
+        # silently returning nothing.
+        if self._parsed_dict is not None:
+            raise ValueError(
+                "render_pages_as_images requires the source PDF file; "
+                "it cannot render pages from a parsed document dict."
+            )
+        if self.is_empty:
+            return []
+        return self._engine.render_pages_as_images(output_dir=output_dir, dpi=dpi, image_format=image_format)

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -481,3 +482,173 @@ class TestPDFWriterMinImageDimension:
         # the 20px image is written because the threshold was lowered
         assert images_dir.exists(), "image_output_dir was not created"
         assert any(images_dir.glob("*")), "no image files written to image_output_dir"
+
+
+class TestPDFWriterRenderPagesAsImages:
+    """Tests for rendering PDF pages as images."""
+
+    def test_render_pages_as_images(self, sample_pdf, tmp_path):
+        out = tmp_path / "page_imgs"
+        writer = PDFWriter(sample_pdf, engine="pdfium")
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=150, image_format="png")
+        assert paths
+        assert len(paths) >= 1
+        stem = Path(sample_pdf).stem
+        for idx, p in enumerate(paths):
+            assert os.path.exists(p)
+            assert os.path.basename(p) == f"{stem}_page_{idx + 1}.png"
+
+    def test_render_pages_as_images_pymupdf(self, sample_pdf, tmp_path):
+        out = tmp_path / "page_imgs_pymupdf"
+        writer = PDFWriter(sample_pdf, engine="pymupdf")
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=150, image_format="png")
+        assert paths
+        assert len(paths) >= 1
+        stem = Path(sample_pdf).stem
+        for idx, p in enumerate(paths):
+            assert os.path.exists(p)
+            assert os.path.basename(p) == f"{stem}_page_{idx + 1}.png"
+
+    def test_render_pages_as_images_parallel(self, sample_pdf, tmp_path):
+        out = tmp_path / "page_imgs_parallel"
+        writer = PDFWriter(sample_pdf, engine="pdfium", workers=2)
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=150, image_format="png")
+        assert paths
+        assert len(paths) >= 1
+        stem = Path(sample_pdf).stem
+        for idx, p in enumerate(paths):
+            assert os.path.exists(p)
+            assert os.path.basename(p) == f"{stem}_page_{idx + 1}.png"
+
+    def test_render_pages_as_images_empty_pdf(self, empty_pdf, tmp_path):
+        out = tmp_path / "page_imgs_empty"
+        writer = PDFWriter(empty_pdf)
+        paths = writer.render_pages_as_images(output_dir=str(out))
+        assert paths == []
+
+    @pytest.mark.parametrize("engine", ["pdfium", "pymupdf"])
+    def test_render_pages_as_images_jpg(self, multipage_pdf, tmp_path, engine):
+        """format='jpg' must map to PIL's 'JPEG' handler yet keep the .jpg suffix.
+
+        Regression: the pdfium path called img.save(format='JPG'), which PIL does
+        not register (it registers JPEG), raising KeyError('JPG').
+        """
+        from PIL import Image
+
+        out = tmp_path / f"jpg_imgs_{engine}"
+        writer = PDFWriter(multipage_pdf, engine=engine)
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=100, image_format="jpg")
+        assert len(paths) == 3
+        for p in paths:
+            assert p.endswith(".jpg")
+            assert os.path.exists(p)
+            with Image.open(p) as img:
+                assert img.format == "JPEG"
+
+    def test_render_pages_error_isolation_sequential_pdfium(self, multipage_pdf, tmp_path, monkeypatch):
+        """A single bad page is skipped (logged), never dropping the whole batch."""
+        from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumPage
+
+        original = PdfiumPage.render_pil
+        calls = {"n": 0}
+
+        def flaky_render(self, dpi=300):
+            calls["n"] += 1
+            if calls["n"] == 2:  # second page rendered
+                raise RuntimeError("boom on page 2")
+            return original(self, dpi=dpi)
+
+        monkeypatch.setattr(PdfiumPage, "render_pil", flaky_render)
+
+        out = tmp_path / "iso_pdfium"
+        writer = PDFWriter(multipage_pdf, engine="pdfium")  # workers=1 -> sequential
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=72)
+
+        stem = Path(multipage_pdf).stem
+        assert len(paths) == 2
+        assert not any(os.path.basename(p) == f"{stem}_page_2.png" for p in paths)
+        assert all(os.path.exists(p) for p in paths)
+
+    def test_render_pages_error_isolation_sequential_pymupdf(self, multipage_pdf, tmp_path, monkeypatch):
+        """PyMuPDF path: a single failing page is skipped, the rest are written.
+
+        Patching ``pymupdf.Matrix``/``get_pixmap`` is unsafe (pymupdf runs
+        internal ``isinstance`` checks against those types), so the failure is
+        injected at the per-page file write instead — still inside the
+        engine's per-page try/except.
+        """
+        import builtins
+
+        real_open = builtins.open
+
+        def flaky_open(file, mode="r", *args, **kwargs):
+            if "w" in str(mode) and "_page_2." in str(file):
+                raise RuntimeError("boom writing page 2")
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", flaky_open)
+
+        out = tmp_path / "iso_pymupdf"
+        writer = PDFWriter(multipage_pdf, engine="pymupdf")
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=72)
+
+        stem = Path(multipage_pdf).stem
+        assert len(paths) == 2
+        assert not any(os.path.basename(p) == f"{stem}_page_2.png" for p in paths)
+        assert all(os.path.exists(p) for p in paths)
+
+    def test_render_pages_parallel_ordering(self, multipage_pdf, tmp_path):
+        """Parallel (pdfium process pool) returns all pages in page order."""
+        out = tmp_path / "parallel_order"
+        writer = PDFWriter(multipage_pdf, engine="pdfium", workers=2)
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=72)
+
+        stem = Path(multipage_pdf).stem
+        assert len(paths) == 3
+        for idx, p in enumerate(paths):
+            assert os.path.exists(p)
+            assert os.path.basename(p) == f"{stem}_page_{idx + 1}.png"
+
+    def test_render_pages_error_isolation_parallel_pdfium(self, multipage_pdf, tmp_path):
+        """Parallel path: a worker whose page fails is skipped, others survive.
+
+        The worker runs in a subprocess (monkeypatch can't reach it), so the
+        fault is injected deterministically at the filesystem: a *directory* is
+        pre-created at page 2's output path, so only that worker's ``img.save``
+        raises. The parallel branch must catch ``future.result()`` and return
+        the other pages in order.
+        """
+        out = tmp_path / "iso_parallel"
+        out.mkdir(parents=True)
+        stem = Path(multipage_pdf).stem
+        # A directory where the file should go makes page 2's save fail only.
+        (out / f"{stem}_page_2.png").mkdir()
+
+        writer = PDFWriter(multipage_pdf, engine="pdfium", workers=2)
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=72)
+
+        assert len(paths) == 2
+        assert not any(os.path.basename(p) == f"{stem}_page_2.png" for p in paths)
+        assert all(os.path.exists(p) for p in paths)
+
+    @pytest.mark.parametrize("engine", ["pdfium", "pymupdf"])
+    def test_render_pages_unsupported_format_raises(self, sample_pdf, tmp_path, engine):
+        """An unsupported image_format is a caller bug -> fail fast, don't return []."""
+        writer = PDFWriter(sample_pdf, engine=engine)
+        with pytest.raises(ValueError, match="Unsupported image_format"):
+            writer.render_pages_as_images(output_dir=str(tmp_path / "bad"), image_format="pngg")
+
+    def test_render_pages_unsupported_format_raises_even_when_empty(self, empty_pdf, tmp_path):
+        """The format is validated before the is_empty short-circuit (documented contract)."""
+        writer = PDFWriter(empty_pdf)
+        with pytest.raises(ValueError, match="Unsupported image_format"):
+            writer.render_pages_as_images(output_dir=str(tmp_path / "bad"), image_format="pngg")
+
+    def test_render_pages_dict_constructed_writer_raises(self, sample_pdf, tmp_path):
+        """A dict/JSON-constructed writer has no source file to render pages from."""
+        from datagrunt.pdf_api.pdfreader import PDFReader
+
+        parsed = PDFReader(sample_pdf).to_dicts()
+        writer = PDFWriter(parsed)
+        with pytest.raises(ValueError):
+            writer.render_pages_as_images(output_dir=str(tmp_path / "nope"))


### PR DESCRIPTION
## Summary

Adds `PDFWriter.render_pages_as_images(output_dir, dpi, image_format)` — rasterize each page of a PDF to an image file, on both the **pdfium** and **pymupdf** engines (sequential, plus a process-pool parallel path for pdfium). This lands the capability correctly, fixing the defects found in review before merge.

## What's included

**Correctness**
- **Shared `_normalize_image_format`** — `jpg`/`jpeg` map to PIL's `"JPEG"` save handler (PIL does not register `"JPG"`, which previously crashed the pdfium path with `KeyError('JPG')`). Both engines now behave identically over the supported set (`png`/`jpg`/`jpeg`).
- **Fail-fast on a bad argument** — an unsupported `image_format` raises `ValueError` up front (validated even for empty/dict-backed writers), instead of silently returning `[]`.
- **Per-page error isolation (project invariant)** — in every branch (sequential pdfium, sequential pymupdf, and the parallel `future.result()` path) a page that fails to render is logged and skipped, never aborting the batch.
- **Dict/JSON-constructed writer** raises a clear `ValueError` (no source PDF to rasterize) rather than a bare `FileNotFoundError`.

**Design / hygiene**
- Automatic resource lifecycle — every pdfium/pymupdf handle is context-managed or released in a `finally`; no caller `.close()` required.
- Shared `_render_pdfium_page_to_file` removes duplication between the in-process loop and the process worker (DRY within the PDF domain).
- pymupdf warns when `workers > 1` (renders sequentially), mirroring the reader.

## Testing
- `uv run pytest tests/ -q` → **1410 passed** (Rust backend)
- `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` → **1410 passed** (Python backend)
- `ruff check` + `ruff format --check .` clean
- New tests: both engines, `jpg`→JPEG, multi-page ordering, **sequential and parallel** error isolation, unsupported-format (incl. empty PDF), and the dict-constructed guard.

Pure-Python PDF subsystem — no Rust/parity impact.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)