### PR TITLE
ci(security): retire long-lived PAT in bump-version via GitHub App token

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -28,14 +28,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Mint a short-lived token from a GitHub App (contents:write) instead of a
+      # long-lived PAT (#242). The token is generated per run and cannot expire.
+      - name: Mint a GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.BUMP_APP_ID }}
+          private-key: ${{ secrets.BUMP_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          # TODO(#242): retire this long-lived PAT (GitHub App token or
-          # fine-grained scoped PAT). Tracked separately — needs maintainer
-          # provisioning.
-          token: ${{ secrets.PAT_TOKEN }}
+          # Check out with the App token so the bump commit/push is made with it:
+          # a push made with the default GITHUB_TOKEN does NOT trigger the
+          # downstream "Publish to PyPI" workflow_run, but an App-token push does.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
## Summary

Retires the long-lived classic PAT (`PAT_TOKEN`) that broke the release pipeline when it silently expired. The `Bump Version` checkout now mints a **short-lived token per run** from a GitHub App (`contents:write`), via SHA-pinned `actions/create-github-app-token@v3.2.0`.

An App-token push still triggers the downstream **Publish to PyPI** `workflow_run` (a push made with the default `GITHUB_TOKEN` does not), so the auto-bump → publish-on-`src/`-merge behavior is **unchanged** — but there is no longer any secret that can expire.

Implements option 1 (recommended) from #242.

## ⚠️ Required maintainer provisioning (before/at merge)

This workflow will fail until two repo secrets exist:

1. **Create a GitHub App** (Settings → Developer settings → GitHub Apps → New):
   - Repository permission: **Contents → Read and write** (only this).
   - No webhook needed (uncheck Active).
   - Generate a **private key** (.pem) and note the **App ID**.
2. **Install the App** on `pmgraham/datagrunt` (Only select repositories → this repo).
3. **Add repo secrets** (Settings → Secrets and variables → Actions):
   - `BUMP_APP_ID` = the App ID
   - `BUMP_APP_PRIVATE_KEY` = the full contents of the .pem private key
4. If `main` is a **protected branch**, allow the App to push to it (branch protection → allow the app / bypass), since the bump commit is pushed to `main`.

After that, `PAT_TOKEN` can be deleted.

## Testing note

The bump→publish chain can't be exercised by PR CI without performing a real release. Recommend validating on the next intended release via `Bump Version` → **workflow_dispatch** (choose `part`), which will bump + publish. I can watch that run with you.

## Deferred (logged separately)

`auto-publish-site.yml` uses the same long-lived-PAT pattern (`SITE_DEPLOY_TOKEN`) and an unpinned `actions/checkout@v4` — same fragility class, tracked as its own issue rather than expanding this PR.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)