### PR TITLE
ci(security): retire SITE_DEPLOY_TOKEN PAT via dedicated GitHub App + SHA-pin actions

### DIFF
--- a/.github/workflows/auto-publish-site.yml
+++ b/.github/workflows/auto-publish-site.yml
@@ -13,20 +13,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout datagrunt
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: datagrunt
           fetch-depth: 0
 
+      # Mint a short-lived token for the sister datagrunt-site repo from a
+      # dedicated GitHub App (contents:write on datagrunt-site) instead of a
+      # long-lived PAT (#271). The default GITHUB_TOKEN cannot write another repo.
+      - name: Mint a GitHub App token for datagrunt-site
+        id: site-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SITE_APP_ID }}
+          private-key: ${{ secrets.SITE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: datagrunt-site
+
       - name: Checkout datagrunt-site
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: pmgraham/datagrunt-site
-          token: ${{ secrets.SITE_DEPLOY_TOKEN }}
+          token: ${{ steps.site-token.outputs.token }}
           path: datagrunt-site
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary

Retires the last long-lived PAT in the CI setup (`SITE_DEPLOY_TOKEN`), which `auto-publish-site.yml` used to push generated docs/blog posts to the sister **datagrunt-site** repo. It now mints a **short-lived token per run** from a **dedicated GitHub App** (`contents:write` scoped to datagrunt-site only), via SHA-pinned `actions/create-github-app-token@v3.2.0` with `owner`/`repositories` targeting the site repo.

Same pattern as #242/#270 — but a separate App (least privilege: each App writes exactly one repo). Also SHA-pins the previously floating `actions/checkout` and `astral-sh/setup-uv` in this workflow (per #175).

## ⚠️ Required maintainer provisioning (before/at merge)

This workflow will fail until two repo secrets exist on **datagrunt** (not the site repo):

1. **Create a GitHub App** (Settings → Developer settings → GitHub Apps → New):
   - Repository permission: **Contents → Read and write** (only this).
   - Uncheck webhook **Active**. Generate a **private key**; note the **App ID**.
2. **Install the App on `pmgraham/datagrunt-site`** (Only select repositories → datagrunt-site).
3. **Add repo secrets** on `pmgraham/datagrunt` (Settings → Secrets and variables → Actions):
   - `SITE_APP_ID` = the App ID
   - `SITE_APP_PRIVATE_KEY` = the full `.pem` contents
4. After it's verified, delete the old `SITE_DEPLOY_TOKEN` secret.

## Testing note

This workflow only runs on a `v*` tag push (i.e. a release). It'll be exercised on the next release's docs auto-publish; I can watch that run. No PR CI path fully exercises it.

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)