### PR TITLE
fix(pdf): zero-pad numbers in output image filenames

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -99,7 +99,8 @@ def _render_pdfium_page_to_file(
     render-and-save step lives in exactly one place (DRY within the PDF domain).
     """
     img = page.render_pil(dpi=dpi)
-    out_path = directory / f"{pdf_name}_page_{page_index + 1}.{ext}"
+    # Zero-padded so directory listings sort in page order (page_02 < page_10).
+    out_path = directory / f"{pdf_name}_page_{page_index + 1:02d}.{ext}"
     img.save(out_path, format=pil_format)
     return str(out_path)
 
@@ -533,7 +534,8 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
                     mat = pymupdf.Matrix(zoom, zoom)
                     pix = page.get_pixmap(matrix=mat)
                     img_data = pix.tobytes(ext)
-                    out_path = directory / f"{pdf_name}_page_{idx + 1}.{ext}"
+                    # Zero-padded to match the pdfium engine's filenames.
+                    out_path = directory / f"{pdf_name}_page_{idx + 1:02d}.{ext}"
                     with open(out_path, "wb") as f:
                         f.write(img_data)
                     written_paths.append(str(out_path))

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -17,6 +17,7 @@ from datagrunt.core.pdf_io import pdfcomponents
 from datagrunt.core.pdf_io.extraction import PdfiumBackend, PdfiumNativeReader, PyMuPDFBackend
 from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumDocument
+from datagrunt.core.pdf_io.filenames import page_image_filename
 
 logger = logging.getLogger(__name__)
 
@@ -99,8 +100,7 @@ def _render_pdfium_page_to_file(
     render-and-save step lives in exactly one place (DRY within the PDF domain).
     """
     img = page.render_pil(dpi=dpi)
-    # Zero-padded so directory listings sort in page order (page_02 < page_10).
-    out_path = directory / f"{pdf_name}_page_{page_index + 1:02d}.{ext}"
+    out_path = directory / page_image_filename(pdf_name, page_index, ext)
     img.save(out_path, format=pil_format)
     return str(out_path)
 
@@ -534,8 +534,7 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
                     mat = pymupdf.Matrix(zoom, zoom)
                     pix = page.get_pixmap(matrix=mat)
                     img_data = pix.tobytes(ext)
-                    # Zero-padded to match the pdfium engine's filenames.
-                    out_path = directory / f"{pdf_name}_page_{idx + 1:02d}.{ext}"
+                    out_path = directory / page_image_filename(pdf_name, idx, ext)
                     with open(out_path, "wb") as f:
                         f.write(img_data)
                     written_paths.append(str(out_path))

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from datagrunt.core.pdf_io.extraction.config import _DEFAULT_MIN_IMAGE_DIMENSION
 from datagrunt.core.pdf_io.extraction.shapes import BBox, ImageBlock, TextItem
+from datagrunt.core.pdf_io.filenames import embedded_image_filename
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +196,8 @@ class PdfiumPage:
             bbox = self._display_box(left, bottom, right, top, rotation, disp_w, disp_h)
             file_path, fmt = None, "png"
             if output_dir:
-                written = self._extract_image(obj, Path(output_dir) / f"{name_prefix}_page{page_number}_img{idx}")
+                image_stem = embedded_image_filename(name_prefix, page_number, idx)
+                written = self._extract_image(obj, Path(output_dir) / image_stem)
                 if written is not None:
                     file_path, fmt = str(written), (written.suffix.lstrip(".") or "png")
             yield ImageBlock(bbox=bbox, file_path=file_path, width_px=px_w, height_px=px_h, fmt=fmt)

--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -9,6 +9,7 @@ from datagrunt.core.pdf_io.extraction.ocr import ocr_data_to_blocks
 from datagrunt.core.pdf_io.extraction.pdfium_document import ENCRYPTED_PDF_MESSAGE
 from datagrunt.core.pdf_io.extraction.shapes import BBox, ImageBlock, PageAnalysis, TextBlock
 from datagrunt.core.pdf_io.extraction.text_block_builder import classify_by_median, page_median_size
+from datagrunt.core.pdf_io.filenames import embedded_image_filename
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +299,7 @@ class PyMuPDFBackend(_ThreadLocalDocSession, ExtractionBackend):
         if output_dir:
             import os
 
-            file_path = os.path.join(output_dir, f"{name_prefix}_page{page_number}_img{idx}.{ext}")
+            file_path = os.path.join(output_dir, embedded_image_filename(name_prefix, page_number, idx, ext))
             with open(file_path, "wb") as f:
                 f.write(image_bytes)
         return ImageBlock(bbox=bbox, file_path=file_path, width_px=width, height_px=height, fmt=ext)

--- a/src/datagrunt/core/pdf_io/filenames.py
+++ b/src/datagrunt/core/pdf_io/filenames.py
@@ -1,0 +1,26 @@
+"""Output-filename builders for the PDF domain.
+
+Single source of truth for the numbering convention: every number embedded in
+an output filename is 1-based and zero-padded to two digits so directory
+listings sort in page order (``page_02`` < ``page_10``).
+"""
+
+
+def _ordinal(index: int) -> str:
+    """Return the 1-based, zero-padded filename label for a 0-based index."""
+    return f"{index + 1:02d}"
+
+
+def page_image_filename(name_prefix: str, page_index: int, ext: str) -> str:
+    """Return the filename for a full-page render, e.g. ``report_page_01.png``."""
+    return f"{name_prefix}_page_{_ordinal(page_index)}.{ext}"
+
+
+def embedded_image_filename(name_prefix: str, page_index: int, image_index: int, ext: str | None = None) -> str:
+    """Return the filename for an extracted embedded image, e.g. ``report_page01_img01.png``.
+
+    With ``ext=None`` the bare stem is returned, for writers that append the
+    extension themselves (pdfium's image extractor).
+    """
+    stem = f"{name_prefix}_page{_ordinal(page_index)}_img{_ordinal(image_index)}"
+    return f"{stem}.{ext}" if ext else stem

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,6 +269,23 @@ def small_image_pdf(tmp_path):
 
 
 @pytest.fixture
+def two_page_image_pdf(tmp_path):
+    """Create a 2-page PDF with one 100px image on each page."""
+    import pymupdf
+
+    doc = pymupdf.open()
+    for _ in range(2):
+        page = doc.new_page(width=612, height=792)
+        pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 100, 100))
+        pix.set_rect(pix.irect, (255, 0, 0))
+        page.insert_image(pymupdf.Rect(72, 200, 172, 300), stream=pix.tobytes("png"))
+    pdf_path = tmp_path / "imagepages.pdf"
+    doc.save(str(pdf_path))
+    doc.close()
+    return str(pdf_path)
+
+
+@pytest.fixture
 def multipage_small_image_pdf(tmp_path):
     """Create a 2-page PDF; each page's only image is below the 40px threshold."""
     import pymupdf

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_backend.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_backend.py
@@ -24,6 +24,15 @@ class TestPdfiumBackend:
         assert imgs and all(isinstance(i, ImageBlock) for i in imgs)
         assert imgs[0].file_path is not None
 
+    def test_extracted_image_filenames_one_based_zero_padded(self, two_page_image_pdf, tmp_path):
+        """Extracted-image names use 1-based, zero-padded page/img numbers
+        (page02_img01), matching render_pages_as_images so listings sort."""
+        from pathlib import Path
+
+        out = tmp_path / "imgs"
+        imgs = PdfiumBackend(two_page_image_pdf).extract_images(1, output_dir=str(out), name_prefix="doc")
+        assert [Path(i.file_path).stem for i in imgs] == ["doc_page02_img01"]
+
     def test_ocr(self, scanned_pdf, tesseract_available):
         if not tesseract_available:
             pytest.skip("tesseract not available")

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pymupdf_backend.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pymupdf_backend.py
@@ -21,6 +21,15 @@ class TestPyMuPDFBackend:
         imgs = PyMuPDFBackend(sample_pdf).extract_images(0, output_dir=str(tmp_path))
         assert all(isinstance(i, ImageBlock) for i in imgs)
 
+    def test_extracted_image_filenames_one_based_zero_padded(self, two_page_image_pdf, tmp_path):
+        """Extracted-image names use 1-based, zero-padded page/img numbers
+        (page02_img01), matching render_pages_as_images so listings sort."""
+        from pathlib import Path
+
+        out = tmp_path / "imgs"
+        imgs = PyMuPDFBackend(two_page_image_pdf).extract_images(1, output_dir=str(out), name_prefix="doc")
+        assert [Path(i.file_path).stem for i in imgs] == ["doc_page02_img01"]
+
     def test_missing_file_raises(self):
         with pytest.raises(FileNotFoundError):
             PyMuPDFBackend("nope.pdf")

--- a/tests/core_tests/pdf_io_tests/test_filenames.py
+++ b/tests/core_tests/pdf_io_tests/test_filenames.py
@@ -1,0 +1,26 @@
+"""Tests for the PDF output-filename builders (single source of the numbering convention)."""
+
+from datagrunt.core.pdf_io.filenames import embedded_image_filename, page_image_filename
+
+
+class TestPageImageFilename:
+    def test_first_page_is_one_based_and_zero_padded(self):
+        assert page_image_filename("report", 0, "png") == "report_page_01.png"
+
+    def test_tenth_page_sorts_after_second(self):
+        names = [page_image_filename("report", i, "png") for i in range(10)]
+        assert names[-1] == "report_page_10.png"
+        assert sorted(names) == names
+
+
+class TestEmbeddedImageFilename:
+    def test_page_and_image_numbers_are_one_based_and_zero_padded(self):
+        assert embedded_image_filename("report", 0, 0, "png") == "report_page01_img01.png"
+        assert embedded_image_filename("report", 1, 2, "jpg") == "report_page02_img03.jpg"
+
+    def test_without_extension_returns_stem(self):
+        assert embedded_image_filename("report", 9, 10) == "report_page10_img11"
+
+    def test_names_sort_in_page_then_image_order(self):
+        names = [embedded_image_filename("doc", p, i, "png") for p in range(11) for i in range(11)]
+        assert sorted(names) == names

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -496,7 +496,7 @@ class TestPDFWriterRenderPagesAsImages:
         stem = Path(sample_pdf).stem
         for idx, p in enumerate(paths):
             assert os.path.exists(p)
-            assert os.path.basename(p) == f"{stem}_page_{idx + 1}.png"
+            assert os.path.basename(p) == f"{stem}_page_{idx + 1:02d}.png"
 
     def test_render_pages_as_images_pymupdf(self, sample_pdf, tmp_path):
         out = tmp_path / "page_imgs_pymupdf"
@@ -507,7 +507,7 @@ class TestPDFWriterRenderPagesAsImages:
         stem = Path(sample_pdf).stem
         for idx, p in enumerate(paths):
             assert os.path.exists(p)
-            assert os.path.basename(p) == f"{stem}_page_{idx + 1}.png"
+            assert os.path.basename(p) == f"{stem}_page_{idx + 1:02d}.png"
 
     def test_render_pages_as_images_parallel(self, sample_pdf, tmp_path):
         out = tmp_path / "page_imgs_parallel"
@@ -518,7 +518,7 @@ class TestPDFWriterRenderPagesAsImages:
         stem = Path(sample_pdf).stem
         for idx, p in enumerate(paths):
             assert os.path.exists(p)
-            assert os.path.basename(p) == f"{stem}_page_{idx + 1}.png"
+            assert os.path.basename(p) == f"{stem}_page_{idx + 1:02d}.png"
 
     def test_render_pages_as_images_empty_pdf(self, empty_pdf, tmp_path):
         out = tmp_path / "page_imgs_empty"
@@ -566,7 +566,7 @@ class TestPDFWriterRenderPagesAsImages:
 
         stem = Path(multipage_pdf).stem
         assert len(paths) == 2
-        assert not any(os.path.basename(p) == f"{stem}_page_2.png" for p in paths)
+        assert not any(os.path.basename(p) == f"{stem}_page_02.png" for p in paths)
         assert all(os.path.exists(p) for p in paths)
 
     def test_render_pages_error_isolation_sequential_pymupdf(self, multipage_pdf, tmp_path, monkeypatch):
@@ -582,7 +582,7 @@ class TestPDFWriterRenderPagesAsImages:
         real_open = builtins.open
 
         def flaky_open(file, mode="r", *args, **kwargs):
-            if "w" in str(mode) and "_page_2." in str(file):
+            if "w" in str(mode) and "_page_02." in str(file):
                 raise RuntimeError("boom writing page 2")
             return real_open(file, mode, *args, **kwargs)
 
@@ -594,7 +594,7 @@ class TestPDFWriterRenderPagesAsImages:
 
         stem = Path(multipage_pdf).stem
         assert len(paths) == 2
-        assert not any(os.path.basename(p) == f"{stem}_page_2.png" for p in paths)
+        assert not any(os.path.basename(p) == f"{stem}_page_02.png" for p in paths)
         assert all(os.path.exists(p) for p in paths)
 
     def test_render_pages_parallel_ordering(self, multipage_pdf, tmp_path):
@@ -607,7 +607,7 @@ class TestPDFWriterRenderPagesAsImages:
         assert len(paths) == 3
         for idx, p in enumerate(paths):
             assert os.path.exists(p)
-            assert os.path.basename(p) == f"{stem}_page_{idx + 1}.png"
+            assert os.path.basename(p) == f"{stem}_page_{idx + 1:02d}.png"
 
     def test_render_pages_error_isolation_parallel_pdfium(self, multipage_pdf, tmp_path):
         """Parallel path: a worker whose page fails is skipped, others survive.
@@ -622,14 +622,39 @@ class TestPDFWriterRenderPagesAsImages:
         out.mkdir(parents=True)
         stem = Path(multipage_pdf).stem
         # A directory where the file should go makes page 2's save fail only.
-        (out / f"{stem}_page_2.png").mkdir()
+        (out / f"{stem}_page_02.png").mkdir()
 
         writer = PDFWriter(multipage_pdf, engine="pdfium", workers=2)
         paths = writer.render_pages_as_images(output_dir=str(out), dpi=72)
 
         assert len(paths) == 2
-        assert not any(os.path.basename(p) == f"{stem}_page_2.png" for p in paths)
+        assert not any(os.path.basename(p) == f"{stem}_page_02.png" for p in paths)
         assert all(os.path.exists(p) for p in paths)
+
+    @pytest.mark.parametrize("engine", ["pdfium", "pymupdf"])
+    def test_render_pages_filenames_zero_padded_and_sortable(self, tmp_path, engine):
+        """Page numbers are zero-padded so filenames sort in page order.
+
+        Regression: unpadded page numbers made a 10+ page document's files
+        sort lexicographically as page_1, page_10, page_2, ...
+        """
+        import pymupdf
+
+        pdf_path = tmp_path / "tenpage.pdf"
+        doc = pymupdf.open()
+        for n in range(1, 11):
+            page = doc.new_page(width=612, height=792)
+            page.insert_text((72, 72), f"Page Marker {n}", fontsize=18)
+        doc.save(str(pdf_path))
+        doc.close()
+
+        out = tmp_path / f"padded_{engine}"
+        writer = PDFWriter(str(pdf_path), engine=engine)
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=72)
+
+        names = [os.path.basename(p) for p in paths]
+        assert names == [f"tenpage_page_{n:02d}.png" for n in range(1, 11)]
+        assert sorted(names) == names
 
     @pytest.mark.parametrize("engine", ["pdfium", "pymupdf"])
     def test_render_pages_unsupported_format_raises(self, sample_pdf, tmp_path, engine):


### PR DESCRIPTION
## Summary

Output image filenames sorted lexicographically out of page order (`page_1, page_10, page_2, …`). All numbered output filenames now follow one convention — **1-based, zero-padded to two digits** — defined in one place, `core/pdf_io/filenames.py`:

- **Rendered pages** (`render_pages_as_images`, both engines): `report_page_1.png` → `report_page_01.png`.
- **Extracted embedded images** (both extraction backends): `report_page0_img0.png` → `report_page01_img01.png`. These were previously 0-based and unpadded — inconsistent with rendered pages, the unified schema's 1-based `page` field, and element ids.

Both engines produce identical filenames, built through the shared `page_image_filename` / `embedded_image_filename` helpers (DRY within the PDF domain).

## Tests

- New regression test: a 10-page document's rendered filenames equal the padded names and sort lexicographically in page order (both engines).
- New backend tests: extracted image on page 2 is named `doc_page02_img01` (both backends).
- Unit tests for the filename helpers, including sortability across 10+ pages/images.
- Updated existing assertions that pinned the old names.

## Gates

- `uv run pytest tests/ -q` — 1419 passed
- `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` — 1419 passed
- `ruff check` + `ruff format --check` — clean
- No Rust changes.

## Note

Two-digit padding covers documents up to 99 pages; 100+ page documents would need wider padding (deferred, noted in the issue).

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)