### PR TITLE
fix(ci): docs & blog workflow never self-triggered on releases

### DIFF
--- a/.github/workflows/auto-publish-site.yml
+++ b/.github/workflows/auto-publish-site.yml
@@ -1,9 +1,19 @@
 name: Auto Update Docs & Blog
 
 on:
+  # Chain off the version bump like Publish to PyPI does. A tag trigger cannot
+  # work for releases: bumpver's tags point at the bump commit, whose
+  # "[skip ci]" message suppresses all push-triggered workflows (#275).
+  workflow_run:
+    workflows: ["Bump Version"]
+    types: [completed]
+    branches: [main]
+  # Manual fallbacks: dispatch from the Actions tab, or push a v-prefixed tag
+  # at a commit without "[skip ci]" (how releases were published before #275).
+  workflow_dispatch:
   push:
     tags:
-      - 'v*'  # Triggers whenever a version release tag (e.g., v4.4.1) is pushed
+      - 'v*'
 
 permissions:
   contents: write
@@ -11,6 +21,9 @@ permissions:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    if: >-
+      ${{ github.event_name != 'workflow_run' ||
+          github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout datagrunt
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -49,8 +62,16 @@ jobs:
       - name: Run Antigravity Workflow
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        # Diff against the previous release tag so the post covers the whole
+        # release, not just the commit before HEAD. Tags for the version being
+        # released are excluded so a backfill run (HEAD already tagged) still
+        # finds the prior release; with no prior tag, fall back to HEAD~1.
         run: |
-          python datagrunt/scripts/antigravity_workflow.py --pre-merge-commit HEAD~1
+          VERSION=$(grep -m1 '^current_version = ' datagrunt/pyproject.toml | cut -d'"' -f2)
+          PREV_TAG=$(git -C datagrunt describe --tags --abbrev=0 \
+            --exclude="$VERSION" --exclude="v$VERSION" HEAD 2>/dev/null || echo "HEAD~1")
+          echo "Documenting version $VERSION (diff base: $PREV_TAG)"
+          python datagrunt/scripts/antigravity_workflow.py --pre-merge-commit "$PREV_TAG"
 
       - name: Commit and Push Docs Update
         working-directory: datagrunt-site

--- a/.github/workflows/auto-publish-site.yml
+++ b/.github/workflows/auto-publish-site.yml
@@ -79,5 +79,5 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add content/
-          git diff-index --quiet HEAD || git commit -m "docs: draft release blog post for version $(git log -n 1 --format=%s)"
+          git diff-index --quiet HEAD || git commit -m "docs: release blog post for version $(git log -n 1 --format=%s)"
           git push origin main

--- a/scripts/antigravity_workflow.py
+++ b/scripts/antigravity_workflow.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Antigravity workflow script to run the AI agent that updates the doc site and drafts the release blog post."""
+"""Antigravity workflow script to run the AI agent that updates the doc site and publishes the release blog post."""
 
 import argparse
 import asyncio
@@ -59,23 +59,30 @@ async def run_agent(version, commit_log, file_stat, git_diff, repo_dir):
         "You are a technical writer and release coordination agent for Datagrunt.\n"
         f"The current local date is: {datetime.now().strftime('%Y-%m-%d')}.\n\n"
         "Your goal is to:\n"
-        "1. Analyze the git diff, file statistics, and commit log of the datagrunt codebase (located at `/Users/pmgraham/projects/datagrunt`).\n"
+        "1. Analyze the git diff, file statistics, and commit log of the datagrunt codebase "
+        "(located at `/Users/pmgraham/projects/datagrunt`).\n"
         "2. Identify new features, bug fixes, performance improvements, or breaking changes.\n"
-        "3. Update the documentation in the Hugo site located at `/Users/pmgraham/projects/datagrunt-site/content/docs/_index.md` or other files. You must read the existing documentation first if you want to update it accurately. Ensure you format links and structures using Markdown.\n"
-        "4. Write a release blog post under `/Users/pmgraham/projects/datagrunt-site/content/blog/2026/june/` (or current year/month folder as appropriate). Use the format `datagrunt-<version>-<short-description>.md`.\n"
+        "3. Update the documentation in the Hugo site located at "
+        "`/Users/pmgraham/projects/datagrunt-site/content/docs/_index.md` or other files. You must read the "
+        "existing documentation first if you want to update it accurately. Ensure you format links and "
+        "structures using Markdown.\n"
+        "4. Write a release blog post under `/Users/pmgraham/projects/datagrunt-site/content/blog/2026/june/` "
+        "(or current year/month folder as appropriate). Use the format `datagrunt-<version>-<short-description>.md`.\n"
         "   - The blog post must have front matter at the top: \n"
         "     ---\n"
         '     title: "Datagrunt <version>: <engaging headline>"\n'
         "     date: <YYYY-MM-DD>\n"
-        "     draft: true\n"
+        "     draft: false\n"
         '     author: "Martin Graham"\n'
         '     author_email: "datagrunt@datagrunt.io"\n'
         '     description: "<engaging description of release highlights>"\n'
         '     tags: ["python", "csv", "data-engineering", "release-notes"]\n'
         "     ---\n"
-        "   - The post should have a structured, premium technical style with code snippets explaining how to use new features.\n"
-        "5. Output a summary of the files updated and created (including their absolute paths) and a brief overview of the content generated.\n"
-        "6. Do not mark the blog post draft: false yet. The user will review and approve it."
+        "   - The post should have a structured, premium technical style with code snippets explaining "
+        "how to use new features.\n"
+        "5. Output a summary of the files updated and created (including their absolute paths) and a brief "
+        "overview of the content generated.\n"
+        "6. Publish the post immediately (draft: false). Never future-date it; Hugo skips posts dated after the build."
     )
 
     # Check if using Vertex AI


### PR DESCRIPTION
## Problem

`Auto Update Docs & Blog` listened only for `v*` tag pushes, but the release pipeline (bumpver) pushes **unprefixed** tags (`4.5.1`) pointing at the bump commit, whose skip-ci directive suppresses all push-triggered workflows — including tag pushes. The automation has never self-triggered; the only successful run rode on a manually pushed `v4.5.0` tag. Confirmed empirically: a manual `v4.5.1` at the bump commit (matching the existing `v*` pattern) produced no run.

## Fix

- **Trigger via `workflow_run`** on `Bump Version` completing successfully on main — the same chaining pattern `Publish to PyPI` already uses (and which fired correctly for 4.5.1 today). Skip-ci directives do not affect `workflow_run` events.
- **Add `workflow_dispatch`** for manual and backfill runs; `v*` tag pushes remain as a manual fallback.
- **Diff base = previous release tag** instead of `HEAD~1`: the workflow computes `git describe --tags --exclude=<current version>` so the generated post covers the entire release. Excluding the current version's tags means a backfill run (where HEAD is already tagged) still finds the prior release; with no prior tag it falls back to `HEAD~1`.
- **Publish immediately** (#277): the Antigravity agent now emits `draft: false` instead of holding posts for manual review, and is reminded never to future-date posts (Hugo skips them).

Verified locally against the real repo state:
- pre-bump (releasing 4.5.0): base `4.4.1`, diff spans all 4.5.0 commits
- post-bump (releasing 4.5.1): base `v4.5.0`, diff spans exactly the 4.5.1 release

No injection surface added: the workflow interpolates only secrets/step outputs in `with:`/`env:`; the tag name is never used in `run:` commands.

Note: merging this does **not** re-trigger Bump Version (its path filter is `src/**`/`rust/**`). After merge, a one-time `workflow_dispatch` backfills the 4.5.1 docs/blog.

Closes #275
Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)