### PR TITLE
fix(ci): use datagrunt release version in site blog commit message

### DIFF
--- a/.github/workflows/auto-publish-site.yml
+++ b/.github/workflows/auto-publish-site.yml
@@ -75,9 +75,12 @@ jobs:
 
       - name: Commit and Push Docs Update
         working-directory: datagrunt-site
+        # Read the version from the datagrunt checkout — this step runs inside
+        # datagrunt-site, where `git log` would return the site's own history.
         run: |
+          VERSION=$(grep -m1 '^current_version = ' "$GITHUB_WORKSPACE/datagrunt/pyproject.toml" | cut -d'"' -f2)
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add content/
-          git diff-index --quiet HEAD || git commit -m "docs: release blog post for version $(git log -n 1 --format=%s)"
+          git diff-index --quiet HEAD || git commit -m "docs: release blog post for version $VERSION"
           git push origin main


### PR DESCRIPTION
## Summary

The "Commit and Push Docs Update" step in `auto-publish-site.yml` built the datagrunt-site commit message with `$(git log -n 1 --format=%s)`. Because the step runs with `working-directory: datagrunt-site`, that command substitution resolved against the **site's** history and grabbed its previous commit subject instead of the datagrunt release version — today's 4.5.1 run committed:

> docs: release blog post for version docs: publish 4.5.0 release blog post

## Fix

Read the version from the datagrunt checkout's `pyproject.toml` (via `$GITHUB_WORKSPACE`, since the step's working directory is the site checkout), exactly how the "Run Antigravity Workflow" step already derives it:

```bash
VERSION=$(grep -m1 '^current_version = ' "$GITHUB_WORKSPACE/datagrunt/pyproject.toml" | cut -d'"' -f2)
git commit -m "docs: release blog post for version $VERSION"
```

## Validation

- Workflow YAML re-validated with `yaml.safe_load` — parses cleanly.
- `grep -m1 '^current_version = ' pyproject.toml | cut -d'"' -f2` verified locally → `4.5.1`.
- No `${{ }}` interpolation of event data added; `VERSION` is shell-derived from a checked-out file.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)