### PR TITLE
feat: add n_rows parameter to get_sample() on tabular readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ path is rejected at construction (`ValueError` / `FileNotFoundError`).
 from datagrunt import ParquetReader, ParquetWriter
 
 reader = ParquetReader("data.parquet")
-reader.get_sample()                          # first rows as a Polars DataFrame
+reader.get_sample()                          # first rows as a Polars DataFrame (n_rows= adjusts the sample size)
 reader.to_dataframe()                        # full file as a Polars DataFrame
 reader.to_arrow_table()                      # Apache Arrow Table
 reader.to_dicts()                            # list of row dicts

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -33,6 +33,9 @@ from datagrunt.core.csv_io.protocol import (
 from datagrunt.core.csv_io.protocol import (
     resolve_normalize_columns as _resolve_normalize_columns,
 )
+from datagrunt.core.csv_io.protocol import (
+    resolve_sample_rows as _resolve_sample_rows,
+)
 from datagrunt.core.databases import DuckDBQueries
 
 
@@ -175,12 +178,14 @@ class CSVBaseReaderEngine(_DuckDBBackedEngine):
         self.delimiter = self.queries.delimiter
 
     @abstractmethod
-    def get_sample(self, normalize_columns: Optional[bool] = None) -> pl.DataFrame:
+    def get_sample(self, normalize_columns: Optional[bool] = None, n_rows: Optional[int] = None) -> pl.DataFrame:
         """Return a sample of the data as a Polars DataFrame.
 
         Args:
             normalize_columns (bool or None): Whether to normalize column
             names. ``None`` (default) inherits the instance-level setting.
+            n_rows (int or None): Number of sample rows. ``None`` (default)
+            uses ``CSVEngineProperties.dataframe_sample_rows`` (20).
 
         Returns:
             A Polars DataFrame containing the sample rows.
@@ -301,26 +306,26 @@ class CSVReaderDuckDBEngine(CSVBaseReaderEngine):
     Class to read CSV files and convert CSV files powered by DuckDB.
     """
 
-    def get_sample(self, normalize_columns=None):
+    def get_sample(self, normalize_columns=None, n_rows=None):
         """
         Return a sample of the CSV as a Polars DataFrame.
 
         Args:
             normalize_columns (bool or None): Whether to normalize column
             names. ``None`` (default) inherits the instance-level setting.
+            n_rows (int or None): Number of sample rows. ``None`` (default)
+            uses ``CSVEngineProperties.dataframe_sample_rows`` (20).
 
         Returns:
             A Polars DataFrame containing the sample rows.
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
+        sample_rows = _resolve_sample_rows(n_rows, CSVEngineProperties.dataframe_sample_rows)
         # The engine is cached on the CSVReader, so the streaming-sample
         # connection is reused by later reads and released when the reader goes
         # out of scope (its connection is reference-counted), or earlier via the
         # optional close()/`with`. datagrunt manages this; callers never must.
-        return self.queries.sample_dataframe(
-            CSVEngineProperties.dataframe_sample_rows,
-            normalize_columns,
-        )
+        return self.queries.sample_dataframe(sample_rows, normalize_columns)
 
     def to_dataframe(self, normalize_columns=None, **kwargs):
         """
@@ -444,12 +449,15 @@ class CSVReaderPolarsEngine(DataFrameDerivedReaderMixin, CSVBaseReaderEngine):
     Class to read CSV files and convert CSV files powered by Polars.
     """
 
-    def _create_dataframe(self, normalize_columns=False, sample=False, **kwargs):
+    def _create_dataframe(self, normalize_columns=False, sample=False, sample_rows=None, **kwargs):
         """Read the CSV into a Polars dataframe.
 
         Args:
             normalize_columns (bool): Whether to normalize column names.
             sample (bool): When True, read only the leading sample rows.
+            sample_rows (int or None): Number of sample rows to read when
+            ``sample`` is True. ``None`` uses
+            ``CSVEngineProperties.dataframe_sample_rows`` (20).
             **kwargs: Overrides/options for Polars read_csv.
 
         Returns:
@@ -465,7 +473,7 @@ class CSVReaderPolarsEngine(DataFrameDerivedReaderMixin, CSVBaseReaderEngine):
 
         n_rows = kwargs.pop("n_rows", None)
         if sample:
-            n_rows = CSVEngineProperties.dataframe_sample_rows
+            n_rows = sample_rows if sample_rows is not None else CSVEngineProperties.dataframe_sample_rows
 
         df = _polars_read_csv(
             self.filepath,
@@ -478,19 +486,22 @@ class CSVReaderPolarsEngine(DataFrameDerivedReaderMixin, CSVBaseReaderEngine):
             df = df.rename(CSVColumnNameNormalizer(self.filepath, columns=df.columns).columns_to_normalized_mapping)
         return df
 
-    def get_sample(self, normalize_columns=None):
+    def get_sample(self, normalize_columns=None, n_rows=None):
         """
         Return a sample of the CSV file.
 
         Args:
             normalize_columns (bool or None): Whether to normalize column
             names. ``None`` (default) inherits the instance-level setting.
+            n_rows (int or None): Number of sample rows. ``None`` (default)
+            uses ``CSVEngineProperties.dataframe_sample_rows`` (20).
 
         Returns:
             A Polars dataframe.
         """
         resolved = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
-        return self._create_dataframe(resolved, sample=True)
+        sample_rows = _resolve_sample_rows(n_rows, CSVEngineProperties.dataframe_sample_rows)
+        return self._create_dataframe(resolved, sample=True, sample_rows=sample_rows)
 
     def to_dataframe(self, normalize_columns=None, **kwargs):
         """
@@ -759,12 +770,15 @@ class CSVReaderPyArrowEngine(_PyArrowEngineMixin, CSVBaseReaderEngine):
             table = self._normalize_arrow_columns(table, columns)
         return table
 
-    def _create_table(self, normalize_columns=False, sample=False):
+    def _create_table(self, normalize_columns=False, sample=False, sample_rows=None):
         """Create a PyArrow table from the CSV file (all columns cast to string).
 
         Args:
             normalize_columns (bool): Whether to normalize column names.
             sample (bool): When True, read only the leading sample rows.
+            sample_rows (int or None): Number of sample rows to read when
+            ``sample`` is True. ``None`` uses
+            ``CSVEngineProperties.dataframe_sample_rows`` (20).
 
         Returns:
             A PyArrow table.
@@ -777,7 +791,7 @@ class CSVReaderPyArrowEngine(_PyArrowEngineMixin, CSVBaseReaderEngine):
                 "PyArrow engine does not support legacy Mac OS carriage return (\\r) newlines. "
                 "Please use engine='duckdb' or convert the file to Unix/Windows newlines."
             )
-        sample_rows = CSVEngineProperties.dataframe_sample_rows
+        sample_rows = sample_rows if sample_rows is not None else CSVEngineProperties.dataframe_sample_rows
         fallback_rows = sample_rows if sample else None
         if self.lenient:
             _check_csv_ragged_and_warn(self.filepath, self.delimiter)
@@ -836,19 +850,22 @@ class CSVReaderPyArrowEngine(_PyArrowEngineMixin, CSVBaseReaderEngine):
             reader.close()
         return pa.Table.from_batches(batches, schema=string_schema).slice(0, sample_rows)
 
-    def get_sample(self, normalize_columns=None):
+    def get_sample(self, normalize_columns=None, n_rows=None):
         """
         Return a sample of the CSV file.
 
         Args:
             normalize_columns (bool or None): Whether to normalize column
             names. ``None`` (default) inherits the instance-level setting.
+            n_rows (int or None): Number of sample rows. ``None`` (default)
+            uses ``CSVEngineProperties.dataframe_sample_rows`` (20).
 
         Returns:
             A Polars DataFrame containing the sample rows.
         """
         normalize_columns = _resolve_normalize_columns(self.normalize_columns, normalize_columns)
-        return _arrow_to_polars(self._create_table(normalize_columns, sample=True))
+        sample_rows = _resolve_sample_rows(n_rows, CSVEngineProperties.dataframe_sample_rows)
+        return _arrow_to_polars(self._create_table(normalize_columns, sample=True, sample_rows=sample_rows))
 
     def to_dataframe(self, normalize_columns=None, **kwargs) -> pl.DataFrame:
         """

--- a/src/datagrunt/core/csv_io/protocol.py
+++ b/src/datagrunt/core/csv_io/protocol.py
@@ -15,6 +15,19 @@ def resolve_normalize_columns(instance_default: bool, per_call_value: Optional[b
     return instance_default if per_call_value is None else per_call_value
 
 
+def resolve_sample_rows(n_rows: Optional[int], default: int) -> int:
+    """Resolve a per-call sample size against the engine default.
+
+    ``None`` inherits ``default``. Anything else must be a positive int;
+    bools are rejected because they are ints in Python but never a row count.
+    """
+    if n_rows is None:
+        return default
+    if isinstance(n_rows, bool) or not isinstance(n_rows, int) or n_rows < 1:
+        raise ValueError(f"n_rows must be a positive integer, got {n_rows!r}.")
+    return n_rows
+
+
 def arrow_to_polars(table: pa.Table) -> pl.DataFrame:
     """Convert a PyArrow table to a Polars DataFrame, never a bare Series."""
     df = pl.from_arrow(table)
@@ -40,7 +53,7 @@ class CSVReaderEngineProtocol(Protocol):
         """Release engine-held resources."""
         ...
 
-    def get_sample(self, normalize_columns: Optional[bool] = None) -> pl.DataFrame:
+    def get_sample(self, normalize_columns: Optional[bool] = None, n_rows: Optional[int] = None) -> pl.DataFrame:
         """Return a sample of the data as a Polars DataFrame."""
         ...
 

--- a/src/datagrunt/core/excel_io/engines.py
+++ b/src/datagrunt/core/excel_io/engines.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 # third party libraries
 import duckdb
@@ -42,6 +42,19 @@ class ExcelEngineProperties:
 def _resolve_normalize(instance_value, per_call_value):
     """Return the per-call override when given, else the instance default."""
     return instance_value if per_call_value is None else per_call_value
+
+
+def resolve_sample_rows(n_rows: Optional[int], default: int) -> int:
+    """Resolve a per-call sample size against the engine default.
+
+    ``None`` inherits ``default``. Anything else must be a positive int;
+    bools are rejected because they are ints in Python but never a row count.
+    """
+    if n_rows is None:
+        return default
+    if isinstance(n_rows, bool) or not isinstance(n_rows, int) or n_rows < 1:
+        raise ValueError(f"n_rows must be a positive integer, got {n_rows!r}.")
+    return n_rows
 
 
 def _freeze(value):
@@ -121,11 +134,15 @@ class ExcelReaderEngine:
             self._frame_cache[key] = df
         return self._frame_cache[key]
 
-    def get_sample(self, sheet=None, normalize_columns=None, **read_options):
-        """Return the leading sample rows of a sheet as a Polars frame."""
-        return self._read_sheet(sheet, normalize_columns, read_options).head(
-            ExcelEngineProperties.dataframe_sample_rows
-        )
+    def get_sample(self, sheet=None, normalize_columns=None, n_rows=None, **read_options):
+        """Return the leading sample rows of a sheet as a Polars frame.
+
+        ``n_rows`` is the sample size (default 20). It is consumed here, not
+        forwarded to ``read_excel`` — pass row limits for full reads via
+        ``to_dataframe(n_rows=...)`` instead.
+        """
+        sample_rows = resolve_sample_rows(n_rows, ExcelEngineProperties.dataframe_sample_rows)
+        return self._read_sheet(sheet, normalize_columns, read_options).head(sample_rows)
 
     def to_dataframe(self, sheet=None, normalize_columns=None, **read_options):
         """Return a sheet as a Polars DataFrame."""

--- a/src/datagrunt/core/parquet_io/engines.py
+++ b/src/datagrunt/core/parquet_io/engines.py
@@ -36,6 +36,19 @@ def _resolve_normalize(instance_value, per_call_value):
     return instance_value if per_call_value is None else per_call_value
 
 
+def resolve_sample_rows(n_rows, default):
+    """Resolve a per-call sample size against the engine default.
+
+    ``None`` inherits ``default``. Anything else must be a positive int;
+    bools are rejected because they are ints in Python but never a row count.
+    """
+    if n_rows is None:
+        return default
+    if isinstance(n_rows, bool) or not isinstance(n_rows, int) or n_rows < 1:
+        raise ValueError(f"n_rows must be a positive integer, got {n_rows!r}.")
+    return n_rows
+
+
 def _freeze(value):
     """Recursively convert dicts/lists into a hashable key for caching."""
     if isinstance(value, dict):
@@ -113,9 +126,15 @@ class ParquetReaderEngine:
             self._frame_cache[key] = df
         return self._frame_cache[key]
 
-    def get_sample(self, normalize_columns=None, **read_options):
-        """Return the leading sample rows as a Polars frame."""
-        return self._read_frame(normalize_columns, read_options).head(ParquetEngineProperties.dataframe_sample_rows)
+    def get_sample(self, normalize_columns=None, n_rows=None, **read_options):
+        """Return the leading sample rows as a Polars frame.
+
+        ``n_rows`` is the sample size (default 20). It is consumed here, not
+        forwarded to ``read_parquet`` — pass row limits for full reads via
+        ``to_dataframe(n_rows=...)`` instead.
+        """
+        sample_rows = resolve_sample_rows(n_rows, ParquetEngineProperties.dataframe_sample_rows)
+        return self._read_frame(normalize_columns, read_options).head(sample_rows)
 
     def to_dataframe(self, normalize_columns=None, **read_options):
         """Return the file as a Polars DataFrame."""

--- a/src/datagrunt/core/parquet_io/engines.py
+++ b/src/datagrunt/core/parquet_io/engines.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 # third party libraries
 import duckdb
@@ -36,7 +36,7 @@ def _resolve_normalize(instance_value, per_call_value):
     return instance_value if per_call_value is None else per_call_value
 
 
-def resolve_sample_rows(n_rows, default):
+def resolve_sample_rows(n_rows: Optional[int], default: int) -> int:
     """Resolve a per-call sample size against the engine default.
 
     ``None`` inherits ``default``. Anything else must be a positive int;

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -11,7 +11,8 @@ import polars as pl
 import pyarrow as pa
 
 # local libraries
-from datagrunt.core import DuckDBQueries
+from datagrunt.core import CSVEngineProperties, DuckDBQueries
+from datagrunt.core.csv_io.protocol import resolve_sample_rows
 from datagrunt.csv_api._compat import warn_per_call_normalize
 from datagrunt.csv_api._engine_backed import _CSVEngineBacked
 
@@ -63,9 +64,12 @@ class CSVReader(_CSVEngineBacked):
         Raises:
             ValueError: If ``n_rows`` is not ``None`` or a positive integer.
         """
+        # Validate n_rows before the empty/blank short-circuit so a bad value
+        # raises regardless of file contents, as the Raises clause promises.
+        sample_rows = resolve_sample_rows(n_rows, CSVEngineProperties.dataframe_sample_rows)
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pl.DataFrame())
-        return self._engine.get_sample(warn_per_call_normalize(normalize_columns), n_rows=n_rows)
+        return self._engine.get_sample(warn_per_call_normalize(normalize_columns), n_rows=sample_rows)
 
     def to_dataframe(self, normalize_columns: bool | None = None, **kwargs):
         """Converts CSV to a dataframe.

--- a/src/datagrunt/csv_api/csvreader.py
+++ b/src/datagrunt/csv_api/csvreader.py
@@ -47,20 +47,25 @@ class CSVReader(_CSVEngineBacked):
         """Return an empty object of the specified type."""
         return object
 
-    def get_sample(self, normalize_columns: bool | None = None):
+    def get_sample(self, normalize_columns: bool | None = None, n_rows: int | None = None):
         """Return a sample of the CSV file.
 
         Args:
             normalize_columns (bool or None): Deprecated per-call override.
             ``None`` (default) inherits the constructor-level setting.
+            n_rows (int or None): Number of sample rows to return. ``None``
+            (default) uses the standard sample size (20).
 
         Returns:
             A Polars DataFrame (all engines), or an empty ``pl.DataFrame()``
             for empty/blank files.
+
+        Raises:
+            ValueError: If ``n_rows`` is not ``None`` or a positive integer.
         """
         if self.is_empty or self.is_blank:
             return self._return_empty_file_object(pl.DataFrame())
-        return self._engine.get_sample(warn_per_call_normalize(normalize_columns))
+        return self._engine.get_sample(warn_per_call_normalize(normalize_columns), n_rows=n_rows)
 
     def to_dataframe(self, normalize_columns: bool | None = None, **kwargs):
         """Converts CSV to a dataframe.

--- a/src/datagrunt/excel_api/excelreader.py
+++ b/src/datagrunt/excel_api/excelreader.py
@@ -8,6 +8,7 @@ import polars as pl
 import pyarrow as pa
 
 # local libraries
+from datagrunt.core.excel_io.engines import ExcelEngineProperties, resolve_sample_rows
 from datagrunt.excel_api._engine_backed import _ExcelEngineBacked
 
 
@@ -45,11 +46,29 @@ class ExcelReader(_ExcelEngineBacked):
         """The DuckDB table name ``query_data`` registers the sheet under."""
         return self._engine.db_table
 
-    def get_sample(self, sheet=None, normalize_columns: bool | None = None, **read_options) -> pl.DataFrame:
-        """Return the leading sample rows of a sheet (empty frame if empty/blank)."""
+    def get_sample(
+        self, sheet=None, normalize_columns: bool | None = None, n_rows: int | None = None, **read_options
+    ) -> pl.DataFrame:
+        """Return the leading sample rows of a sheet (empty frame if empty/blank).
+
+        Args:
+            sheet (str or int or None): Sheet to sample; ``None`` reads the
+                first sheet.
+            normalize_columns (bool or None): Per-call override; ``None``
+                (default) inherits the constructor-level setting.
+            n_rows (int or None): Number of sample rows to return. ``None``
+                (default) uses the standard sample size (20).
+            **read_options: Polars ``read_excel`` options for this call.
+
+        Raises:
+            ValueError: If ``n_rows`` is not ``None`` or a positive integer.
+        """
+        # Validate n_rows before the empty/blank short-circuit so a bad value
+        # raises regardless of workbook contents, as the Raises clause promises.
+        sample_rows = resolve_sample_rows(n_rows, ExcelEngineProperties.dataframe_sample_rows)
         if self.is_empty or self.is_blank:
             return pl.DataFrame()
-        return self._engine.get_sample(sheet, normalize_columns, **read_options)
+        return self._engine.get_sample(sheet, normalize_columns, n_rows=sample_rows, **read_options)
 
     def to_dataframe(self, sheet=None, normalize_columns: bool | None = None, **read_options) -> pl.DataFrame:
         """Convert a sheet to a Polars DataFrame (empty frame if empty/blank)."""

--- a/src/datagrunt/parquet_api/parquetreader.py
+++ b/src/datagrunt/parquet_api/parquetreader.py
@@ -8,6 +8,7 @@ import polars as pl
 import pyarrow as pa
 
 # local libraries
+from datagrunt.core.parquet_io.engines import ParquetEngineProperties, resolve_sample_rows
 from datagrunt.parquet_api._engine_backed import _ParquetEngineBacked
 
 
@@ -34,11 +35,27 @@ class ParquetReader(_ParquetEngineBacked):
         """The DuckDB table name ``query_data`` registers the file under."""
         return self._engine.db_table
 
-    def get_sample(self, normalize_columns: bool | None = None, **read_options) -> pl.DataFrame:
-        """Return the leading sample rows (empty frame if empty/blank)."""
+    def get_sample(
+        self, normalize_columns: bool | None = None, n_rows: int | None = None, **read_options
+    ) -> pl.DataFrame:
+        """Return the leading sample rows (empty frame if empty/blank).
+
+        Args:
+            normalize_columns (bool or None): Per-call override; ``None``
+                (default) inherits the constructor-level setting.
+            n_rows (int or None): Number of sample rows to return. ``None``
+                (default) uses the standard sample size (20).
+            **read_options: Polars ``read_parquet`` options for this call.
+
+        Raises:
+            ValueError: If ``n_rows`` is not ``None`` or a positive integer.
+        """
+        # Validate n_rows before the empty/blank short-circuit so a bad value
+        # raises regardless of file contents, as the Raises clause promises.
+        sample_rows = resolve_sample_rows(n_rows, ParquetEngineProperties.dataframe_sample_rows)
         if self.is_empty or self.is_blank:
             return pl.DataFrame()
-        return self._engine.get_sample(normalize_columns, **read_options)
+        return self._engine.get_sample(normalize_columns, n_rows=sample_rows, **read_options)
 
     def to_dataframe(self, normalize_columns: bool | None = None, **read_options) -> pl.DataFrame:
         """Convert to a Polars DataFrame (empty frame if empty/blank)."""

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -116,6 +116,31 @@ class TestCSVReader:
             assert "John" in names
             assert "Jane" in names
 
+    def test_get_sample_n_rows(self, tmp_path):
+        """get_sample(n_rows=...) adjusts the sample size on every engine."""
+        csv_file = tmp_path / "wide.csv"
+        rows = "\n".join(f"row{i},{i}" for i in range(30))
+        csv_file.write_text(f"name,value\n{rows}")
+        for engine in ALL_ENGINES:
+            reader = CSVReader(str(csv_file), engine=engine)
+            assert len(reader.get_sample()) == 20  # default unchanged
+            assert len(reader.get_sample(n_rows=5)) == 5
+            assert len(reader.get_sample(n_rows=100)) == 30  # capped at file size
+
+    def test_get_sample_n_rows_invalid(self, sample_csv):
+        """Invalid n_rows raises ValueError on every engine."""
+        for engine in ALL_ENGINES:
+            reader = CSVReader(sample_csv, engine=engine)
+            for bad in (0, -3, 2.5, "ten", True):
+                with pytest.raises(ValueError):
+                    reader.get_sample(n_rows=bad)
+
+    def test_get_sample_n_rows_empty_file(self, empty_csv):
+        """n_rows on an empty file still returns an empty DataFrame."""
+        for engine in ALL_ENGINES:
+            reader = CSVReader(empty_csv, engine=engine)
+            assert reader.get_sample(n_rows=5).is_empty()
+
     def test_same_stem_files_do_not_collide(self, tmp_path):
         """Two files sharing a name stem must not overwrite each other's data.
 

--- a/tests/csv_api_tests/test_csvreader.py
+++ b/tests/csv_api_tests/test_csvreader.py
@@ -141,6 +141,13 @@ class TestCSVReader:
             reader = CSVReader(empty_csv, engine=engine)
             assert reader.get_sample(n_rows=5).is_empty()
 
+    def test_get_sample_n_rows_invalid_on_empty_file(self, empty_csv):
+        """Invalid n_rows raises even when the file is empty."""
+        for engine in ALL_ENGINES:
+            reader = CSVReader(empty_csv, engine=engine)
+            with pytest.raises(ValueError):
+                reader.get_sample(n_rows=0)
+
     def test_same_stem_files_do_not_collide(self, tmp_path):
         """Two files sharing a name stem must not overwrite each other's data.
 

--- a/tests/excel_api_tests/test_excelreader.py
+++ b/tests/excel_api_tests/test_excelreader.py
@@ -108,3 +108,29 @@ def test_excelreader_to_dataframe_read_options_deprecation(sample_xlsx):
         df = reader.to_dataframe(read_options={"n_rows": 1})
 
     assert df.height == 1
+
+
+def test_get_sample_n_rows(tmp_path):
+    import polars as pl
+    import xlsxwriter
+
+    path = tmp_path / "wide.xlsx"
+    with xlsxwriter.Workbook(str(path)) as wb:
+        pl.DataFrame({"n": list(range(30))}).write_excel(workbook=wb, worksheet="Wide")
+    reader = ExcelReader(str(path))
+    assert reader.get_sample().height == 20  # default unchanged
+    assert reader.get_sample(n_rows=5).height == 5
+    assert reader.get_sample(n_rows=100).height == 30  # capped at sheet size
+
+
+def test_get_sample_n_rows_invalid(sample_xlsx):
+    reader = ExcelReader(sample_xlsx)
+    for bad in (0, -3, 2.5, "ten", True):
+        with pytest.raises(ValueError):
+            reader.get_sample(n_rows=bad)
+
+
+def test_get_sample_n_rows_invalid_on_empty_file(empty_xlsx):
+    """Invalid n_rows raises even when the workbook is empty."""
+    with pytest.raises(ValueError):
+        ExcelReader(empty_xlsx).get_sample(n_rows=0)

--- a/tests/parquet_api_tests/test_parquetreader.py
+++ b/tests/parquet_api_tests/test_parquetreader.py
@@ -85,9 +85,7 @@ def test_get_sample_n_rows_invalid(sample_parquet):
             reader.get_sample(n_rows=bad)
 
 
-def test_get_sample_n_rows_invalid_on_empty_file(tmp_path):
+def test_get_sample_n_rows_invalid_on_empty_file(empty_parquet):
     """Invalid n_rows raises even when the file is empty."""
-    path = tmp_path / "empty.parquet"
-    path.touch()
     with pytest.raises(ValueError):
-        ParquetReader(str(path)).get_sample(n_rows=0)
+        ParquetReader(empty_parquet).get_sample(n_rows=0)

--- a/tests/parquet_api_tests/test_parquetreader.py
+++ b/tests/parquet_api_tests/test_parquetreader.py
@@ -65,3 +65,29 @@ def test_parquetreader_to_dataframe_kwargs(sample_parquet):
     df = reader.to_dataframe(n_rows=2)
     assert df.height == 2
     assert list(df.columns) == ["name", "age", "city"]
+
+
+def test_get_sample_n_rows(tmp_path):
+    import polars as pl
+
+    path = tmp_path / "wide.parquet"
+    pl.DataFrame({"n": list(range(30))}).write_parquet(str(path))
+    reader = ParquetReader(str(path))
+    assert reader.get_sample().height == 20  # default unchanged
+    assert reader.get_sample(n_rows=5).height == 5
+    assert reader.get_sample(n_rows=100).height == 30  # capped at file size
+
+
+def test_get_sample_n_rows_invalid(sample_parquet):
+    reader = ParquetReader(sample_parquet)
+    for bad in (0, -3, 2.5, "ten", True):
+        with pytest.raises(ValueError):
+            reader.get_sample(n_rows=bad)
+
+
+def test_get_sample_n_rows_invalid_on_empty_file(tmp_path):
+    """Invalid n_rows raises even when the file is empty."""
+    path = tmp_path / "empty.parquet"
+    path.touch()
+    with pytest.raises(ValueError):
+        ParquetReader(str(path)).get_sample(n_rows=0)


### PR DESCRIPTION
## Summary

Adds an optional `n_rows` parameter to `get_sample()` on `CSVReader`, `ExcelReader`, and `ParquetReader` (and their engine layers), so callers can adjust the sample size per call:

```python
reader.get_sample()            # 20 rows, unchanged default
reader.get_sample(n_rows=100)  # 100 rows
```

Closes #280

## Design

- **Default unchanged:** `n_rows=None` resolves to the existing `dataframe_sample_rows` (20) on each domain's `EngineProperties` — the no-argument path is byte-for-byte identical.
- **Validation:** `n_rows` must be a positive `int` (`bool` explicitly rejected), else `ValueError`. Validation runs **before** each reader's empty/blank short-circuit, so an invalid value raises even on empty files.
- **Per-domain DRY:** one `resolve_sample_rows(n_rows, default)` helper per domain (CSV: `core/csv_io/protocol.py`; Excel/Parquet: their `engines.py`), shared by the public reader and the engine — mirroring the existing `_resolve_normalize` per-domain pattern; no cross-domain coupling.
- **CSV streaming preserved:** DuckDB keeps the streaming `sample_dataframe(limit)` path, Polars threads `n_rows=` into `read_csv`, PyArrow keeps its batch-streaming `_read_sample_table` — no engine materializes the whole file for a sample.
- **Documented behavior change (Excel/Parquet):** previously an `n_rows` keyword fell into `**read_options` (a Polars read option) and was then capped at 20 by `.head()`; it is now the explicit sample size, consumed by `get_sample` and not forwarded to the underlying read. Engine docstrings call this out and point full-read row limits at `to_dataframe(n_rows=...)`.
- **Out of scope:** PDF (`get_sample()` returns per-page dicts — a row count doesn't apply). No Rust/compute-core changes (sampling lives in the engine layer), so no parity impact.

## Testing

- New tests per domain across all engines: default still 20, `n_rows` under/over file size, invalid values (`0`, `-3`, `2.5`, `"ten"`, `True`) raise `ValueError`, empty-file behavior (valid `n_rows` → empty frame; invalid `n_rows` → raises).
- Full gate set green: `uv run pytest tests/ -q` (Rust backend) and `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` — 1429 passed each; `ruff check` and `ruff format --check` clean.
- Final whole-branch review: READY TO MERGE, no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)