### PR TITLE
refactor(rust): fix clippy int_plus_one and unnecessary_map_or in rows.rs

### DIFF
--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -79,7 +79,7 @@ pub fn probe_csv_header(path: &Path) -> std::io::Result<HeaderProbe> {
             segment.extend_from_slice(&available[..capped_take]);
             reader.consume(capped_take);
             total_read += capped_take;
-            if newline_pos.map_or(false, |pos| capped_take >= pos + 1) {
+            if newline_pos.is_some_and(|pos| capped_take > pos) {
                 found_newline = true;
                 break;
             }


### PR DESCRIPTION
## Summary

Fixes the two pre-existing clippy warnings at `rust/datagrunt-core/src/rows.rs:82` in the bounded line-read loop of the row-counting path:

- `clippy::int_plus_one`: `capped_take >= pos + 1` → `capped_take > pos`
- `unnecessary_map_or`: `newline_pos.map_or(false, |pos| …)` → `newline_pos.is_some_and(|pos| …)`

Both operands are `usize`, so `>= pos + 1` and `> pos` are exactly equivalent (and `pos + 1` could not overflow anyway, since `pos < available.len()`); `is_some_and` is definitionally identical to `map_or(false, …)`. No behavior change — parity semantics in the row-counting hot path are untouched.

The three remaining `dead_code` warnings in `io.rs` are pre-existing, unrelated test-only helpers, deferred to #285.

Closes #283

## Test plan

- [x] `cd rust && cargo test` — 58 passed
- [x] `cargo clippy --all-targets` — both target warnings gone (only pre-existing #285 dead-code warnings remain)
- [x] `uv pip install -e ".[dev,pdf]"` rebuild, then `uv run pytest tests/ -q` — 1429 passed
- [x] `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` — 1429 passed
- [x] `uv run pytest tests/parity/ -q` — 622 passed (Rust == Python over the corpus)
- [x] `ruff check src/datagrunt/core/csv_io` + `ruff check src/` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)