### PR TITLE
fix: gate test-only io.rs helpers with #[cfg(test)] (dead_code warnings)

### DIFF
--- a/rust/datagrunt-core/src/io.rs
+++ b/rust/datagrunt-core/src/io.rs
@@ -105,6 +105,10 @@ fn decode_chunk_with_carry(bytes: &[u8], carry: &mut Vec<u8>) -> String {
 }
 
 /// Read whole file as text the way Python's probes do: utf-8-sig + ignore.
+///
+/// Test-only: the eager reference implementation the streaming-parity tests
+/// compare [`DecodedReader`] against.
+#[cfg(test)]
 pub(crate) fn read_decoded(path: &Path) -> std::io::Result<String> {
     let mut bytes = Vec::new();
     File::open(path)?.read_to_end(&mut bytes)?;
@@ -574,7 +578,11 @@ impl Iterator for UniversalLines {
 /// "a\nb\n" -> ["a","b"]; "a\nb" -> ["a","b"]; "" -> [].
 ///
 /// Thin `collect()` over [`universal_lines`] so there is one line-splitting
-/// implementation. Other components rely on this for small samples.
+/// implementation.
+///
+/// Test-only: production code streams via [`universal_lines`]; the tests use
+/// this eager collect as their reference.
+#[cfg(test)]
 pub(crate) fn read_universal_lines(path: &Path) -> std::io::Result<Vec<String>> {
     universal_lines(path)?.collect::<Result<Vec<_>, _>>()
 }
@@ -610,6 +618,9 @@ pub fn is_empty(path: &Path) -> std::io::Result<bool> {
 /// bytes) is never blank; otherwise strict decode (BOM allowed) — invalid
 /// UTF-8 counts as content; blank iff all whitespace.
 /// The stat-then-read order mirrors Python's BlankFile (the size gate is advisory; Python has the same TOCTOU characteristics, and parity is the spec).
+///
+/// Test-only: kept as the reference implementation for blank-detection tests.
+#[cfg(test)]
 pub(crate) fn is_blank(path: &Path) -> bool {
     let size = match std::fs::metadata(path) {
         Ok(m) => m.len(),

--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -79,7 +79,7 @@ pub fn probe_csv_header(path: &Path) -> std::io::Result<HeaderProbe> {
             segment.extend_from_slice(&available[..capped_take]);
             reader.consume(capped_take);
             total_read += capped_take;
-            if newline_pos.map_or(false, |pos| capped_take >= pos + 1) {
+            if newline_pos.is_some_and(|pos| capped_take > pos) {
                 found_newline = true;
                 break;
             }


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets` (and plain `cargo check`) emitted three pre-existing `dead_code` warnings for `pub(crate)` helpers in `rust/datagrunt-core/src/io.rs` that are only referenced from `#[cfg(test)]` modules, where they serve as eager reference implementations for the streaming-parity tests:

- `read_decoded`
- `read_universal_lines`
- `is_blank`

Each is now gated with `#[cfg(test)]`, with a doc-comment note on its test-only role. A crate-wide grep confirmed no non-test references (the only hit outside `io.rs` is a doc comment in `delimiter.rs`).

While verifying the zero-warning gate, clippy 1.96 also flagged two lints at `rows.rs:82` (`int_plus_one`, `unnecessary_map_or`); the condition was rewritten to the behavior-identical `newline_pos.is_some_and(|pos| capped_take > pos)` so `cargo clippy --all-targets` is fully warning-free.

Closes #285

## Test plan

- [x] `cd rust && cargo test` — 58 passed
- [x] `cd rust && cargo clippy --all-targets` — zero warnings
- [x] Rebuilt extension: `uv pip install -e ".[dev,pdf]"`
- [x] `uv run pytest tests/ -q` — 1429 passed
- [x] `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` — 1429 passed
- [x] `uv run pytest tests/parity/ -q` — 622 passed
- [x] `ruff check src/datagrunt/core/csv_io` (and full `src/`) — clean
- [x] `ruff format --check` — 137 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)