### PR TITLE
Stamp release blog posts with full timestamps, not bare dates

### DIFF
--- a/scripts/antigravity_workflow.py
+++ b/scripts/antigravity_workflow.py
@@ -54,10 +54,15 @@ async def run_agent(version, commit_log, file_stat, git_diff, repo_dir):
     os.makedirs(save_dir, exist_ok=True)
     os.makedirs(app_data_dir, exist_ok=True)
 
+    # Full ISO 8601 timestamp, not a bare date: same-day releases must carry
+    # distinct front-matter dates or Hugo breaks the listing tie by title,
+    # rendering the newer release below the older one (#288).
+    release_timestamp = datetime.now().astimezone().isoformat(timespec="seconds")
+
     # Configure the system instructions
     system_instructions = (
         "You are a technical writer and release coordination agent for Datagrunt.\n"
-        f"The current local date is: {datetime.now().strftime('%Y-%m-%d')}.\n\n"
+        f"The current local date-time is: {release_timestamp}.\n\n"
         "Your goal is to:\n"
         "1. Analyze the git diff, file statistics, and commit log of the datagrunt codebase "
         "(located at `/Users/pmgraham/projects/datagrunt`).\n"
@@ -71,7 +76,7 @@ async def run_agent(version, commit_log, file_stat, git_diff, repo_dir):
         "   - The blog post must have front matter at the top: \n"
         "     ---\n"
         '     title: "Datagrunt <version>: <engaging headline>"\n'
-        "     date: <YYYY-MM-DD>\n"
+        f"     date: {release_timestamp}\n"
         "     draft: false\n"
         '     author: "Martin Graham"\n'
         '     author_email: "datagrunt@datagrunt.io"\n'


### PR DESCRIPTION
## Summary
- `scripts/antigravity_workflow.py`: compute `release_timestamp` (full ISO 8601 with UTC offset) once and inject it into the agent prompt — both the "current date-time" context line and, verbatim, the front-matter `date:` template. The agent no longer formats dates itself.

## Why
Same-day releases produced posts tied at midnight (`date: 2026-07-18`), and the site's blog listing breaks date ties by title — so 4.5.4 rendered below 4.5.3 on /blog/release-notes/. Full root-cause analysis in #288. Distinct generation timestamps eliminate the tie; generation always precedes the site build, so the never-future-date rule holds.

Site-side content hotfix for the four already-tied posts landed in pmgraham/datagrunt-site@38ebe90 (live order verified fixed).

## Scope
`scripts/` only — no `src/`/`rust/` changes, so no version bump and no PyPI publish (bump-version.yml paths don't match).

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)