### PR TITLE
fix: publish release blog post only after approved PyPI publish

### DIFF
--- a/.github/workflows/auto-publish-site.yml
+++ b/.github/workflows/auto-publish-site.yml
@@ -1,19 +1,20 @@
 name: Auto Update Docs & Blog
 
 on:
-  # Chain off the version bump like Publish to PyPI does. A tag trigger cannot
-  # work for releases: bumpver's tags point at the bump commit, whose
-  # "[skip ci]" message suppresses all push-triggered workflows (#275).
+  # Chain off the APPROVED PyPI publish, not the version bump, so the release
+  # post can never precede the maintainer's consent at the gated PyPi
+  # environment (#305). A rejected or failed publish never posts. The chain
+  # push (bump) -> Publish to PyPI -> this stays within GitHub's three-level
+  # workflow_run limit. (A tag trigger cannot work for releases: bumpver's
+  # tags point at the bump commit, whose "[skip ci]" message suppresses all
+  # push-triggered workflows — #275; the old v* fallback is gone with the
+  # v-prefixed tags.)
   workflow_run:
-    workflows: ["Bump Version"]
+    workflows: ["Publish to PyPI"]
     types: [completed]
     branches: [main]
-  # Manual fallbacks: dispatch from the Actions tab, or push a v-prefixed tag
-  # at a commit without "[skip ci]" (how releases were published before #275).
+  # Manual fallback: dispatch from the Actions tab.
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
 
 # Read-only on THIS repo — the datagrunt-site push uses the scoped App token
 # minted below, never the workflow's GITHUB_TOKEN.
@@ -23,9 +24,15 @@ permissions:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    # Post only for the automated release chain: the publish run must have
+    # succeeded AND itself been workflow_run-triggered (i.e. the real-PyPI
+    # path off Bump Version). Manual publish dispatches — e.g. TestPyPI
+    # smoke publishes — never generate a release post; dispatch this
+    # workflow manually if a post is wanted for one.
     if: >-
       ${{ github.event_name != 'workflow_run' ||
-          github.event.workflow_run.conclusion == 'success' }}
+          (github.event.workflow_run.conclusion == 'success' &&
+           github.event.workflow_run.event == 'workflow_run') }}
     steps:
       - name: Checkout datagrunt
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
Closes #305

The release blog post currently publishes to datagrunt.io the moment Bump Version completes — before the maintainer approves or rejects the PyPI publish at the gated `PyPi` environment. A rejected release would leave a live post for a version that never shipped (happened 2026-07-22, required a manual revert).

- Rechained `auto-publish-site.yml` off **Publish to PyPI** `workflow_run` success. The chain push (bump) → publish → site stays within GitHub's three-level `workflow_run` limit. A rejected or failed publish never posts.
- Added a guard so only the automated release chain posts (`workflow_run.event == 'workflow_run'`): manual publish dispatches (e.g. TestPyPI smoke tests) don't generate release posts. `workflow_dispatch` remains as the manual fallback for the site workflow itself.
- Removed the obsolete `v*` tag-push fallback trigger — the duplicate v-prefixed tags are deleted and bare semver is the convention.

Workflow-only change: no `src/**`/`rust/**` paths touched, so merging does not trigger a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)