### PR TITLE
fix: stop Dependabot proposing dependency-floor raises for the library

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # datagrunt is a LIBRARY: pyproject constraints are >= floors, and raising
+    # a floor forces every downstream user to upgrade. Only propose a bump
+    # when the existing constraint actually excludes the new version
+    # (security floor-raises still arrive via Dependabot security updates).
+    versioning-strategy: increase-if-necessary
   - package-ecosystem: "cargo"
     directory: "/rust"
     schedule:


### PR DESCRIPTION
Dependabot's first sweep proposed five pyproject requirement-floor raises (#299, #301, #302, #303, #304). datagrunt is a library — its constraints are `>=` floors, and raising a floor is a downstream-facing compat change that forces users to upgrade transitive deps for no benefit. `versioning-strategy: increase-if-necessary` keeps update PRs only for cases where the constraint actually excludes a new version; Dependabot *security* updates are unaffected. GitHub-Actions and Cargo update flows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)