### PR TITLE
fix: restore site-workflow env after setup-uv v9 bump

### DIFF
--- a/.github/workflows/auto-publish-site.yml
+++ b/.github/workflows/auto-publish-site.yml
@@ -63,6 +63,11 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           python-version: "3.12"
+          # setup-uv >= 6 no longer provides an implicit environment for
+          # `uv pip install`; create and activate one so the install step and
+          # the bare `python` invocation below keep working (broke in the
+          # v5 -> v9 bump: "No virtual environment found").
+          activate-environment: true
 
       - name: Install dependencies
         # Pinned: these feed an AI agent that commits to datagrunt-site, so an


### PR DESCRIPTION
The 4.5.6 release blog-post run failed ([run 29916163871](https://github.com/pmgraham/datagrunt/actions/runs/29916163871)): setup-uv v9 (bumped in #294) no longer provides an implicit environment, so `uv pip install` errors with "No virtual environment found". This workflow never runs on PRs, so #294's green CI couldn't catch it.

One-line fix: `activate-environment: true` on the setup-uv step — creates and activates a venv for both the pinned install and the bare `python` invocation. After merge, the 4.5.6 post will be backfilled via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)