### PR TITLE
fix: normalize Rust formatting and gate cargo fmt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
           CARGO_NET_RETRY: "10"
         run: cargo clippy --all-targets -- -D warnings
 
+      # The Rust counterpart to the `ruff format --check` gate below. rustfmt
+      # needs no dependency resolution, so no CARGO_NET_RETRY here.
+      - name: cargo fmt check (blocking)
+        working-directory: rust
+        run: cargo fmt --check
+
       - name: pytest (Rust backend)
         run: .venv/bin/pytest tests/ -q
 

--- a/rust/datagrunt-core/src/delimiter.rs
+++ b/rust/datagrunt-core/src/delimiter.rs
@@ -100,7 +100,10 @@ mod tests {
     #[test]
     fn candidate_ordering_is_count_desc_then_first_seen() {
         // '.' seen first, ';' same count -> '.' first; ':' more frequent -> first overall
-        assert_eq!(candidates_most_common_first("a.b;c.d;e:f:g:h"), vec![':', '.', ';']);
+        assert_eq!(
+            candidates_most_common_first("a.b;c.d;e:f:g:h"),
+            vec![':', '.', ';']
+        );
     }
 
     #[test]

--- a/rust/datagrunt-core/src/dialect.rs
+++ b/rust/datagrunt-core/src/dialect.rs
@@ -81,10 +81,7 @@ const QUOTE_PATTERNS: [(&str, bool); 4] = [
         r#"(?sm)(?P<delim>[^\w\n"'])(?P<space> ?)(?P<quote>["']).*?\k<quote>(?:$|\n)"#,
         true,
     ),
-    (
-        r#"(?sm)(?:^|\n)(?P<quote>["']).*?\k<quote>(?:$|\n)"#,
-        false,
-    ),
+    (r#"(?sm)(?:^|\n)(?P<quote>["']).*?\k<quote>(?:$|\n)"#, false),
 ];
 
 /// Compiled forms of QUOTE_PATTERNS. Initialized once; avoids per-call `Regex::new`.
@@ -257,7 +254,10 @@ fn guess_delimiter(data: &str, delimiters: Option<&str>) -> (String, bool) {
                     Some((_, meta)) => meta,
                     None => {
                         char_frequency.push((ch, Vec::new()));
-                        &mut char_frequency.last_mut().expect("just pushed, cannot be empty").1
+                        &mut char_frequency
+                            .last_mut()
+                            .expect("just pushed, cannot be empty")
+                            .1
                     }
                 };
                 match meta.iter_mut().find(|(f, _)| *f == freq) {
@@ -352,14 +352,15 @@ fn guess_delimiter(data: &str, delimiters: Option<&str>) -> (String, bool) {
     // Otherwise pick the dominant char: Python builds `[(v, k) ...]`, sorts, and
     // takes the LAST. v is the (freq, adjusted) tuple, so the sort key is
     // ((freq, adjusted), char); the maximum such tuple wins.
-    let mut items: Vec<(usize, i64, char)> =
-        delims.iter().map(|(k, v)| (v.freq, v.adjusted, *k)).collect();
-    items.sort_by(|a, b| {
-        a.0.cmp(&b.0)
-            .then(a.1.cmp(&b.1))
-            .then(a.2.cmp(&b.2))
-    });
-    let delim = items.last().expect("delims non-empty after preference scan").2;
+    let mut items: Vec<(usize, i64, char)> = delims
+        .iter()
+        .map(|(k, v)| (v.freq, v.adjusted, *k))
+        .collect();
+    items.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)).then(a.2.cmp(&b.2)));
+    let delim = items
+        .last()
+        .expect("delims non-empty after preference scan")
+        .2;
     let sis = skipinitialspace_for(lines[0], delim);
     (delim.to_string(), sis)
 }
@@ -369,21 +370,19 @@ fn guess_delimiter(data: &str, delimiters: Option<&str>) -> (String, bool) {
 pub fn sniff(sample: &str, delimiters: Option<&str>) -> Option<SniffedDialect> {
     let quote_guess = guess_quote_and_delimiter(sample, delimiters);
 
-    let (delimiter, doublequote, mut quotechar, skipinitialspace) = if quote_guess
-        .delimiter
-        .is_empty()
-    {
-        // Quote guess could not determine a delimiter; fall back to frequency.
-        let (delim, sis) = guess_delimiter(sample, delimiters);
-        (delim, quote_guess.doublequote, quote_guess.quotechar, sis)
-    } else {
-        (
-            quote_guess.delimiter,
-            quote_guess.doublequote,
-            quote_guess.quotechar,
-            quote_guess.skipinitialspace,
-        )
-    };
+    let (delimiter, doublequote, mut quotechar, skipinitialspace) =
+        if quote_guess.delimiter.is_empty() {
+            // Quote guess could not determine a delimiter; fall back to frequency.
+            let (delim, sis) = guess_delimiter(sample, delimiters);
+            (delim, quote_guess.doublequote, quote_guess.quotechar, sis)
+        } else {
+            (
+                quote_guess.delimiter,
+                quote_guess.doublequote,
+                quote_guess.quotechar,
+                quote_guess.skipinitialspace,
+            )
+        };
 
     if delimiter.is_empty() {
         return None;

--- a/rust/datagrunt-core/src/io.rs
+++ b/rust/datagrunt-core/src/io.rs
@@ -42,7 +42,8 @@ pub(crate) fn py_strip(s: &str) -> &str {
 /// discarding empty leading/trailing fields. Mirrors `str::split_whitespace`
 /// but with Python's whitespace definition (see [`is_python_whitespace`]).
 pub(crate) fn py_split_whitespace(s: &str) -> impl Iterator<Item = &str> {
-    s.split(is_python_whitespace).filter(|field| !field.is_empty())
+    s.split(is_python_whitespace)
+        .filter(|field| !field.is_empty())
 }
 
 /// Python `errors="ignore"`: invalid byte sequences are dropped, not replaced.
@@ -113,7 +114,11 @@ fn decode_chunk_with_carry(bytes: &[u8], carry: &mut Vec<u8>) -> String {
 pub(crate) fn read_decoded(path: &Path) -> std::io::Result<String> {
     let mut bytes = Vec::new();
     File::open(path)?.read_to_end(&mut bytes)?;
-    let body = if bytes.starts_with(BOM) { &bytes[BOM.len()..] } else { &bytes[..] };
+    let body = if bytes.starts_with(BOM) {
+        &bytes[BOM.len()..]
+    } else {
+        &bytes[..]
+    };
     Ok(decode_ignore(body))
 }
 
@@ -634,10 +639,17 @@ pub(crate) fn is_blank(path: &Path) -> bool {
         return false;
     }
     let mut bytes = Vec::new();
-    if File::open(path).and_then(|mut f| f.read_to_end(&mut bytes)).is_err() {
+    if File::open(path)
+        .and_then(|mut f| f.read_to_end(&mut bytes))
+        .is_err()
+    {
         return false;
     }
-    let body = if bytes.starts_with(BOM) { &bytes[BOM.len()..] } else { &bytes[..] };
+    let body = if bytes.starts_with(BOM) {
+        &bytes[BOM.len()..]
+    } else {
+        &bytes[..]
+    };
     match std::str::from_utf8(body) {
         // `py_strip` matches Python's `str.strip()` whitespace set (incl. the
         // C0 separators), so an all-separator file reads as blank (issue #176).
@@ -676,7 +688,10 @@ mod tests {
         // but NOT to Rust's char::is_whitespace — the entire divergence set.
         for c in ['\u{1c}', '\u{1d}', '\u{1e}', '\u{1f}'] {
             assert!(is_python_whitespace(c), "{c:?} should be Python whitespace");
-            assert!(!c.is_whitespace(), "{c:?} is not Rust White_Space (precondition)");
+            assert!(
+                !c.is_whitespace(),
+                "{c:?} is not Rust White_Space (precondition)"
+            );
         }
         // Ordinary whitespace (incl. \xa0 NBSP, already shared) is unchanged.
         for c in [' ', '\t', '\n', '\r', '\u{0c}', '\u{a0}'] {
@@ -702,11 +717,20 @@ mod tests {
     #[test]
     fn py_split_whitespace_splits_on_c0_separators_like_python() {
         // Python: "a\x1cb\x1cc".split() == ["a", "b", "c"].
-        assert_eq!(py_split_whitespace("a\u{1c}b\u{1c}c").collect::<Vec<_>>(), ["a", "b", "c"]);
+        assert_eq!(
+            py_split_whitespace("a\u{1c}b\u{1c}c").collect::<Vec<_>>(),
+            ["a", "b", "c"]
+        );
         // Mixed separators and ordinary whitespace collapse into one split.
-        assert_eq!(py_split_whitespace("a\u{1d} \tb").collect::<Vec<_>>(), ["a", "b"]);
+        assert_eq!(
+            py_split_whitespace("a\u{1d} \tb").collect::<Vec<_>>(),
+            ["a", "b"]
+        );
         // Leading/trailing separators produce no empty fields.
-        assert_eq!(py_split_whitespace("\u{1f}a b\u{1c}").collect::<Vec<_>>(), ["a", "b"]);
+        assert_eq!(
+            py_split_whitespace("\u{1f}a b\u{1c}").collect::<Vec<_>>(),
+            ["a", "b"]
+        );
         assert_eq!(py_split_whitespace("\u{1c}\u{1d}\u{1e}\u{1f}").count(), 0);
     }
 
@@ -777,7 +801,10 @@ mod tests {
     fn streaming_invalid_utf8_dropped() {
         // errors="ignore": the lone \xe9 is dropped per line.
         let f = tmp(b"Jos\xe9,NYC\nb\n", ".csv");
-        assert_eq!(read_universal_lines(f.path()).unwrap(), vec!["Jos,NYC", "b"]);
+        assert_eq!(
+            read_universal_lines(f.path()).unwrap(),
+            vec!["Jos,NYC", "b"]
+        );
     }
 
     #[test]
@@ -788,7 +815,9 @@ mod tests {
         let f = tmp(content, ".csv");
         let streamed = read_universal_lines(f.path()).unwrap();
         // Reference: old whole-file split implementation.
-        let text = decode_ignore(content).replace("\r\n", "\n").replace('\r', "\n");
+        let text = decode_ignore(content)
+            .replace("\r\n", "\n")
+            .replace('\r', "\n");
         let mut expected: Vec<String> = text.split('\n').map(str::to_string).collect();
         if text.ends_with('\n') {
             expected.pop();
@@ -847,7 +876,7 @@ mod tests {
         assert_eq!(drain(f.path(), false), "hello");
         // Partial BOM at offset 0 that is NOT a BOM must be emitted verbatim.
         let g = tmp(b"\xef\xbb", ".csv"); // 2 bytes: incomplete BOM, also invalid UTF-8
-        // errors="ignore" drops the incomplete tail at EOF, matching read_decoded.
+                                          // errors="ignore" drops the incomplete tail at EOF, matching read_decoded.
         assert_eq!(drain(g.path(), false), eager(g.path(), false));
         // A 2-byte valid-UTF8 non-BOM start must round-trip.
         let h = tmp(b"ab", ".csv");
@@ -944,9 +973,13 @@ mod tests {
     #[test]
     fn legacy_mac_detection() {
         assert!(is_legacy_mac_newlines(tmp(b"a,b\rc,d\r", ".csv").path()));
-        assert!(!is_legacy_mac_newlines(tmp(b"a,b\r\nc,d\r\n", ".csv").path()));
+        assert!(!is_legacy_mac_newlines(
+            tmp(b"a,b\r\nc,d\r\n", ".csv").path()
+        ));
         assert!(!is_legacy_mac_newlines(tmp(b"a,b\nc,d\n", ".csv").path()));
-        assert!(!is_legacy_mac_newlines(std::path::Path::new("/nonexistent/x.csv")));
+        assert!(!is_legacy_mac_newlines(std::path::Path::new(
+            "/nonexistent/x.csv"
+        )));
     }
 
     #[test]
@@ -957,8 +990,8 @@ mod tests {
         assert!(!is_blank(tmp(b"a", ".csv").path()));
         assert!(!is_blank(tmp(b"\xff\xfe", ".csv").path())); // invalid UTF-8 = content
         assert!(is_blank(tmp(b"\xef\xbb\xbf \n", ".csv").path())); // BOM + whitespace
-        // C0 separators are whitespace to Python's strip, so an all-separator
-        // file is blank (issue #176) — matching BlankFile.is_blank.
+                                                                   // C0 separators are whitespace to Python's strip, so an all-separator
+                                                                   // file is blank (issue #176) — matching BlankFile.is_blank.
         assert!(is_blank(tmp(b"\x1c\x1d\x1e\x1f\n", ".csv").path()));
         assert!(is_tsv(std::path::Path::new("x.tsv")));
         assert!(is_tsv(std::path::Path::new("x.TSV")));
@@ -996,13 +1029,20 @@ mod tests {
         content.extend_from_slice(b"\nnext_line\n");
         let f = tmp(&content, ".csv");
         let lines = read_universal_lines(f.path()).unwrap();
-        assert_eq!(lines.len(), 2, "should yield the giant line and the next line");
+        assert_eq!(
+            lines.len(),
+            2,
+            "should yield the giant line and the next line"
+        );
         assert_eq!(
             lines[0].chars().count(),
             MAX_LINE_CHARS,
             "giant line capped at MAX_LINE_CHARS"
         );
-        assert_eq!(lines[1], "next_line", "second line must read correctly after cap");
+        assert_eq!(
+            lines[1], "next_line",
+            "second line must read correctly after cap"
+        );
     }
 
     /// Giant line terminated by '\r\n' must be capped and the '\r\n' counted

--- a/rust/datagrunt-core/src/lib.rs
+++ b/rust/datagrunt-core/src/lib.rs
@@ -1,7 +1,7 @@
 //! Pure-Rust port of datagrunt's csvcomponents logic. No PyO3 here.
 
-pub mod dialect;
 pub mod delimiter;
+pub mod dialect;
 pub mod io;
 pub mod normalize;
 pub mod ragged;

--- a/rust/datagrunt-core/src/normalize.rs
+++ b/rust/datagrunt-core/src/normalize.rs
@@ -61,8 +61,14 @@ mod tests {
 
     #[test]
     fn basic_and_collisions() {
-        assert_eq!(norm(&["First Name", "LAST-NAME"]), vec!["first_name", "last_name"]);
-        assert_eq!(norm(&["col_a", "col_a", "col_a_1"]), vec!["col_a", "col_a_1", "col_a_1_1"]);
+        assert_eq!(
+            norm(&["First Name", "LAST-NAME"]),
+            vec!["first_name", "last_name"]
+        );
+        assert_eq!(
+            norm(&["col_a", "col_a", "col_a_1"]),
+            vec!["col_a", "col_a_1", "col_a_1_1"]
+        );
         assert_eq!(norm(&["%", "()"]), vec!["column", "column_1"]);
         assert_eq!(norm(&["123abc"]), vec!["_123abc"]);
     }

--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -164,7 +164,10 @@ pub fn leading_rows(path: &Path, limit: usize) -> std::io::Result<Vec<String>> {
 
 /// CSVRows.first_row: first non-comment row stripped, or "".
 pub fn first_row(path: &Path) -> std::io::Result<String> {
-    Ok(leading_rows(path, 1)?.into_iter().next().unwrap_or_default())
+    Ok(leading_rows(path, 1)?
+        .into_iter()
+        .next()
+        .unwrap_or_default())
 }
 
 /// _count_leading_comments: '#' lines before the header; blanks skipped.

--- a/rust/datagrunt-python/src/lib.rs
+++ b/rust/datagrunt-python/src/lib.rs
@@ -97,19 +97,21 @@ fn sniff_dialect(
     // Python threads make progress during the scan (issue #177); the GIL is
     // reacquired only to build the result dict.
     let sniffed = py
-        .detach(|| -> std::io::Result<Option<datagrunt_core::dialect::SniffedDialect>> {
-            let probe = datagrunt_core::rows::probe_csv_header(&path)?;
-            if probe.empty || probe.blank {
-                return Ok(None);
-            }
-            let sample = probe.sample_lines.join("");
-            // An empty delimiter string is Python-falsy (`if delimiter:`), meaning
-            // "no restriction" — normalize it to None so it doesn't reject every
-            // candidate (Some("") would make the substring guard `"".contains(x)`
-            // reject all).
-            let delimiter = delimiter.as_deref().filter(|s| !s.is_empty());
-            Ok(datagrunt_core::dialect::sniff(&sample, delimiter))
-        })
+        .detach(
+            || -> std::io::Result<Option<datagrunt_core::dialect::SniffedDialect>> {
+                let probe = datagrunt_core::rows::probe_csv_header(&path)?;
+                if probe.empty || probe.blank {
+                    return Ok(None);
+                }
+                let sample = probe.sample_lines.join("");
+                // An empty delimiter string is Python-falsy (`if delimiter:`), meaning
+                // "no restriction" — normalize it to None so it doesn't reject every
+                // candidate (Some("") would make the substring guard `"".contains(x)`
+                // reject all).
+                let delimiter = delimiter.as_deref().filter(|s| !s.is_empty());
+                Ok(datagrunt_core::dialect::sniff(&sample, delimiter))
+            },
+        )
         .map_err(oserr)?;
     let Some(d) = sniffed else {
         return Ok(None);
@@ -149,7 +151,10 @@ fn datagrunt_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(leading_rows, m)?)?;
     m.add_function(wrap_pyfunction!(first_row, m)?)?;
     m.add_function(wrap_pyfunction!(count_leading_comments, m)?)?;
-    m.add_function(wrap_pyfunction!(count_leading_physical_lines_before_header, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        count_leading_physical_lines_before_header,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(normalize_columns, m)?)?;
     m.add_function(wrap_pyfunction!(infer_delimiter, m)?)?;
     m.add_function(wrap_pyfunction!(row_count_with_header, m)?)?;


### PR DESCRIPTION
## What

`cargo fmt --check` was failing on committed Rust sources across seven files. This runs `cargo fmt` and adds a blocking `cargo fmt --check` step to CI so the drift cannot return.

## Why

CI gated Python formatting (`ruff format --check .`) and Rust lints (`cargo clippy --all-targets -- -D warnings`), but had no Rust formatting gate. Nothing was checking it, so the drift accumulated silently — adding unrelated reformatting noise to future Rust diffs, which matters because the crate carries the parity-critical delimiter/dialect logic and its diffs need to stay readable against the Python oracle.

## Changes

- `cargo fmt` across `rust/` — line wrapping only. The one non-wrapping change is rustfmt alphabetizing the `pub mod` declarations in `datagrunt-core/src/lib.rs` (`delimiter` before `dialect`), which has no semantic effect in Rust.
- New blocking `cargo fmt check` step in `ci.yml`, placed beside the existing `cargo clippy` gate. It needs no `CARGO_NET_RETRY` since rustfmt does no dependency resolution.

No logic changes. `git diff --ignore-all-space` over `rust/` is line-joins and the module reorder only.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo test` | 58 passed |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `pytest tests/ -q` (Rust backend) | 1429 passed |
| `DATAGRUNT_DISABLE_RUST=1 pytest tests/ -q` | 1429 passed |
| `pytest tests/parity/ -q` | 622 passed |
| `ruff check src/datagrunt/core/csv_io` | clean |
| `ruff check src tests` | clean |
| `ruff format --check .` | 135 files formatted |

Extension rebuilt via `uv pip install -e ".[dev,pdf]"` before the Python gates.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)