### PR TITLE
fix: stop ruff 0.16 Markdown formatting from breaking the CI gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,11 @@ pdf = [
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
-    "ruff>=0.15.17",
+    # Upper-bounded deliberately: ruff's formatter output is a moving target by
+    # design (0.16 began formatting Python inside Markdown, #312), and CI gates
+    # on `ruff format --check`. Unbounded, a formatter release breaks CI on
+    # untouched code. Runtime deps stay unbounded (see #307); dev tools do not.
+    "ruff>=0.15.17,<0.17",
     "bumpver>=2026.1132",
     "maturin>=1.7,<2.0",
     "pre-commit>=4.0.0",
@@ -104,3 +108,8 @@ ignore = ["E203"]
 quote-style = "double"
 indent-style = "space"
 line-ending = "auto"
+# ruff 0.16 formats Python inside Markdown fences. Docs are hand-authored:
+# the README aligns trailing comments across example lines for readability,
+# which the formatter collapses. The gate exists to keep *source* consistent,
+# so it stops at source. See #312.
+exclude = ["*.md"]


### PR DESCRIPTION
## What

`ruff format --check .` — a blocking gate — fails on **untouched `main`**. This unbreaks it and prevents recurrence.

## Root cause

ruff 0.16 began formatting Python code blocks embedded in Markdown. The gate then started demanding a rewrite of `README.md`'s examples. Reproduced on clean `main` (`ceffdcb`):

| ruff | `ruff format --check .` |
|---|---|
| 0.15.17 | `135 files already formatted` |
| 0.16.1 | `1 file would be reformatted, 141 files already formatted` |

`pyproject.toml` had `ruff>=0.15.17` with no upper bound and CI installs fresh, so CI floats to the newest ruff. Nobody changed the README — a formatter release did. Observed in run 30576878199 (`+ ruff==0.16.1`).

## Changes

**1. Scope the formatter to source** — `exclude = ["*.md"]` under `[tool.ruff.format]`.

The README aligns trailing comments across example lines for readability, which the formatter collapses:

```python
# authored (preserved)
reader_polars = CSVReader(csv_file, engine='polars')    # String path - fast DataFrame ops
reader_duckdb = CSVReader(csv_path, engine='duckdb')    # Path object - best for SQL queries

# what the formatter wanted
reader_polars = CSVReader(csv_file, engine="polars")  # String path - fast DataFrame ops
reader_duckdb = CSVReader(csv_path, engine="duckdb")  # Path object - best for SQL queries
```

66 lines would have changed on the project's GitHub/PyPI front page. Docs are hand-authored; the gate exists to keep *source* consistent, so it stops at source.

**2. Upper-bound the dev dependency** — `ruff>=0.15.17,<0.17`.

A formatter's output is a moving target by design. Unbounded in a blocking gate, it is a standing CI outage waiting for the next release. Runtime deps stay unbounded for the library (#307); dev tooling is a different case. Dependabot can still propose deliberate bumps.

## Verification

Run with ruff 0.16.1 locally (matching CI):

| Gate | Result |
|---|---|
| `ruff format --check .` | clean — 135 files |
| `ruff check src tests` | clean |
| `ruff check src/datagrunt/core/csv_io` | clean |
| `pytest tests/ -q` (Rust backend) | 1429 passed |
| `DATAGRUNT_DISABLE_RUST=1 pytest tests/ -q` | 1429 passed |
| `pytest tests/parity/ -q` | 622 passed |

`README.md` is byte-identical — no docs churn.

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)