### PR TITLE
test: add property-based differential parity testing between the Rust and Python compute backends

### DIFF
--- a/.github/workflows/deep-property-search.yml
+++ b/.github/workflows/deep-property-search.yml
@@ -1,0 +1,58 @@
+name: Deep property search
+
+# The PR gate runs these properties derandomized at max_examples=100 so it is
+# fast and reproducible. This job does the genuinely random, long-running
+# exploration off the critical path, and caches .hypothesis/ so the example
+# database persists and previously-failing inputs are retried first.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays, 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deep-search:
+    name: hypothesis deep search (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Create venv, build the extension (editable), install dev extras
+        run: |
+          uv venv --clear
+          uv pip install -e ".[dev]"
+
+      - name: Restore the Hypothesis example database
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .hypothesis
+          key: hypothesis-${{ github.run_id }}
+          restore-keys: hypothesis-
+
+      # Advisory, NOT blocking: test_path_only_functions_agree (in
+      # test_parity_property.py) is deliberately left un-xfailed — it is the
+      # highest-value property in the suite, 6 functions times the full
+      # generator — and it can reach #317's divergence at roughly 1-in-20,000
+      # examples. At this profile's 10,000 examples per property, that makes a
+      # failure here naming `count_leading_physical_lines_before_header` a
+      # recurring, already-known result, not a new one: see
+      # https://github.com/pmgraham/datagrunt/issues/317.
+      #
+      # Remove this continue-on-error once #317 lands. A standing red that
+      # nobody can act on trains people to ignore this job, which defeats its
+      # purpose.
+      - name: Deep property search
+        continue-on-error: true
+        env:
+          HYPOTHESIS_PROFILE: deep
+        run: .venv/bin/pytest tests/parity/test_parity_property.py -q -p no:randomly

--- a/.github/workflows/deep-property-search.yml
+++ b/.github/workflows/deep-property-search.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   deep-search:
-    name: hypothesis deep search (advisory)
+    name: hypothesis deep search
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -39,20 +39,18 @@ jobs:
           key: hypothesis-${{ github.run_id }}
           restore-keys: hypothesis-
 
-      # Advisory, NOT blocking: test_path_only_functions_agree (in
-      # test_parity_property.py) is deliberately left un-xfailed — it is the
-      # highest-value property in the suite, 6 functions times the full
-      # generator — and it can reach #317's divergence at roughly 1-in-20,000
-      # examples. At this profile's 10,000 examples per property, that makes a
-      # failure here naming `count_leading_physical_lines_before_header` a
-      # recurring, already-known result, not a new one: see
-      # https://github.com/pmgraham/datagrunt/issues/317.
+      # EXPECTED GREEN, and blocking. Every known divergence is pinned in
+      # test_parity_property.py — #317 by a per-example .xfail(), #318 by a
+      # test-level one — so a red run here means the search found something NEW.
+      # Investigate it; do not paper over it with continue-on-error. A standing
+      # red that nobody can act on trains people to ignore this job, which
+      # defeats its purpose.
       #
-      # Remove this continue-on-error once #317 lands. A standing red that
-      # nobody can act on trains people to ignore this job, which defeats its
-      # purpose.
+      # Depth comes from HYPOTHESIS_PROFILE, not from a pytest marker, so no -m
+      # override is needed. --no-cov because coverage tracing across ~70,000
+      # file-I/O examples is pure overhead in a job whose only product is search
+      # depth.
       - name: Deep property search
-        continue-on-error: true
         env:
           HYPOTHESIS_PROFILE: deep
-        run: .venv/bin/pytest tests/parity/test_parity_property.py -q -p no:randomly
+        run: .venv/bin/pytest tests/parity/test_parity_property.py -q --no-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ dev = [
     "bumpver>=2026.1132",
     "maturin>=1.7,<2.0",
     "pre-commit>=4.0.0",
+    # Bounded at the major only, unlike ruff (#312) and mypy (#314): Hypothesis
+    # is a library whose API is stable across 6.x, not a linter that adds
+    # default-on failures in minor releases. A 6.x bump cannot redden this gate
+    # on untouched code the way a formatter or type-checker release can.
+    "hypothesis>=6.164.0,<7.0",
 ]
 
 [project.urls]
@@ -89,10 +94,11 @@ testpaths = "tests"
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-v --cov=src/datagrunt --cov-report=term-missing -m 'not corpus'"
+addopts = "-v --cov=src/datagrunt --cov-report=term-missing -m 'not corpus and not deep'"
 pythonpath = "."
 markers = [
     "corpus: slow, local-only cross-engine tests over the data/pdfs corpus (deselected by default; run with -m corpus)",
+    "deep: long property searches; run by the scheduled job, deselected by default",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,13 @@ dev = [
     "bumpver>=2026.1132",
     "maturin>=1.7,<2.0",
     "pre-commit>=4.0.0",
-    # Bounded at the major only, unlike ruff (#312) and mypy (#314): Hypothesis
-    # is a library whose API is stable across 6.x, not a linter that adds
-    # default-on failures in minor releases. A 6.x bump cannot redden this gate
-    # on untouched code the way a formatter or type-checker release can.
-    "hypothesis>=6.164.0,<7.0",
+    # Bounded to the next minor, same as ruff (#312) and mypy (#314).
+    # Hypothesis's compatibility guarantee covers the DOCUMENTED API only;
+    # validation strictness can tighten in any 6.x minor (6.140.0 made
+    # characters(exclude_characters=...) reject multi-char strings; 6.136.2
+    # made @precondition without @rule raise). Either would redden this gate
+    # on untouched code.
+    "hypothesis>=6.164.0,<6.165",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,19 @@ dev = [
     "bumpver>=2026.1132",
     "maturin>=1.7,<2.0",
     "pre-commit>=4.0.0",
-    # Bounded to the next minor, same as ruff (#312) and mypy (#314).
-    # Hypothesis's compatibility guarantee covers the DOCUMENTED API only;
-    # validation strictness can tighten in any 6.x minor (6.140.0 made
-    # characters(exclude_characters=...) reject multi-char strings; 6.136.2
-    # made @precondition without @rule raise). Either would redden this gate
-    # on untouched code.
+    # Pinned to a SINGLE minor — deliberately tighter than ruff (<0.17, two
+    # minors) and mypy (<1.21, seven), so do not read those as precedent for
+    # this bound. Two reasons for the extra tightness. Hypothesis's
+    # compatibility guarantee covers the DOCUMENTED API only, and validation
+    # strictness tightens in ordinary minors (6.140.0 made
+    # characters(exclude_characters=...) reject multi-char strings; 6.136.2 made
+    # @precondition without @rule raise) — either reddens this blocking gate on
+    # untouched code. More important, tests/parity/test_parity_strategies.py's
+    # vacuity guard asserts on the GENERATION DISTRIBUTION, which is not part of
+    # any compatibility promise and shifts freely between minors. Reproducible
+    # parity search is worth the cost, and the cost is real: Hypothesis ships
+    # minors roughly weekly, so expect near-continuous Dependabot bumps here.
+    # Take them one at a time and re-run the parity suite on each.
     "hypothesis>=6.164.0,<6.165",
 ]
 
@@ -96,11 +103,15 @@ testpaths = "tests"
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-v --cov=src/datagrunt --cov-report=term-missing -m 'not corpus and not deep'"
+addopts = "-v --cov=src/datagrunt --cov-report=term-missing -m 'not corpus'"
 pythonpath = "."
+# No `deep` marker on purpose. The scheduled deep search selects its work by
+# Hypothesis profile (HYPOTHESIS_PROFILE=deep) and file path, never by marker,
+# so registering one would only create a trap: a `deep`-marked test would be
+# deselected by this addopts AND unselected by the deep job, and would run
+# nowhere. Depth is a profile, not a marker.
 markers = [
     "corpus: slow, local-only cross-engine tests over the data/pdfs corpus (deselected by default; run with -m corpus)",
-    "deep: long property searches; run by the scheduled job, deselected by default",
 ]
 
 [tool.ruff]

--- a/tests/parity/conftest.py
+++ b/tests/parity/conftest.py
@@ -1,8 +1,11 @@
 """Differential parity harness: every test compares datagrunt_rs (Rust)
 against the Python implementation in datagrunt.core.csv_io.csvcomponents."""
 
+import os
+
 import pytest
 from corpus import CORPUS
+from hypothesis import HealthCheck, settings
 
 
 @pytest.fixture(scope="session")
@@ -18,3 +21,19 @@ def corpus_dir(tmp_path_factory):
 def corpus_file(request, corpus_dir):
     """One corpus file per parametrized test case."""
     return corpus_dir / request.param
+
+
+# derandomize: a random seed in the PR gate produces failures that do not
+# reproduce on re-run, which is worse than no test. The scheduled `deep` job is
+# where genuinely random exploration happens.
+# deadline: every example writes a temp file, so per-example timing is noisy
+# and a deadline would be a pure flake source.
+settings.register_profile("ci", max_examples=100, derandomize=True, deadline=None)
+settings.register_profile("dev", max_examples=200, deadline=None)
+settings.register_profile(
+    "deep",
+    max_examples=10_000,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "ci"))

--- a/tests/parity/corpus.py
+++ b/tests/parity/corpus.py
@@ -123,15 +123,25 @@ CORPUS: dict[str, bytes] = {
     #     same first_row / sample_rows as Python for both backends.
     "c0_leading_trailing_strip.csv": b"\x1cname,age\x1d\nalice,30\nbob,25\n",
     # KNOWN DIVERGENCE (see #317), found by tests/parity/test_parity_property.py.
-    # A file whose bytes are non-empty but decode to the EMPTY string under
-    # errors="ignore", with no line terminator: every byte is dropped by the
-    # decoder, so there is no text left to form a line.
-    #   count_leading_physical_lines_before_header -> Rust 1, Python 0.
-    # Rust's universal_lines works on the byte stream and emits a final
-    # (now empty) line because bytes remained unterminated; CPython iterates
-    # DECODED text, which is "", so it yields no lines at all. Appending a
-    # terminator (b"\x80\n") makes both return 1, and b"\x80a" makes both
-    # return 1 — only the fully-dropped, unterminated case diverges.
+    # b"\x80" is the MINIMAL case, not the whole shape. The general shape is:
+    # TRAILING UNTERMINATED BYTES THAT DECODE TO "" under errors="ignore", where
+    # every line before them is blank or a comment.
+    #   count_leading_physical_lines_before_header -> Rust n+1, Python n.
+    # Rust's universal_lines works on the byte stream and emits a final (now
+    # empty) line because bytes remained unterminated; CPython iterates DECODED
+    # text, where those bytes have vanished, so it yields no final line. The
+    # "blank or comment" clause is the counter's loop condition: it stops at the
+    # first non-blank non-comment line, so the phantom line is only reachable
+    # while no header has been seen yet.
+    # The FILE need not decode to "" — only its unterminated tail. Verified:
+    #   b"\x80"                     -> 1 / 0   b"# c\n\xc3"          -> 2 / 1
+    #   b"\n\xe9\xff\xfe"           -> 2 / 1   b"\n\n\xe9\xff\xfe"   -> 3 / 2
+    #   b"\xef\xbb\xbf\xe9\xff\xfe" -> 1 / 0   b"# a\n# b\n\xc3"     -> 3 / 2
+    # A truncated UTF-8 download with a comment header is the realistic form.
+    # Both agree once the phantom line cannot form or cannot be reached:
+    # b"\x80\n" and b"\x80a" (1/1), b"# c\n\xc3\n" (2/2), b"a,b\n\xc3" (1/1,
+    # header consumed first). A fix and its regression test must cover the whole
+    # shape above, not just this single-byte case.
     "invalid_utf8_only_no_newline.csv": b"\x80",
     # KNOWN DIVERGENCE (see #318), found by tests/parity/test_parity_property.py.
     # sniff_dialect's own `delimiter` differs on characters where CPython's `\w`

--- a/tests/parity/corpus.py
+++ b/tests/parity/corpus.py
@@ -122,7 +122,7 @@ CORPUS: dict[str, bytes] = {
     # (e) Header with leading/trailing C0 separators: stripping must yield the
     #     same first_row / sample_rows as Python for both backends.
     "c0_leading_trailing_strip.csv": b"\x1cname,age\x1d\nalice,30\nbob,25\n",
-    # KNOWN DIVERGENCE (see #NNN), found by tests/parity/test_parity_property.py.
+    # KNOWN DIVERGENCE (see #317), found by tests/parity/test_parity_property.py.
     # A file whose bytes are non-empty but decode to the EMPTY string under
     # errors="ignore", with no line terminator: every byte is dropped by the
     # decoder, so there is no text left to form a line.
@@ -133,14 +133,16 @@ CORPUS: dict[str, bytes] = {
     # terminator (b"\x80\n") makes both return 1, and b"\x80a" makes both
     # return 1 — only the fully-dropped, unterminated case diverges.
     "invalid_utf8_only_no_newline.csv": b"\x80",
-    # KNOWN DIVERGENCE (see #NNN), found by tests/parity/test_parity_property.py.
+    # KNOWN DIVERGENCE (see #318), found by tests/parity/test_parity_property.py.
     # sniff_dialect's own `delimiter` differs on characters where CPython's `\w`
-    # and the Rust regex crate's `\w` disagree, because the sniffer's delimiter
-    # class is `[^\w\n"']`:
+    # and fancy-regex's `\w` disagree, because the sniffer's delimiter class is
+    # `[^\w\n"']`:
     #   - CPython `\w` is str.isalnum()-based, so it MATCHES category No
     #     (U+00B2 '²', U+00BD '½', U+2460 '①') -> not a delimiter candidate.
-    #   - The regex crate's `\w` is [\p{Alphabetic}\p{M}\p{Nd}\p{Pc}\p{Join_Control}],
-    #     which excludes No -> '²' IS a candidate and wins.
+    #   - fancy-regex (rust/datagrunt-core/Cargo.toml) inherits regex-syntax's
+    #     UTS#18 perl_word table, so its `\w` is
+    #     [\p{Alphabetic}\p{M}\p{Nd}\p{Pc}\p{Join_Control}], which excludes No
+    #     -> '²' IS a candidate and wins.
     # Rust sniffs delimiter '²'; Python sniffs '"'. The reverse holds for marks
     # (U+0301, category Mn): Python picks it, Rust does not.
     # Every other sniffed field agrees, so the corpus dialect tests (which

--- a/tests/parity/corpus.py
+++ b/tests/parity/corpus.py
@@ -122,4 +122,29 @@ CORPUS: dict[str, bytes] = {
     # (e) Header with leading/trailing C0 separators: stripping must yield the
     #     same first_row / sample_rows as Python for both backends.
     "c0_leading_trailing_strip.csv": b"\x1cname,age\x1d\nalice,30\nbob,25\n",
+    # KNOWN DIVERGENCE (see #NNN), found by tests/parity/test_parity_property.py.
+    # A file whose bytes are non-empty but decode to the EMPTY string under
+    # errors="ignore", with no line terminator: every byte is dropped by the
+    # decoder, so there is no text left to form a line.
+    #   count_leading_physical_lines_before_header -> Rust 1, Python 0.
+    # Rust's universal_lines works on the byte stream and emits a final
+    # (now empty) line because bytes remained unterminated; CPython iterates
+    # DECODED text, which is "", so it yields no lines at all. Appending a
+    # terminator (b"\x80\n") makes both return 1, and b"\x80a" makes both
+    # return 1 — only the fully-dropped, unterminated case diverges.
+    "invalid_utf8_only_no_newline.csv": b"\x80",
+    # KNOWN DIVERGENCE (see #NNN), found by tests/parity/test_parity_property.py.
+    # sniff_dialect's own `delimiter` differs on characters where CPython's `\w`
+    # and the Rust regex crate's `\w` disagree, because the sniffer's delimiter
+    # class is `[^\w\n"']`:
+    #   - CPython `\w` is str.isalnum()-based, so it MATCHES category No
+    #     (U+00B2 '²', U+00BD '½', U+2460 '①') -> not a delimiter candidate.
+    #   - The regex crate's `\w` is [\p{Alphabetic}\p{M}\p{Nd}\p{Pc}\p{Join_Control}],
+    #     which excludes No -> '²' IS a candidate and wins.
+    # Rust sniffs delimiter '²'; Python sniffs '"'. The reverse holds for marks
+    # (U+0301, category Mn): Python picks it, Rust does not.
+    # Every other sniffed field agrees, so the corpus dialect tests (which
+    # normalize through dialect_properties_from_rust and drop `delimiter`)
+    # cannot see this; the property suite compares the raw dicts.
+    "sniff_delimiter_word_class.csv": b'"\'"\'\n"\xc2\xb2\'"',
 }

--- a/tests/parity/strategies.py
+++ b/tests/parity/strategies.py
@@ -1,0 +1,200 @@
+"""Hypothesis strategies and primitives for differential parity testing.
+
+Generates CSV-shaped bytes aimed at the seams both backends special-case, and
+carries a label set describing which seams each example actually hit so the
+suite can prove it is not testing one shape ten thousand times.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+from hypothesis import strategies as st
+
+# Delimiters the inference logic ranks and tie-breaks between.
+DELIMITERS = [",", ";", "|", "\t", ":", ".", "'", " "]
+LINE_TERMINATORS = ["\n", "\r\n", "\r"]
+EXTENSIONS = [".csv", ".tsv", ".TSV", ".txt"]
+
+# Python's str.split() treats these as whitespace; Rust's char::is_whitespace
+# does not. rust/datagrunt-core/src/io.rs (is_python_whitespace) calls this the
+# ONLY divergence between the two, bridged by py_split_whitespace — so
+# generated input must reach it.
+C0_WHITESPACE = ["\x1c", "\x1d", "\x1e", "\x1f"]
+
+BOM = b"\xef\xbb\xbf"
+INVALID_UTF8 = b"\xe9\xff\xfe"
+
+SEAM_LABELS = frozenset(
+    {
+        "bom",
+        "lf",
+        "crlf",
+        "legacy-mac",
+        "quoted",
+        "embedded-delimiter",
+        "embedded-newline",
+        "comments",
+        "blank-lines",
+        "ragged",
+        "invalid-utf8",
+        "c0-controls",
+        "no-trailing-newline",
+        "tsv-extension",
+        "empty",
+        "single-column",
+    }
+)
+
+
+@dataclass(frozen=True)
+class GeneratedCSV:
+    """One generated example: the bytes, the filename suffix, and the seams hit."""
+
+    data: bytes
+    suffix: str
+    seams: frozenset[str]
+
+
+@contextmanager
+def csv_file(data: bytes, suffix: str = ".csv"):
+    """Write `data` to a temp file, yield its path as str, always clean up.
+
+    A context manager rather than a pytest fixture: Hypothesis re-runs a test
+    body many times against one function-scoped fixture instance, which trips
+    HealthCheck.function_scoped_fixture. Owning the file here sidesteps that
+    without suppressing a health check that exists for good reason.
+    """
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+        yield path
+    finally:
+        os.unlink(path)
+
+
+def outcome(fn, *args):
+    """Collapse a call into a comparable ('ok', value) or ('raised', name).
+
+    Comparing outcomes rather than return values is what lets one primitive
+    cover both value parity and panic-freedom: a Rust panic crossing PyO3
+    arrives as PanicException, a name the Python oracle can never produce, so
+    any reachable panic becomes a parity failure with a minimized repro.
+
+    OSError subclasses are normalized to the family name because PyO3 maps io
+    errors to bare OSError while CPython raises specific subclasses; without
+    this, every missing-file example would read as a false divergence.
+    PanicException is not an OSError, so this narrowing cannot hide a panic.
+    """
+    try:
+        return ("ok", fn(*args))
+    except OSError:
+        return ("raised", "OSError")
+    except Exception as exc:  # noqa: BLE001 - comparing behavior, not handling it
+        return ("raised", type(exc).__name__)
+
+
+# exclude_categories, not the blacklist_categories alias: the old spelling is
+# still accepted by 6.164.0 but is a documented deprecated alias that warns
+# about nothing today and can disappear in any minor.
+_TEXT = st.text(
+    alphabet=st.characters(min_codepoint=32, max_codepoint=0x2FFF, exclude_categories=("Cs",)),
+    max_size=12,
+)
+
+
+@st.composite
+def csv_bytes(draw) -> GeneratedCSV:
+    """Build a CSV-shaped example plus the set of seams it exercises."""
+    seams: set[str] = set()
+
+    delimiter = draw(st.sampled_from(DELIMITERS))
+    terminator = draw(st.sampled_from(LINE_TERMINATORS))
+    seams.add({"\n": "lf", "\r\n": "crlf", "\r": "legacy-mac"}[terminator])
+
+    suffix = draw(st.sampled_from(EXTENSIONS))
+    if suffix.lower() == ".tsv":
+        seams.add("tsv-extension")
+
+    n_fields = draw(st.integers(min_value=1, max_value=5))
+    if n_fields == 1:
+        seams.add("single-column")
+    n_rows = draw(st.integers(min_value=0, max_value=6))
+
+    def make_field() -> str:
+        text = draw(_TEXT)
+        if draw(st.booleans()) and draw(st.booleans()):
+            text += draw(st.sampled_from(C0_WHITESPACE))
+            seams.add("c0-controls")
+        if draw(st.booleans()) and draw(st.booleans()):
+            text += delimiter
+            seams.add("embedded-delimiter")
+            text = f'"{text}"'
+            seams.add("quoted")
+        elif draw(st.booleans()) and draw(st.booleans()):
+            text = f'"{text}\n more"'
+            seams.add("embedded-newline")
+            seams.add("quoted")
+        elif draw(st.booleans()):
+            text = f'"{text}"'
+            seams.add("quoted")
+        return text
+
+    lines: list[str] = []
+
+    for _ in range(draw(st.integers(min_value=0, max_value=3))):
+        lines.append("# " + draw(_TEXT))
+        seams.add("comments")
+
+    header = [make_field() for _ in range(n_fields)]
+    lines.append(delimiter.join(header))
+
+    for _ in range(n_rows):
+        if draw(st.booleans()) and draw(st.booleans()):
+            lines.append("")
+            seams.add("blank-lines")
+        width = n_fields
+        if draw(st.booleans()) and draw(st.booleans()):
+            width = draw(st.integers(min_value=1, max_value=n_fields + 2))
+            if width != n_fields:
+                seams.add("ragged")
+        lines.append(delimiter.join(make_field() for _ in range(width)))
+
+    text = terminator.join(lines)
+    if lines and draw(st.booleans()):
+        text += terminator
+    else:
+        seams.add("no-trailing-newline")
+
+    data = text.encode("utf-8")
+
+    if draw(st.booleans()) and draw(st.booleans()):
+        data = BOM + data
+        seams.add("bom")
+    if draw(st.booleans()) and draw(st.booleans()) and draw(st.booleans()):
+        data += INVALID_UTF8
+        seams.add("invalid-utf8")
+    if not data:
+        seams.add("empty")
+
+    return GeneratedCSV(data=data, suffix=suffix, seams=frozenset(seams))
+
+
+def raw_bytes():
+    """Arbitrary bytes. Most examples are garbage both backends reject the same
+    way; the job here is finding input that crashes one of them."""
+    return st.binary(max_size=200)
+
+
+def column_names():
+    """Column-name lists for normalize_columns: duplicates, empties, unicode,
+    and names that collide only after normalization."""
+    name = st.one_of(
+        _TEXT,
+        st.sampled_from(["", " ", "col a", "COL-B", "col_a", "col_a_1", "123abc", "%", "näme", "城市"]),
+    )
+    return st.lists(name, max_size=8)

--- a/tests/parity/strategies.py
+++ b/tests/parity/strategies.py
@@ -25,6 +25,14 @@ EXTENSIONS = [".csv", ".tsv", ".TSV", ".txt"]
 # generated input must reach it.
 C0_WHITESPACE = ["\x1c", "\x1d", "\x1e", "\x1f"]
 
+# A NUL is a version-dependent seam, not just an odd byte: Python < 3.11's csv
+# module raises "line contains NUL" where the Rust csv crate reads it as
+# ordinary field content, which is why _compute_python._nul_safe_lines exists.
+# CI's compat matrix still includes 3.10, so the property layer has to be able
+# to combine a NUL with ragged/BOM/CRLF — corpus.py's static interior_nul.csv
+# covers the plain case only.
+NUL = "\x00"
+
 BOM = b"\xef\xbb\xbf"
 INVALID_UTF8 = b"\xe9\xff\xfe"
 
@@ -46,6 +54,7 @@ SEAM_LABELS = frozenset(
         "tsv-extension",
         "empty",
         "single-column",
+        "nul-byte",
     }
 )
 
@@ -85,6 +94,17 @@ def outcome(fn, *args):
     arrives as PanicException, a name the Python oracle can never produce, so
     any reachable panic becomes a parity failure with a minimized repro.
 
+    Catching BaseException is deliberate, and the clause order with it. PyO3
+    declares PanicException with PyBaseException as its base (pyo3/src/panic.rs:
+    "Like SystemExit, this exception is derived from BaseException so that it
+    will typically propagate all the way through the stack"), so an `except
+    Exception` clause would let a real panic straight through. Hypothesis's
+    failure_exceptions_to_catch() covers Exception, SystemExit and GeneratorExit
+    only, so an escaping panic reddens the suite *unshrunk* — no minimized
+    repro, which is the entire benefit above. Catching it here turns the panic
+    into an ordinary tuple mismatch, and Hypothesis shrinks that. Control-flow
+    exceptions are re-raised first so the broad clause cannot swallow them.
+
     OSError subclasses are normalized to the family name because PyO3 maps io
     errors to bare OSError while CPython raises specific subclasses; without
     this, every missing-file example would read as a false divergence.
@@ -92,9 +112,11 @@ def outcome(fn, *args):
     """
     try:
         return ("ok", fn(*args))
+    except (KeyboardInterrupt, SystemExit):
+        raise
     except OSError:
         return ("raised", "OSError")
-    except Exception as exc:  # noqa: BLE001 - comparing behavior, not handling it
+    except BaseException as exc:  # noqa: BLE001 - comparing behavior, not handling it
         return ("raised", type(exc).__name__)
 
 
@@ -105,6 +127,18 @@ _TEXT = st.text(
     alphabet=st.characters(min_codepoint=32, max_codepoint=0x2FFF, exclude_categories=("Cs",)),
     max_size=12,
 )
+
+
+def _rare(draw) -> bool:
+    """A low-probability gate for one seam: two ANDed boolean draws, ~1 in 4.
+
+    Two rather than one so most examples stay plain and shrinking drops the
+    seam readily (Hypothesis shrinks each boolean toward False), and two rather
+    than three because ~1 in 8 is too rare at the ci profile's 100 examples —
+    `invalid-utf8` sat behind a third ANDed draw and went missing entirely on
+    seeds 4 and 8. Keep new seams at this gate unless you measure otherwise.
+    """
+    return draw(st.booleans()) and draw(st.booleans())
 
 
 @st.composite
@@ -127,15 +161,18 @@ def csv_bytes(draw) -> GeneratedCSV:
 
     def make_field() -> str:
         text = draw(_TEXT)
-        if draw(st.booleans()) and draw(st.booleans()):
+        if _rare(draw):
             text += draw(st.sampled_from(C0_WHITESPACE))
             seams.add("c0-controls")
-        if draw(st.booleans()) and draw(st.booleans()):
+        if _rare(draw):
+            text += NUL
+            seams.add("nul-byte")
+        if _rare(draw):
             text += delimiter
             seams.add("embedded-delimiter")
             text = f'"{text}"'
             seams.add("quoted")
-        elif draw(st.booleans()) and draw(st.booleans()):
+        elif _rare(draw):
             text = f'"{text}\n more"'
             seams.add("embedded-newline")
             seams.add("quoted")
@@ -154,11 +191,11 @@ def csv_bytes(draw) -> GeneratedCSV:
     lines.append(delimiter.join(header))
 
     for _ in range(n_rows):
-        if draw(st.booleans()) and draw(st.booleans()):
+        if _rare(draw):
             lines.append("")
             seams.add("blank-lines")
         width = n_fields
-        if draw(st.booleans()) and draw(st.booleans()):
+        if _rare(draw):
             width = draw(st.integers(min_value=1, max_value=n_fields + 2))
             if width != n_fields:
                 seams.add("ragged")
@@ -172,10 +209,10 @@ def csv_bytes(draw) -> GeneratedCSV:
 
     data = text.encode("utf-8")
 
-    if draw(st.booleans()) and draw(st.booleans()):
+    if _rare(draw):
         data = BOM + data
         seams.add("bom")
-    if draw(st.booleans()) and draw(st.booleans()) and draw(st.booleans()):
+    if _rare(draw):
         data += INVALID_UTF8
         seams.add("invalid-utf8")
     if not data:

--- a/tests/parity/strategies.py
+++ b/tests/parity/strategies.py
@@ -86,6 +86,12 @@ def csv_file(data: bytes, suffix: str = ".csv"):
         os.unlink(path)
 
 
+# The name outcome() reports for a Rust panic crossing the PyO3 boundary. PyO3
+# raises pyo3_runtime.PanicException, whose __name__ is this; the Python oracle
+# can never produce it, which makes it an unambiguous crash signal.
+PANIC_EXCEPTION_NAME = "PanicException"
+
+
 def outcome(fn, *args):
     """Collapse a call into a comparable ('ok', value) or ('raised', name).
 

--- a/tests/parity/test_parity_probes.py
+++ b/tests/parity/test_parity_probes.py
@@ -9,7 +9,7 @@ from datagrunt.core.csv_io import _compute_python as py
 COUNT_LEADING_PHYSICAL_LINES_DIVERGENCES = {
     "invalid_utf8_only_no_newline.csv": (
         "bytes that decode to '' under errors='ignore' with no terminator: Rust counts a final empty line "
-        "(1), CPython iterates decoded text and yields none (0), see #NNN"
+        "(1), CPython iterates decoded text and yields none (0), see #317"
     ),
 }
 

--- a/tests/parity/test_parity_probes.py
+++ b/tests/parity/test_parity_probes.py
@@ -1,5 +1,17 @@
+import pytest
+
 from datagrunt import _native as datagrunt_rs
 from datagrunt.core.csv_io import _compute_python as py
+
+# Corpus cases with a known, tracked backend divergence, mapped to the reason.
+# Applied per-case as a STRICT xfail: fixing the divergence turns it into an
+# XPASS failure, which forces the entry (and this table) out again.
+COUNT_LEADING_PHYSICAL_LINES_DIVERGENCES = {
+    "invalid_utf8_only_no_newline.csv": (
+        "bytes that decode to '' under errors='ignore' with no terminator: Rust counts a final empty line "
+        "(1), CPython iterates decoded text and yields none (0), see #NNN"
+    ),
+}
 
 
 def test_is_legacy_mac_newlines(corpus_file):
@@ -10,7 +22,10 @@ def test_count_leading_comments(corpus_file):
     assert datagrunt_rs.count_leading_comments(str(corpus_file)) == py.count_leading_comments(str(corpus_file))
 
 
-def test_count_leading_physical_lines_before_header(corpus_file):
+def test_count_leading_physical_lines_before_header(corpus_file, request):
+    reason = COUNT_LEADING_PHYSICAL_LINES_DIVERGENCES.get(corpus_file.name)
+    if reason:
+        request.applymarker(pytest.mark.xfail(strict=True, reason=reason))
     assert datagrunt_rs.count_leading_physical_lines_before_header(
         str(corpus_file)
     ) == py.count_leading_physical_lines_before_header(str(corpus_file))

--- a/tests/parity/test_parity_property.py
+++ b/tests/parity/test_parity_property.py
@@ -54,15 +54,15 @@ def test_leading_rows_agrees(gen, limit):
     strict=True,
     reason=(
         "sniff_dialect's delimiter class is [^\\w\\n\"'], and CPython's \\w (str.isalnum()-based) "
-        "disagrees with the Rust regex crate's \\w on category No (U+00B2) and on marks (U+0301), "
-        "so the two sniff different delimiters. Corpus case sniff_delimiter_word_class.csv. See #NNN"
+        "disagrees with fancy-regex's \\w on category No (U+00B2) and on marks (U+0301), so the "
+        "two sniff different delimiters. Corpus case sniff_delimiter_word_class.csv. See #318"
     ),
 )
 @example(
     # The minimized falsifying example, pinned so this fails at every profile
     # rather than only where the search happens to reach it (it was found at the
     # deep profile, not at ci's 100 examples). Keep as a regression case once
-    # #NNN is fixed and the xfail comes off.
+    # #318 is fixed and the xfail comes off.
     gen=GeneratedCSV(
         data=b'"\'"\'\n"\xc2\xb2\'"',
         suffix=".csv",
@@ -112,13 +112,13 @@ def test_normalize_columns_agrees(names):
         "count_leading_physical_lines_before_header diverges on bytes that decode to '' under "
         "errors='ignore' with no line terminator (b'\\x80'): Rust counts a final empty line (1), "
         "CPython iterates decoded text and yields none (0). Corpus case "
-        "invalid_utf8_only_no_newline.csv. See #NNN"
+        "invalid_utf8_only_no_newline.csv. See #317"
     ),
 )
 @example(
     # The minimized falsifying example, pinned so the failure does not depend on
     # the search reaching it under a given profile or Hypothesis version. Keep as
-    # a regression case once #NNN is fixed and the xfail comes off.
+    # a regression case once #317 is fixed and the xfail comes off.
     data=b"\x80",
     fn_name="count_leading_physical_lines_before_header",
 )

--- a/tests/parity/test_parity_property.py
+++ b/tests/parity/test_parity_property.py
@@ -1,0 +1,130 @@
+"""Differential properties: the two compute backends must agree on generated input.
+
+The fixed corpus in corpus.py proves the cases someone thought to write down.
+These prove the cases nobody did. Every property compares *outcomes* — returned
+value or raised exception — so a Rust panic crossing PyO3 is a parity failure
+with a minimized repro attached, not a mysterious crash.
+
+On divergence: minimize, add the bytes to corpus.py as a named case, open an
+issue, and mark that property xfail(strict=True) with the issue link. Do not
+weaken a property to make it pass.
+"""
+
+import pytest
+from hypothesis import event, example, given
+from hypothesis import strategies as st
+from strategies import GeneratedCSV, column_names, csv_bytes, csv_file, outcome, raw_bytes
+
+from datagrunt import _native as rs
+from datagrunt.core.csv_io import _compute_python as py
+
+# Functions taking only a path.
+PATH_ONLY = [
+    "is_legacy_mac_newlines",
+    "first_row",
+    "count_leading_comments",
+    "count_leading_physical_lines_before_header",
+    "infer_delimiter",
+    "probe_csv_header",
+]
+
+
+def _record(gen):
+    """Surface which seams this example hit, for --hypothesis-show-statistics."""
+    for seam in gen.seams:
+        event(seam)
+
+
+@given(gen=csv_bytes(), fn_name=st.sampled_from(PATH_ONLY))
+def test_path_only_functions_agree(gen, fn_name):
+    _record(gen)
+    event(f"fn:{fn_name}")
+    with csv_file(gen.data, gen.suffix) as path:
+        assert outcome(getattr(rs, fn_name), path) == outcome(getattr(py, fn_name), path), fn_name
+
+
+@given(gen=csv_bytes(), limit=st.integers(min_value=0, max_value=200))
+def test_leading_rows_agrees(gen, limit):
+    _record(gen)
+    with csv_file(gen.data, gen.suffix) as path:
+        assert outcome(rs.leading_rows, path, limit) == outcome(py.leading_rows, path, limit)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "sniff_dialect's delimiter class is [^\\w\\n\"'], and CPython's \\w (str.isalnum()-based) "
+        "disagrees with the Rust regex crate's \\w on category No (U+00B2) and on marks (U+0301), "
+        "so the two sniff different delimiters. Corpus case sniff_delimiter_word_class.csv. See #NNN"
+    ),
+)
+@example(
+    # The minimized falsifying example, pinned so this fails at every profile
+    # rather than only where the search happens to reach it (it was found at the
+    # deep profile, not at ci's 100 examples). Keep as a regression case once
+    # #NNN is fixed and the xfail comes off.
+    gen=GeneratedCSV(
+        data=b'"\'"\'\n"\xc2\xb2\'"',
+        suffix=".csv",
+        seams=frozenset({"embedded-delimiter", "lf", "no-trailing-newline", "quoted", "ragged"}),
+    ),
+    delimiter=None,
+)
+@given(gen=csv_bytes(), delimiter=st.one_of(st.none(), st.sampled_from([",", ";", "|", "\t", ":", " "])))
+def test_sniff_dialect_agrees(gen, delimiter):
+    """Compares the RAW dicts, including `delimiter`.
+
+    The corpus suite normalizes both sides through dialect_properties_from_rust,
+    which drops `delimiter` — so sniff_dialect's own delimiter output has never
+    been compared. This closes that gap.
+    """
+    _record(gen)
+    with csv_file(gen.data, gen.suffix) as path:
+        args = (path,) if delimiter is None else (path, delimiter)
+        assert outcome(rs.sniff_dialect, *args) == outcome(py.sniff_dialect, *args)
+
+
+@given(gen=csv_bytes(), delimiter=st.sampled_from([",", ";", "|", "\t", ":", " ", "x"]))
+def test_row_count_with_header_agrees(gen, delimiter):
+    _record(gen)
+    with csv_file(gen.data, gen.suffix) as path:
+        assert outcome(rs.row_count_with_header, path, delimiter) == outcome(py.row_count_with_header, path, delimiter)
+
+
+@given(gen=csv_bytes(), delimiter=st.sampled_from([",", ";", "|", "\t", ":", " ", "x"]))
+def test_check_ragged_agrees(gen, delimiter):
+    _record(gen)
+    with csv_file(gen.data, gen.suffix) as path:
+        assert outcome(rs.check_ragged, path, delimiter) == outcome(py.check_ragged, path, delimiter)
+
+
+@given(names=column_names())
+def test_normalize_columns_agrees(names):
+    """Takes a list, not a path — duplicates and post-normalization collisions
+    are the interesting cases."""
+    event(f"n_names:{len(names)}")
+    assert outcome(rs.normalize_columns, names) == outcome(py.normalize_columns, names)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "count_leading_physical_lines_before_header diverges on bytes that decode to '' under "
+        "errors='ignore' with no line terminator (b'\\x80'): Rust counts a final empty line (1), "
+        "CPython iterates decoded text and yields none (0). Corpus case "
+        "invalid_utf8_only_no_newline.csv. See #NNN"
+    ),
+)
+@example(
+    # The minimized falsifying example, pinned so the failure does not depend on
+    # the search reaching it under a given profile or Hypothesis version. Keep as
+    # a regression case once #NNN is fixed and the xfail comes off.
+    data=b"\x80",
+    fn_name="count_leading_physical_lines_before_header",
+)
+@given(data=raw_bytes(), fn_name=st.sampled_from(PATH_ONLY))
+def test_arbitrary_bytes_do_not_diverge(data, fn_name):
+    """Crash hunt. Most examples are garbage both backends reject identically;
+    the value is the one that does not."""
+    with csv_file(data, ".csv") as path:
+        assert outcome(getattr(rs, fn_name), path) == outcome(getattr(py, fn_name), path), fn_name

--- a/tests/parity/test_parity_property.py
+++ b/tests/parity/test_parity_property.py
@@ -51,15 +51,19 @@ KNOWN_DIVERGENT_FN = "count_leading_physical_lines_before_header"
 # failure and stops before `generate` ever executes. The property keeps reporting
 # activity while searching nothing.
 #
-# Both generators reach #317: csv_bytes at roughly 1-in-20,000 examples, and
-# raw_bytes far faster — it rediscovers b"\x80" within ~75 examples, so the ci
-# profile alone would trip it.
+# Both generators reach #317. Measured: csv_bytes at 1-in-2,857 (14/40,000), so
+# a deep run hits it with ~97% probability; raw_bytes at 9.9% of examples
+# (198/2,000, first hit at example #4) — every invalid lone byte triggers it, not
+# just b"\x80" — so even the ci profile's 100 examples trip it essentially always.
 #
-# Nothing is left uncovered meanwhile. The divergence stays strictly asserted by
-# the pinned .xfail() example on test_arbitrary_bytes_do_not_diverge below and by
-# test_parity_probes.py's per-case strict xfail over the corpus case
-# invalid_utf8_only_no_newline.csv; panic-freedom for the held-out function stays
-# covered by test_arbitrary_bytes_never_panic, which samples the full set.
+# One thing IS left uncovered: value parity for the held-out function over
+# GENERATED input. That gap is the point of holding it out, and it closes when
+# #317 lands. What remains covered meanwhile: the divergence stays strictly
+# asserted by the pinned .xfail() example on test_arbitrary_bytes_do_not_diverge
+# below and by test_parity_probes.py's per-case strict xfail over the corpus case
+# invalid_utf8_only_no_newline.csv; value parity over all 56 corpus files stays
+# covered by test_parity_probes.py; and panic-freedom for the held-out function
+# stays covered by test_arbitrary_bytes_never_panic, which samples the full set.
 #
 # RESTORE KNOWN_DIVERGENT_FN TO THIS LIST WHEN #317 LANDS.
 # Measured before holding it out: 60,000 csv_bytes and 80,000 raw_bytes calls
@@ -93,13 +97,16 @@ def test_leading_rows_agrees(gen, limit):
     reason=(
         "sniff_dialect's delimiter class is [^\\w\\n\"'], and CPython's \\w (str.isalnum()-based) "
         "disagrees with fancy-regex's \\w on category No (U+00B2) and on marks (U+0301). The blast "
-        "radius is NOT delimiter-only: measured over 20,000 calls the divergences were delimiter 71, "
-        "delimiter+doublequote 8, delimiter+skipinitialspace 4, doublequote alone 1, "
-        "delimiter+quotechar 1, and 23 where Rust returns a dialect while CPython returns None. "
+        "radius is NOT delimiter-only. Two independent 20,000-call runs agree on the shape while "
+        "differing in the exact counts (they are seed-specific): delimiter alone dominates, with "
+        "delimiter+doublequote, delimiter+skipinitialspace, delimiter+quotechar, doublequote alone "
+        "and skipinitialspace alone all observed, plus dialect-vs-None flips in BOTH directions "
+        "(one run: 23 Rust-dialect/CPython-None and 15 the reverse). "
         "doublequote, quotechar and skipinitialspace ARE fields the corpus dialect tests compare, and "
         "a None-vs-dialect flip is a behavior change, reachable in production from "
         "src/datagrunt/core/databases/databases.py:125 (CSVDialect(self.filepath), no delimiter). "
-        "The rate is 1 in 137 generated examples — too high to pin per-example the way #317 is — so "
+        "The rate is roughly 1 in 140-170 generated examples (two runs: 1-in-137, 1-in-171) — far "
+        "too high to pin per-example the way #317 is — so "
         "this stays a TEST-LEVEL xfail, which means the property explores ZERO generated examples "
         "until #318 is fixed. Corpus case sniff_delimiter_word_class.csv. See #318"
     ),
@@ -168,11 +175,13 @@ def test_normalize_columns_agrees(names):
     #
     # KNOWN_DIVERGENT_FN is deliberately outside the sampled_from domain below.
     # Explicit examples bypass the strategy, so this still runs; generation must
-    # not reach it, because raw_bytes() rediscovers b"\x80" within ~75 examples
-    # and a generate-phase hit is NOT covered by this .xfail() — it is an
-    # ordinary failure that would redden the PR gate and poison the example
-    # database. Panic coverage for the held-out function is preserved by
-    # test_arbitrary_bytes_never_panic below.
+    # not reach it: raw_bytes() hits #317 on 9.9% of examples (any invalid lone
+    # byte, not just b"\x80"), and a generate-phase hit is NOT covered by this
+    # .xfail() — it is an ordinary failure. On the PR gate that means a red run;
+    # on the deep profile it ALSO writes .hypothesis/examples, which the cached
+    # database then replays forever. (The ci profile cannot poison the database:
+    # derandomize=True implies database=None.) Panic coverage for the held-out
+    # function is preserved by test_arbitrary_bytes_never_panic below.
     data=b"\x80",
     fn_name=KNOWN_DIVERGENT_FN,
 ).xfail(
@@ -213,5 +222,7 @@ def test_arbitrary_bytes_never_panic(data, fn_name):
     blocks the search.
     """
     with csv_file(data, ".csv") as path:
+        # Only the Rust side is asserted. PanicException comes from PyO3, so the
+        # pure-Python oracle cannot raise it — asserting it there would be a
+        # permanently-true check masquerading as coverage.
         assert not _panicked(getattr(rs, fn_name), path), f"{fn_name} panicked on {data!r}"
-        assert not _panicked(getattr(py, fn_name), path), f"{fn_name} panicked on {data!r}"

--- a/tests/parity/test_parity_property.py
+++ b/tests/parity/test_parity_property.py
@@ -5,15 +5,27 @@ These prove the cases nobody did. Every property compares *outcomes* — returne
 value or raised exception — so a Rust panic crossing PyO3 is a parity failure
 with a minimized repro attached, not a mysterious crash.
 
-On divergence: minimize, add the bytes to corpus.py as a named case, open an
-issue, and mark that property xfail(strict=True) with the issue link. Do not
-weaken a property to make it pass.
+On divergence: minimize, add the bytes to corpus.py as a named case, and open an
+issue. Then pin it with a per-example `@example(...).xfail(...)` carrying the
+issue link — NOT a test-level `@pytest.mark.xfail`, which stops the property
+searching entirely (the explicit phase raises before the generate phase runs, so
+the test explores nothing and reports no statistics). Reach for a test-level
+xfail only when the divergence rate is too high to enumerate, and say so in the
+reason. Do not weaken a property to make it pass.
 """
 
 import pytest
 from hypothesis import event, example, given
 from hypothesis import strategies as st
-from strategies import GeneratedCSV, column_names, csv_bytes, csv_file, outcome, raw_bytes
+from strategies import (
+    PANIC_EXCEPTION_NAME,
+    GeneratedCSV,
+    column_names,
+    csv_bytes,
+    csv_file,
+    outcome,
+    raw_bytes,
+)
 
 from datagrunt import _native as rs
 from datagrunt.core.csv_io import _compute_python as py
@@ -28,6 +40,32 @@ PATH_ONLY = [
     "probe_csv_header",
 ]
 
+# The one function carrying an open, known divergence (#317).
+KNOWN_DIVERGENT_FN = "count_leading_physical_lines_before_header"
+
+# What the VALUE-PARITY properties sample. KNOWN_DIVERGENT_FN is held out for as
+# long as #317 is open, because a hit there does not merely fail once — it stops
+# the search permanently. On the first hit Hypothesis writes the falsifying
+# example to .hypothesis/examples, the deep job's actions/cache carries that
+# database into every later run, and the `reuse` phase then replays the stored
+# failure and stops before `generate` ever executes. The property keeps reporting
+# activity while searching nothing.
+#
+# Both generators reach #317: csv_bytes at roughly 1-in-20,000 examples, and
+# raw_bytes far faster — it rediscovers b"\x80" within ~75 examples, so the ci
+# profile alone would trip it.
+#
+# Nothing is left uncovered meanwhile. The divergence stays strictly asserted by
+# the pinned .xfail() example on test_arbitrary_bytes_do_not_diverge below and by
+# test_parity_probes.py's per-case strict xfail over the corpus case
+# invalid_utf8_only_no_newline.csv; panic-freedom for the held-out function stays
+# covered by test_arbitrary_bytes_never_panic, which samples the full set.
+#
+# RESTORE KNOWN_DIVERGENT_FN TO THIS LIST WHEN #317 LANDS.
+# Measured before holding it out: 60,000 csv_bytes and 80,000 raw_bytes calls
+# against the other five functions produced zero divergences.
+PATH_ONLY_AGREEING = [fn for fn in PATH_ONLY if fn != KNOWN_DIVERGENT_FN]
+
 
 def _record(gen):
     """Surface which seams this example hit, for --hypothesis-show-statistics."""
@@ -35,7 +73,7 @@ def _record(gen):
         event(seam)
 
 
-@given(gen=csv_bytes(), fn_name=st.sampled_from(PATH_ONLY))
+@given(gen=csv_bytes(), fn_name=st.sampled_from(PATH_ONLY_AGREEING))
 def test_path_only_functions_agree(gen, fn_name):
     _record(gen)
     event(f"fn:{fn_name}")
@@ -54,8 +92,16 @@ def test_leading_rows_agrees(gen, limit):
     strict=True,
     reason=(
         "sniff_dialect's delimiter class is [^\\w\\n\"'], and CPython's \\w (str.isalnum()-based) "
-        "disagrees with fancy-regex's \\w on category No (U+00B2) and on marks (U+0301), so the "
-        "two sniff different delimiters. Corpus case sniff_delimiter_word_class.csv. See #318"
+        "disagrees with fancy-regex's \\w on category No (U+00B2) and on marks (U+0301). The blast "
+        "radius is NOT delimiter-only: measured over 20,000 calls the divergences were delimiter 71, "
+        "delimiter+doublequote 8, delimiter+skipinitialspace 4, doublequote alone 1, "
+        "delimiter+quotechar 1, and 23 where Rust returns a dialect while CPython returns None. "
+        "doublequote, quotechar and skipinitialspace ARE fields the corpus dialect tests compare, and "
+        "a None-vs-dialect flip is a behavior change, reachable in production from "
+        "src/datagrunt/core/databases/databases.py:125 (CSVDialect(self.filepath), no delimiter). "
+        "The rate is 1 in 137 generated examples — too high to pin per-example the way #317 is — so "
+        "this stays a TEST-LEVEL xfail, which means the property explores ZERO generated examples "
+        "until #318 is fixed. Corpus case sniff_delimiter_word_class.csv. See #318"
     ),
 )
 @example(
@@ -106,8 +152,31 @@ def test_normalize_columns_agrees(names):
     assert outcome(rs.normalize_columns, names) == outcome(py.normalize_columns, names)
 
 
-@pytest.mark.xfail(
-    strict=True,
+@example(
+    # The minimized falsifying example for #317, pinned so the failure does not
+    # depend on the search reaching it under a given profile or Hypothesis
+    # version. Keep as a regression case once #317 is fixed and the .xfail()
+    # comes off.
+    #
+    # PER-EXAMPLE .xfail(), not a test-level @pytest.mark.xfail: a test-level
+    # marker made this property completely inert. The explicit phase runs before
+    # the generate phase, so this example raised, pytest recorded the expected
+    # failure, and generation never happened — the test emitted no statistics
+    # block at all. .xfail() scopes the expectation to this one example and
+    # still asserts it strictly (Hypothesis errors if it stops failing), so the
+    # search runs and #317 stays pinned.
+    #
+    # KNOWN_DIVERGENT_FN is deliberately outside the sampled_from domain below.
+    # Explicit examples bypass the strategy, so this still runs; generation must
+    # not reach it, because raw_bytes() rediscovers b"\x80" within ~75 examples
+    # and a generate-phase hit is NOT covered by this .xfail() — it is an
+    # ordinary failure that would redden the PR gate and poison the example
+    # database. Panic coverage for the held-out function is preserved by
+    # test_arbitrary_bytes_never_panic below.
+    data=b"\x80",
+    fn_name=KNOWN_DIVERGENT_FN,
+).xfail(
+    raises=AssertionError,
     reason=(
         "count_leading_physical_lines_before_header diverges on bytes that decode to '' under "
         "errors='ignore' with no line terminator (b'\\x80'): Rust counts a final empty line (1), "
@@ -115,16 +184,34 @@ def test_normalize_columns_agrees(names):
         "invalid_utf8_only_no_newline.csv. See #317"
     ),
 )
-@example(
-    # The minimized falsifying example, pinned so the failure does not depend on
-    # the search reaching it under a given profile or Hypothesis version. Keep as
-    # a regression case once #317 is fixed and the xfail comes off.
-    data=b"\x80",
-    fn_name="count_leading_physical_lines_before_header",
-)
-@given(data=raw_bytes(), fn_name=st.sampled_from(PATH_ONLY))
+@given(data=raw_bytes(), fn_name=st.sampled_from(PATH_ONLY_AGREEING))
 def test_arbitrary_bytes_do_not_diverge(data, fn_name):
-    """Crash hunt. Most examples are garbage both backends reject identically;
-    the value is the one that does not."""
+    """Crash hunt, value-parity half. Most examples are garbage both backends
+    reject identically; the value is the one that does not.
+
+    Measured at 80,000 raw_bytes calls against these five functions: zero
+    divergences.
+    """
     with csv_file(data, ".csv") as path:
         assert outcome(getattr(rs, fn_name), path) == outcome(getattr(py, fn_name), path), fn_name
+
+
+def _panicked(fn, path) -> bool:
+    """True if the call died the one way only the Rust side can."""
+    return outcome(fn, path) == ("raised", PANIC_EXCEPTION_NAME)
+
+
+@given(data=raw_bytes(), fn_name=st.sampled_from(PATH_ONLY))
+def test_arbitrary_bytes_never_panic(data, fn_name):
+    """Crash hunt, panic-freedom half — over ALL of PATH_ONLY.
+
+    A panic crossing PyO3 is a DoS, and this is the only place arbitrary bytes
+    reach every path-only function, so the set here must stay complete even
+    while #317 holds KNOWN_DIVERGENT_FN out of the value-parity property above.
+    Asserting panic-freedom rather than equality is what makes that possible:
+    #317 is a value divergence, invisible to this assertion, so no known bug
+    blocks the search.
+    """
+    with csv_file(data, ".csv") as path:
+        assert not _panicked(getattr(rs, fn_name), path), f"{fn_name} panicked on {data!r}"
+        assert not _panicked(getattr(py, fn_name), path), f"{fn_name} panicked on {data!r}"

--- a/tests/parity/test_parity_strategies.py
+++ b/tests/parity/test_parity_strategies.py
@@ -6,7 +6,18 @@ tests guard the machinery so the properties in test_parity_property.py mean
 something.
 """
 
-from hypothesis import settings
+import os
+
+from hypothesis import given, settings
+from strategies import (
+    SEAM_LABELS,
+    GeneratedCSV,
+    column_names,
+    csv_bytes,
+    csv_file,
+    outcome,
+    raw_bytes,
+)
 
 
 def test_hypothesis_profiles_are_registered():
@@ -24,3 +35,73 @@ def test_ci_profile_is_reproducible():
 
 def test_deep_profile_searches_much_harder_than_ci():
     assert settings.get_profile("deep").max_examples >= 10 * settings.get_profile("ci").max_examples
+
+
+def test_outcome_reports_a_returned_value():
+    assert outcome(lambda: 42) == ("ok", 42)
+
+
+def test_outcome_reports_the_exception_name():
+    def boom():
+        raise ValueError("nope")
+
+    assert outcome(boom) == ("raised", "ValueError")
+
+
+def test_outcome_normalizes_oserror_subclasses():
+    """PyO3 maps io errors to bare OSError; CPython raises specific subclasses.
+
+    Comparing exact names would flag that as a divergence on every missing-file
+    example. Normalizing to the family keeps the comparison honest without
+    hiding anything: PanicException is not an OSError, so panics still surface.
+    """
+
+    def missing():
+        raise FileNotFoundError(2, "No such file")
+
+    assert outcome(missing) == ("raised", "OSError")
+
+
+def test_csv_file_writes_bytes_and_cleans_up():
+    with csv_file(b"a,b\n1,2\n", ".csv") as path:
+        with open(path, "rb") as handle:
+            assert handle.read() == b"a,b\n1,2\n"
+        assert path.endswith(".csv")
+    assert not os.path.exists(path)
+
+
+@given(gen=csv_bytes())
+def test_csv_bytes_produces_a_well_formed_example(gen):
+    assert isinstance(gen, GeneratedCSV)
+    assert isinstance(gen.data, bytes)
+    assert gen.suffix.startswith(".")
+    assert gen.seams <= SEAM_LABELS
+
+
+@given(data=raw_bytes())
+def test_raw_bytes_produces_bytes(data):
+    assert isinstance(data, bytes)
+
+
+@given(names=column_names())
+def test_column_names_produces_a_list_of_str(names):
+    assert all(isinstance(n, str) for n in names)
+
+
+def test_every_seam_is_reachable():
+    """THE VACUITY GUARD.
+
+    If a seam becomes unreachable — a branch mis-weighted to near-zero, a
+    condition that can never fire — the properties keep passing while silently
+    testing less. This test fails loudly instead.
+    """
+    seen: set[str] = set()
+
+    @given(gen=csv_bytes())
+    @settings(max_examples=2000, deadline=None, derandomize=True)
+    def collect(gen):
+        seen.update(gen.seams)
+
+    collect()
+    missing = SEAM_LABELS - seen
+    assert not missing, f"unreachable seams in csv_bytes(): {sorted(missing)}"

--- a/tests/parity/test_parity_strategies.py
+++ b/tests/parity/test_parity_strategies.py
@@ -1,0 +1,26 @@
+"""Meta-tests for the property-testing machinery itself.
+
+A property suite that only ever generates one shape passes thousands of times
+and proves nothing — and its exit code is identical to a working one. These
+tests guard the machinery so the properties in test_parity_property.py mean
+something.
+"""
+
+from hypothesis import settings
+
+
+def test_hypothesis_profiles_are_registered():
+    """CI needs a derandomized profile; the scheduled job needs a deep one."""
+    for name in ("ci", "dev", "deep"):
+        assert settings.get_profile(name) is not None, name
+
+
+def test_ci_profile_is_reproducible():
+    """A random seed in the PR gate means unreproducible red builds."""
+    ci = settings.get_profile("ci")
+    assert ci.derandomize is True
+    assert ci.deadline is None, "file I/O per example makes deadlines a flake source"
+
+
+def test_deep_profile_searches_much_harder_than_ci():
+    assert settings.get_profile("deep").max_examples >= 10 * settings.get_profile("ci").max_examples

--- a/tests/parity/test_parity_strategies.py
+++ b/tests/parity/test_parity_strategies.py
@@ -8,6 +8,7 @@ something.
 
 import os
 
+import pytest
 from hypothesis import given, settings
 from strategies import (
     SEAM_LABELS,
@@ -60,6 +61,36 @@ def test_outcome_normalizes_oserror_subclasses():
         raise FileNotFoundError(2, "No such file")
 
     assert outcome(missing) == ("raised", "OSError")
+
+
+def test_outcome_captures_baseexception_so_hypothesis_can_shrink_it():
+    """The safety-critical path: a panic must be captured, not left to escape.
+
+    PyO3 declares PanicException with PyBaseException as its base, so an
+    `except Exception` clause misses it. Hypothesis's
+    failure_exceptions_to_catch() is (Exception, SystemExit, GeneratorExit),
+    which means an escaping panic reddens the suite with no minimized repro.
+    Captured, it is an ordinary tuple mismatch that Hypothesis shrinks.
+    """
+
+    class FakePanic(BaseException):
+        """Stand-in: PanicException itself needs a real panic to construct."""
+
+    def panics():
+        raise FakePanic("boom")
+
+    assert outcome(panics) == ("raised", "FakePanic")
+
+
+@pytest.mark.parametrize("control_flow", [KeyboardInterrupt, SystemExit])
+def test_outcome_never_swallows_control_flow_exceptions(control_flow):
+    """Broadening to BaseException must not make Ctrl-C uninterruptible."""
+
+    def interrupted():
+        raise control_flow
+
+    with pytest.raises(control_flow):
+        outcome(interrupted)
 
 
 def test_csv_file_writes_bytes_and_cleans_up():


### PR DESCRIPTION
Partial implementation of #315 — the Python differential layer. Does **not** close it; Rust `proptest` and `stubtest` remain.

## What

`tests/parity/` proved the Rust extension and the Python oracle agree over **54 hand-written corpus files**. That proves the cases someone thought to write down. This adds Hypothesis-driven generation for the cases nobody did.

- **`tests/parity/strategies.py`** — CSV-shaped generation across 17 labelled seams (delimiters, `\r`/`\r\n`/`\n`, quoting, comments, blanks, BOM, raggedness, invalid UTF-8, C0 controls, NUL, file extension), plus `outcome()` and `csv_file()`.
- **`tests/parity/test_parity_property.py`** — differential properties over all 11 mirrored functions, comparing **outcomes** (returned value *or* raised exception), plus two crash-hunt properties over arbitrary bytes.
- **Hypothesis profiles** — `ci` derandomized at 100 examples, `deep` at 10,000.
- **`.github/workflows/deep-property-search.yml`** — weekly long search, blocking, with a cached example database.

## It found three real issues before merging

| | |
|---|---|
| **#317** | `count_leading_physical_lines_before_header` on `b"\x80"`: Rust 1, Python 0. Rust's EOF-flush branch gates on a **byte**-level test then decodes to `""`, emitting a phantom line. Python is right — a **Rust-only** fix, a deliberate exception to Python-first. |
| **#318** | `sniff_dialect` picks a different delimiter. CPython `re`'s `\w` is `isalnum()`-based and matches category `No` (`²`); fancy-regex's UTS#18 `perl_word` does not — and the reverse for combining marks. The class is `[^\w\n"']`, so the backends disagree about which characters can even *be* delimiters. |
| **#319** | `dialect_properties_from_rust` drops `delimiter`, so no corpus test had ever compared it — which is why #318 went unseen. |

**#318 is the case for this whole approach.** Finding it by hand required deciding to write a CSV containing a superscript two positioned next to a quote character. The mechanism was confirmed necessary *and* sufficient by running CPython's four `QUOTE_PATTERNS` against the real sample under both `\w` definitions.

## Design notes

**`outcome()` compares exceptions, not just values.** No existing parity test did. It catches `BaseException`, deliberately: `pyo3_runtime.PanicException` derives from `PyBaseException` (verified in the vendored pyo3 0.29.0 source), so `except Exception` would let a real panic straight through — and Hypothesis does not shrink `BaseException` subclasses, so the failure would arrive with no minimized repro.

**The suite is built so it cannot pass vacuously.** A property suite that generates one shape passes ten thousand times, and its exit code is identical to a working one. So: `test_every_seam_is_reachable` samples 2,000 examples and asserts all 17 seams fire (verified across 12 seeds, rarest at ~17× margin); a deliberately-broken oracle was confirmed to turn the suite red; and the seam distribution was read rather than assumed.

## Known-divergence handling

Both divergences are pinned with `strict=True` xfails, so fixing either turns the xfail into an `XPASS` failure and forces the marker out — stale exemptions cannot accumulate.

`count_leading_physical_lines_before_header` is **held out of the value-parity sampled set** while #317 is open. Not cosmetic: a generated hit writes to `.hypothesis/examples`, the deep job's cache carries it forward, and Hypothesis's `reuse` phase then replays the stored failure and stops before `generate` runs — a job that reports activity while searching nothing. It stays covered by the corpus suite, a pinned example, and panic-freedom over the full set.

**One gap is stated plainly rather than papered over:** value parity for that function over *generated* input is not covered until #317 lands, and `test_sniff_dialect_agrees` explores zero generated examples until #318 lands.

## Verification

| Gate | Result |
|---|---|
| `pytest tests/ -q` (Rust backend) | 1474 passed, 2 xfailed |
| `DATAGRUNT_DISABLE_RUST=1 pytest tests/ -q` | 1474 passed, 2 xfailed |
| `pytest tests/parity/ -q` | 664 passed, 2 xfailed |
| `ruff check src tests` / `ruff format --check .` | clean |
| `mypy` | clean |
| cargo gates | untouched — no Rust source changed |

Runtime cost: **+3.9s** on the default suite (19.7s vs 15.8s), against a 30s budget. Both crash-hunt properties verified emitting generate-phase statistics blocks with 100 passing, and no stored examples after a fresh run.

## Remaining for #315

1. Rust `proptest` over `datagrunt-core` internals (`io`, `dialect`, `normalize`).
2. `stubtest` for `_native.pyi` signature drift — the current guard is name-only.
3. Restore `count_leading_physical_lines_before_header` to the sampled set when #317 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)