### PR TITLE
fix: stop emitting a phantom final line for bytes that decode to empty

### DIFF
--- a/rust/datagrunt-core/src/io.rs
+++ b/rust/datagrunt-core/src/io.rs
@@ -488,6 +488,17 @@ impl UniversalLines {
                     let raw = decode_ignore(&self.buf[self.pos..]);
                     let line = take_chars(&raw, MAX_LINE_CHARS);
                     self.pos = self.buf.len();
+                    // Bytes remaining is a BYTE-level condition; a line is
+                    // DECODED text. A tail whose every byte is dropped by
+                    // errors="ignore" is not a line: CPython iterates the
+                    // decoded string and yields nothing for it, so emitting
+                    // Some("") here produced a phantom final line (#317).
+                    // Only the unterminated tail is affected — an explicitly
+                    // terminated empty line (b"a\n\n") is emitted by the \n
+                    // branch above and still counts, matching CPython.
+                    if line.is_empty() {
+                        return Ok(None);
+                    }
                     return Ok(Some(line));
                 }
                 return Ok(None);
@@ -750,6 +761,32 @@ mod tests {
         assert!(read_universal_lines(h.path()).unwrap().is_empty());
         let i = tmp(b"a\n\n", ".csv"); // trailing newline dropped, interior blank kept
         assert_eq!(read_universal_lines(i.path()).unwrap(), vec!["a", ""]);
+    }
+
+    #[test]
+    fn unterminated_tail_decoding_to_nothing_is_not_a_line() {
+        // #317. "Bytes remain" is a BYTE-level condition; a line is DECODED
+        // text. A tail whose every byte is dropped by errors="ignore" must
+        // yield no line, because CPython iterates the decoded string.
+        let a = tmp(b"\x80", ".csv"); // whole file decodes to ""
+        assert!(read_universal_lines(a.path()).unwrap().is_empty());
+        let b = tmp(b"a\n\x80", ".csv"); // real line, then a vanishing tail
+        assert_eq!(read_universal_lines(b.path()).unwrap(), vec!["a"]);
+        let c = tmp(b"# c\n\xc3", ".csv"); // truncated multibyte after a comment
+        assert_eq!(read_universal_lines(c.path()).unwrap(), vec!["# c"]);
+        // BOM + invalid only. The BOM is consumed as an encoding marker (Python
+        // reads with utf-8-sig), so nothing survives decoding and there is no
+        // line — not a U+FEFF line.
+        let d = tmp(b"\xef\xbb\xbf\xe9\xff\xfe", ".csv");
+        assert!(read_universal_lines(d.path()).unwrap().is_empty());
+
+        // Guard the boundary the fix must NOT cross: a tail that decodes to
+        // real text still counts, and an explicitly terminated empty line is
+        // emitted by the \n branch, not this one.
+        let e = tmp(b"a\n\x80b", ".csv"); // invalid byte beside surviving text
+        assert_eq!(read_universal_lines(e.path()).unwrap(), vec!["a", "b"]);
+        let f = tmp(b"a\n   ", ".csv"); // whitespace-only tail is still text
+        assert_eq!(read_universal_lines(f.path()).unwrap(), vec!["a", "   "]);
     }
 
     #[test]

--- a/tests/parity/test_parity_probes.py
+++ b/tests/parity/test_parity_probes.py
@@ -1,17 +1,5 @@
-import pytest
-
 from datagrunt import _native as datagrunt_rs
 from datagrunt.core.csv_io import _compute_python as py
-
-# Corpus cases with a known, tracked backend divergence, mapped to the reason.
-# Applied per-case as a STRICT xfail: fixing the divergence turns it into an
-# XPASS failure, which forces the entry (and this table) out again.
-COUNT_LEADING_PHYSICAL_LINES_DIVERGENCES = {
-    "invalid_utf8_only_no_newline.csv": (
-        "bytes that decode to '' under errors='ignore' with no terminator: Rust counts a final empty line "
-        "(1), CPython iterates decoded text and yields none (0), see #317"
-    ),
-}
 
 
 def test_is_legacy_mac_newlines(corpus_file):
@@ -22,10 +10,7 @@ def test_count_leading_comments(corpus_file):
     assert datagrunt_rs.count_leading_comments(str(corpus_file)) == py.count_leading_comments(str(corpus_file))
 
 
-def test_count_leading_physical_lines_before_header(corpus_file, request):
-    reason = COUNT_LEADING_PHYSICAL_LINES_DIVERGENCES.get(corpus_file.name)
-    if reason:
-        request.applymarker(pytest.mark.xfail(strict=True, reason=reason))
+def test_count_leading_physical_lines_before_header(corpus_file):
     assert datagrunt_rs.count_leading_physical_lines_before_header(
         str(corpus_file)
     ) == py.count_leading_physical_lines_before_header(str(corpus_file))

--- a/tests/parity/test_parity_property.py
+++ b/tests/parity/test_parity_property.py
@@ -40,35 +40,14 @@ PATH_ONLY = [
     "probe_csv_header",
 ]
 
-# The one function carrying an open, known divergence (#317).
-KNOWN_DIVERGENT_FN = "count_leading_physical_lines_before_header"
-
-# What the VALUE-PARITY properties sample. KNOWN_DIVERGENT_FN is held out for as
-# long as #317 is open, because a hit there does not merely fail once — it stops
-# the search permanently. On the first hit Hypothesis writes the falsifying
-# example to .hypothesis/examples, the deep job's actions/cache carries that
-# database into every later run, and the `reuse` phase then replays the stored
-# failure and stops before `generate` ever executes. The property keeps reporting
-# activity while searching nothing.
-#
-# Both generators reach #317. Measured: csv_bytes at 1-in-2,857 (14/40,000), so
-# a deep run hits it with ~97% probability; raw_bytes at 9.9% of examples
-# (198/2,000, first hit at example #4) — every invalid lone byte triggers it, not
-# just b"\x80" — so even the ci profile's 100 examples trip it essentially always.
-#
-# One thing IS left uncovered: value parity for the held-out function over
-# GENERATED input. That gap is the point of holding it out, and it closes when
-# #317 lands. What remains covered meanwhile: the divergence stays strictly
-# asserted by the pinned .xfail() example on test_arbitrary_bytes_do_not_diverge
-# below and by test_parity_probes.py's per-case strict xfail over the corpus case
-# invalid_utf8_only_no_newline.csv; value parity over all 56 corpus files stays
-# covered by test_parity_probes.py; and panic-freedom for the held-out function
-# stays covered by test_arbitrary_bytes_never_panic, which samples the full set.
-#
-# RESTORE KNOWN_DIVERGENT_FN TO THIS LIST WHEN #317 LANDS.
-# Measured before holding it out: 60,000 csv_bytes and 80,000 raw_bytes calls
-# against the other five functions produced zero divergences.
-PATH_ONLY_AGREEING = [fn for fn in PATH_ONLY if fn != KNOWN_DIVERGENT_FN]
+# #317 is fixed, so every path-only function is back in the value-parity search.
+# The function was held out while it carried an open divergence: a generated hit
+# does not merely fail once, it writes the falsifying example to
+# .hypothesis/examples, the deep job's actions/cache carries that database
+# forward, and Hypothesis's `reuse` phase then replays the stored failure and
+# stops before `generate` ever runs — a property reporting activity while
+# searching nothing. Keep that in mind before pinning any future divergence at
+# the test level rather than fixing it.
 
 
 def _record(gen):
@@ -77,7 +56,7 @@ def _record(gen):
         event(seam)
 
 
-@given(gen=csv_bytes(), fn_name=st.sampled_from(PATH_ONLY_AGREEING))
+@given(gen=csv_bytes(), fn_name=st.sampled_from(PATH_ONLY))
 def test_path_only_functions_agree(gen, fn_name):
     _record(gen)
     event(f"fn:{fn_name}")
@@ -106,7 +85,7 @@ def test_leading_rows_agrees(gen, limit):
         "a None-vs-dialect flip is a behavior change, reachable in production from "
         "src/datagrunt/core/databases/databases.py:125 (CSVDialect(self.filepath), no delimiter). "
         "The rate is roughly 1 in 140-170 generated examples (two runs: 1-in-137, 1-in-171) — far "
-        "too high to pin per-example the way #317 is — so "
+        "too high to pin per-example — so "
         "this stays a TEST-LEVEL xfail, which means the property explores ZERO generated examples "
         "until #318 is fixed. Corpus case sniff_delimiter_word_class.csv. See #318"
     ),
@@ -160,46 +139,19 @@ def test_normalize_columns_agrees(names):
 
 
 @example(
-    # The minimized falsifying example for #317, pinned so the failure does not
-    # depend on the search reaching it under a given profile or Hypothesis
-    # version. Keep as a regression case once #317 is fixed and the .xfail()
-    # comes off.
-    #
-    # PER-EXAMPLE .xfail(), not a test-level @pytest.mark.xfail: a test-level
-    # marker made this property completely inert. The explicit phase runs before
-    # the generate phase, so this example raised, pytest recorded the expected
-    # failure, and generation never happened — the test emitted no statistics
-    # block at all. .xfail() scopes the expectation to this one example and
-    # still asserts it strictly (Hypothesis errors if it stops failing), so the
-    # search runs and #317 stays pinned.
-    #
-    # KNOWN_DIVERGENT_FN is deliberately outside the sampled_from domain below.
-    # Explicit examples bypass the strategy, so this still runs; generation must
-    # not reach it: raw_bytes() hits #317 on 9.9% of examples (any invalid lone
-    # byte, not just b"\x80"), and a generate-phase hit is NOT covered by this
-    # .xfail() — it is an ordinary failure. On the PR gate that means a red run;
-    # on the deep profile it ALSO writes .hypothesis/examples, which the cached
-    # database then replays forever. (The ci profile cannot poison the database:
-    # derandomize=True implies database=None.) Panic coverage for the held-out
-    # function is preserved by test_arbitrary_bytes_never_panic below.
+    # #317's minimized falsifying example, kept as a permanent regression case
+    # now that it is fixed. Bytes that decode to "" under errors="ignore" with
+    # no line terminator: Rust used to emit a phantom final line here because
+    # its EOF-flush gate was byte-level while a line is decoded text.
     data=b"\x80",
-    fn_name=KNOWN_DIVERGENT_FN,
-).xfail(
-    raises=AssertionError,
-    reason=(
-        "count_leading_physical_lines_before_header diverges on bytes that decode to '' under "
-        "errors='ignore' with no line terminator (b'\\x80'): Rust counts a final empty line (1), "
-        "CPython iterates decoded text and yields none (0). Corpus case "
-        "invalid_utf8_only_no_newline.csv. See #317"
-    ),
+    fn_name="count_leading_physical_lines_before_header",
 )
-@given(data=raw_bytes(), fn_name=st.sampled_from(PATH_ONLY_AGREEING))
+@given(data=raw_bytes(), fn_name=st.sampled_from(PATH_ONLY))
 def test_arbitrary_bytes_do_not_diverge(data, fn_name):
     """Crash hunt, value-parity half. Most examples are garbage both backends
     reject identically; the value is the one that does not.
 
-    Measured at 80,000 raw_bytes calls against these five functions: zero
-    divergences.
+    Measured at 80,000 raw_bytes calls: zero divergences.
     """
     with csv_file(data, ".csv") as path:
         assert outcome(getattr(rs, fn_name), path) == outcome(getattr(py, fn_name), path), fn_name
@@ -215,11 +167,12 @@ def test_arbitrary_bytes_never_panic(data, fn_name):
     """Crash hunt, panic-freedom half — over ALL of PATH_ONLY.
 
     A panic crossing PyO3 is a DoS, and this is the only place arbitrary bytes
-    reach every path-only function, so the set here must stay complete even
-    while #317 holds KNOWN_DIVERGENT_FN out of the value-parity property above.
-    Asserting panic-freedom rather than equality is what makes that possible:
-    #317 is a value divergence, invisible to this assertion, so no known bug
-    blocks the search.
+    reach every path-only function, so the set here must stay complete.
+
+    Asserting panic-freedom rather than equality is what keeps it complete:
+    the property is immune to value divergences, so a future open bug could
+    hold a function out of the value-parity property above (as #317 once did)
+    without ever costing crash coverage here.
     """
     with csv_file(data, ".csv") as path:
         # Only the Rust side is asserted. PanicException comes from PyO3, so the


### PR DESCRIPTION
Closes #317, found by the property-based parity harness (#315) on its first run.

## The bug

`UniversalLines::next_line`'s EOF flush gated on `self.pos < self.buf.len()` — a **byte**-level condition — then returned **decoded** text:

```rust
if self.pos < self.buf.len() {
    let raw = decode_ignore(&self.buf[self.pos..]);
    let line = take_chars(&raw, MAX_LINE_CHARS);
    self.pos = self.buf.len();
    return Ok(Some(line));          // line may be ""
}
```

A tail whose every byte is dropped by `errors="ignore"` decoded to `""` and was still emitted as a line. CPython iterates the *decoded string*, so it yields nothing for the same input.

## Python is right, so Rust follows

Deliberate exception to the usual Python-first-then-port order — flagging it so it does not read as a process slip. A byte sequence that decodes to nothing is not a line.

## The divergence is wider than the function that exposed it

`count_leading_physical_lines_before_header` was where the harness caught it, but the defect is in line emission:

| input | Rust before | Python | |
|---|---|---|---|
| `b"\x80"` | 1 | 0 | diverged |
| `b"# c\n\xc3"` | 2 | 1 | diverged |
| `b"\n\n\xe9\xff\xfe"` | 3 | 2 | diverged |
| `b"\xef\xbb\xbf\xe9\xff\xfe"` | 1 | 0 | diverged |
| `b"a\n\x80"` | 1 | 1 | **masked** — the count stops at the header |

That last row is why regression tests go in at the `read_universal_lines` level and not only against the counting function: a test written solely against `count_leading_physical_lines_before_header` would pass while the phantom line was still being produced.

## What deliberately does not change

Both boundaries are asserted:

- `b"a\n\n"` — an explicitly terminated empty line is emitted by the `\n` branch, not this one, and still counts (matching CPython).
- `b"a\n   "` — a tail decoding to real text, including whitespace-only, is unaffected.
- `b"a\n\x80b"` — an invalid byte beside surviving text still yields that text.

One test expectation I had to correct while writing them: `b"\xef\xbb\xbf\xe9\xff\xfe"` yields **no** line rather than a `U+FEFF` line, because the BOM is consumed as an encoding marker (`DEFAULT_ENCODING` is `utf-8-sig`). Both backends agree on that; my initial assumption of plain utf-8 was wrong.

## The strict xfails did their job

Both `xfail(strict=True)` markers turned into `XPASS` failures the moment the fix landed, forcing their own removal — the mechanism working exactly as intended rather than a stale exemption quietly surviving.

- `test_parity_probes.py`'s per-case divergence table is gone entirely.
- `count_leading_physical_lines_before_header` is restored to the property suite's sampled set, closing the one coverage gap #315 shipped with: value parity for that function over *generated* input.
- `b"\x80"` is retained as a permanent regression case at both the corpus and property levels.

## Verification

| Gate | Result |
|---|---|
| `cargo test` | 59 passed (was 58; +1 new) |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `pytest tests/ -q` (Rust backend) | 1475 passed, 1 xfailed |
| `DATAGRUNT_DISABLE_RUST=1 pytest tests/ -q` | 1475 passed, 1 xfailed |
| `pytest tests/parity/ -q` | 665 passed, 1 xfailed |
| `ruff check src tests` / `ruff format --check .` | clean |
| `mypy` | clean |

The single remaining xfail is #318, still open. Both crash-hunt properties confirmed still exploring 100 generated examples each, now across all six path-only functions, with no stored failing example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)