### PR TITLE
fix: match CPython's \w in the dialect sniffer instead of fancy-regex's

### DIFF
--- a/rust/datagrunt-core/src/dialect.rs
+++ b/rust/datagrunt-core/src/dialect.rs
@@ -63,32 +63,67 @@ struct QuoteGuess {
     skipinitialspace: bool,
 }
 
-/// The four DOTALL|MULTILINE patterns, in the order Python tries them. The bool
-/// records whether the pattern carries `delim`/`space` groups (the 4th does
-/// not — Python hits `KeyError` and `continue`s, so it never records delims or
-/// spaces for that pattern). Python `(?P=quote)` backreferences become
-/// fancy-regex `\k<quote>`.
-const QUOTE_PATTERNS: [(&str, bool); 4] = [
-    (
-        r#"(?sm)(?P<delim>[^\w\n"'])(?P<space> ?)(?P<quote>["']).*?\k<quote>\k<delim>"#,
-        true,
-    ),
-    (
-        r#"(?sm)(?:^|\n)(?P<quote>["']).*?\k<quote>(?P<delim>[^\w\n"'])(?P<space> ?)"#,
-        true,
-    ),
-    (
-        r#"(?sm)(?P<delim>[^\w\n"'])(?P<space> ?)(?P<quote>["']).*?\k<quote>(?:$|\n)"#,
-        true,
-    ),
-    (r#"(?sm)(?:^|\n)(?P<quote>["']).*?\k<quote>(?:$|\n)"#, false),
-];
+/// CPython's `\w`, spelled out — do NOT write `\w` in a pattern here.
+///
+/// CPython defines `\w` as "alphanumeric characters (as defined by
+/// `str.isalnum()`) as well as the underscore", i.e. general categories L* and
+/// N* plus `_`. fancy-regex inherits regex-syntax's UTS#18 `perl_word`, which is
+/// `Alphabetic ∪ M ∪ Nd ∪ Pc ∪ Join_Control` — a DIFFERENT set, and different in
+/// both directions: it excludes `No`/`Nl` (so `²` U+00B2 is a word char to
+/// CPython but not to Rust) and includes marks (so U+0301 is a word char to Rust
+/// but not to CPython). That divergence made the sniffer pick different
+/// delimiters on either side (#318).
+///
+/// The equivalence below was verified exhaustively: over all 1,114,112 code
+/// points, `re.match(r"\w", ch)` agrees with `category(ch)[0] in "LN" or ch ==
+/// "_"` with zero mismatches.
+///
+/// Residual, unchanged by this: CPython's tables come from the running
+/// interpreter's Unicode version (13.0 on the 3.10 floor) while regex-syntax
+/// pins 16.0, so code points assigned in between can still disagree. That skew
+/// predates this fix and is far narrower than the definitional one it replaces —
+/// `²` and combining marks have been assigned for decades.
+const PY_WORD: &str = r"\p{L}\p{N}_";
 
-/// Compiled forms of QUOTE_PATTERNS. Initialized once; avoids per-call `Regex::new`.
+/// The four DOTALL|MULTILINE patterns, in the order Python tries them, built and
+/// compiled once to avoid a per-call `Regex::new`.
+///
+/// The bool records whether the pattern carries `delim`/`space` groups (the 4th
+/// does not — Python hits `KeyError` and `continue`s, so it never records delims
+/// or spaces for that pattern). Python `(?P=quote)` backreferences become
+/// fancy-regex `\k<quote>`.
+///
+/// The word class is interpolated from `PY_WORD` rather than written as `\w`, so
+/// there is exactly one place to look when asking what "word character" means
+/// here — see that constant for why the distinction matters.
 static COMPILED_QUOTE_PATTERNS: LazyLock<[(Regex, bool); 4]> = LazyLock::new(|| {
-    QUOTE_PATTERNS.map(|(pattern, has_groups)| {
+    let patterns: [(String, bool); 4] = [
         (
-            Regex::new(pattern).expect("static sniffer pattern is valid"),
+            format!(
+                r#"(?sm)(?P<delim>[^{PY_WORD}\n"'])(?P<space> ?)(?P<quote>["']).*?\k<quote>\k<delim>"#
+            ),
+            true,
+        ),
+        (
+            format!(
+                r#"(?sm)(?:^|\n)(?P<quote>["']).*?\k<quote>(?P<delim>[^{PY_WORD}\n"'])(?P<space> ?)"#
+            ),
+            true,
+        ),
+        (
+            format!(
+                r#"(?sm)(?P<delim>[^{PY_WORD}\n"'])(?P<space> ?)(?P<quote>["']).*?\k<quote>(?:$|\n)"#
+            ),
+            true,
+        ),
+        (
+            r#"(?sm)(?:^|\n)(?P<quote>["']).*?\k<quote>(?:$|\n)"#.to_string(),
+            false,
+        ),
+    ];
+    patterns.map(|(pattern, has_groups)| {
+        (
+            Regex::new(&pattern).expect("static sniffer pattern is valid"),
             has_groups,
         )
     })
@@ -184,10 +219,14 @@ fn guess_quote_and_delimiter(data: &str, delimiters: Option<&str>) -> QuoteGuess
     // MULTILINE only; unescaped quotechar (only ever `"` or `'`, both regex-safe;
     // CPython's re.escape is likewise a no-op for them), fancy_regex::escape on the delim.
     let escaped_delim = fancy_regex::escape(&delim);
+    // `[^{PY_WORD}]` rather than `\W`: same reason as QUOTE_PATTERNS above —
+    // fancy-regex's `\W` is the complement of a different word set than
+    // CPython's, which flipped `doublequote` as well as `delimiter` (#318).
     let dq_pattern = format!(
-        r"(?m)(({delim})|^)\W*{quote}[^{delim}\n]*{quote}[^{delim}\n]*{quote}\W*(({delim})|$)",
+        r"(?m)(({delim})|^)[^{word}]*{quote}[^{delim}\n]*{quote}[^{delim}\n]*{quote}[^{word}]*(({delim})|$)",
         delim = escaped_delim,
         quote = quotechar,
+        word = PY_WORD,
     );
     // A failed compile (defensive — the pattern is built from a single-char
     // quotechar and an fancy_regex::escape'd delimiter) or a backtrack-limit Err

--- a/tests/parity/test_parity_dialect.py
+++ b/tests/parity/test_parity_dialect.py
@@ -6,9 +6,17 @@ QUOTING_MAP = CSVDialect.QUOTING_MAP
 
 
 def dialect_properties_from_rust(rust_dict):
-    """Apply CSVDialect's property defaults to the raw Rust sniff result."""
+    """Apply CSVDialect's property defaults to the raw Rust sniff result.
+
+    ``delimiter`` is included deliberately (#319). It used to be omitted, which
+    meant sniff_dialect's own delimiter output was never compared by any corpus
+    test — infer_delimiter has its own test, but it is a different code path.
+    That gap hid #318, a real cross-backend delimiter divergence, until the
+    property suite compared the raw dicts and found it.
+    """
     if rust_dict is None:
         return {
+            "delimiter": None,
             "quotechar": '"',
             "escapechar": None,
             "doublequote": False,
@@ -17,6 +25,7 @@ def dialect_properties_from_rust(rust_dict):
             "quoting": "quote minimal",
         }
     return {
+        "delimiter": rust_dict["delimiter"],
         "quotechar": rust_dict["quotechar"],
         "escapechar": rust_dict["escapechar"],
         "doublequote": rust_dict["doublequote"],

--- a/tests/parity/test_parity_property.py
+++ b/tests/parity/test_parity_property.py
@@ -14,7 +14,6 @@ xfail only when the divergence rate is too high to enumerate, and say so in the
 reason. Do not weaken a property to make it pass.
 """
 
-import pytest
 from hypothesis import event, example, given
 from hypothesis import strategies as st
 from strategies import (
@@ -71,30 +70,11 @@ def test_leading_rows_agrees(gen, limit):
         assert outcome(rs.leading_rows, path, limit) == outcome(py.leading_rows, path, limit)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "sniff_dialect's delimiter class is [^\\w\\n\"'], and CPython's \\w (str.isalnum()-based) "
-        "disagrees with fancy-regex's \\w on category No (U+00B2) and on marks (U+0301). The blast "
-        "radius is NOT delimiter-only. Two independent 20,000-call runs agree on the shape while "
-        "differing in the exact counts (they are seed-specific): delimiter alone dominates, with "
-        "delimiter+doublequote, delimiter+skipinitialspace, delimiter+quotechar, doublequote alone "
-        "and skipinitialspace alone all observed, plus dialect-vs-None flips in BOTH directions "
-        "(one run: 23 Rust-dialect/CPython-None and 15 the reverse). "
-        "doublequote, quotechar and skipinitialspace ARE fields the corpus dialect tests compare, and "
-        "a None-vs-dialect flip is a behavior change, reachable in production from "
-        "src/datagrunt/core/databases/databases.py:125 (CSVDialect(self.filepath), no delimiter). "
-        "The rate is roughly 1 in 140-170 generated examples (two runs: 1-in-137, 1-in-171) — far "
-        "too high to pin per-example — so "
-        "this stays a TEST-LEVEL xfail, which means the property explores ZERO generated examples "
-        "until #318 is fixed. Corpus case sniff_delimiter_word_class.csv. See #318"
-    ),
-)
 @example(
-    # The minimized falsifying example, pinned so this fails at every profile
-    # rather than only where the search happens to reach it (it was found at the
-    # deep profile, not at ci's 100 examples). Keep as a regression case once
-    # #318 is fixed and the xfail comes off.
+    # #318's minimized falsifying example, kept as a permanent regression case
+    # now that it is fixed. U+00B2 is a word character to CPython (category No)
+    # but was not to fancy-regex, so the sniffer's [^\w\n"'] delimiter class
+    # disagreed about whether it could be a delimiter at all.
     gen=GeneratedCSV(
         data=b'"\'"\'\n"\xc2\xb2\'"',
         suffix=".csv",


### PR DESCRIPTION
Closes #318 and #319. Found by the property-based parity harness (#315).

## The bug

The sniffer's delimiter class is `[^\w\n"']`, and the two engines disagree about what `\w` means — **in both directions**.

| | definition |
|---|---|
| CPython `re` | "alphanumeric characters (as defined by `str.isalnum()`) as well as the underscore" → `L* ∪ N* ∪ _` |
| fancy-regex (via regex-syntax UTS#18 `perl_word`) | `Alphabetic ∪ M ∪ Nd ∪ Pc ∪ Join_Control` |

So `²` (U+00B2, category `No`) is a word character to CPython but not to Rust, while a combining mark (U+0301) is one to Rust but not to CPython. The backends disagreed about which characters were even *eligible* to be a delimiter.

```python
data = b'"\'"\'\n"\xc2\xb2\'"'
_native.sniff_dialect(p)["delimiter"]          # was '²'
_compute_python.sniff_dialect(p)["delimiter"]  # '"'
```

## The fix

`\w` → an explicit `\p{L}\p{N}_`, at **all four sites**: the three `QUOTE_PATTERNS` classes and the `\W*` in the doubled-quote detection — the latter being why `doublequote` flipped alongside `delimiter`.

The equivalence was verified exhaustively rather than reasoned about:

```
over all 1,114,112 code points, re.match(r"\w", ch) agrees with
category(ch)[0] in "LN" or ch == "_"  →  zero mismatches
```

Python is the oracle and is correct, so this is Rust-only — same as #317.

The class now lives in one named constant (`PY_WORD`) rather than being spelled `\w` in four places, so there is a single place to look when asking what "word character" means here, and a doc comment explaining why the distinction is load-bearing.

## Measured effect

`sniff_dialect` divergences over 20,000 generated examples: **~1-in-137 → zero.**

The strict xfail XPASS-failed the moment the fix landed and is removed. The U+00B2 case is retained as a permanent `@example` regression. **The parity suite now has zero xfails.**

## Also closes #319

`dialect_properties_from_rust` omitted `delimiter` from its comparison, so no corpus test had ever checked `sniff_dialect`'s delimiter output — which is exactly why #318 survived until the property suite compared the raw dicts. `infer_delimiter` has its own test, but it is a different code path. Now included, which also gives this fix corpus-level verification.

## Residual, stated rather than glossed

CPython's tables come from the running interpreter's Unicode version (13.0 on the 3.10 floor) while regex-syntax pins 16.0, so code points assigned in between can still disagree. That skew **predates this change and is not introduced by it** — it is far narrower than the definitional mismatch it replaces, since `²` and combining marks have been assigned for decades. Recorded in the `PY_WORD` doc comment.

## Verification

| Gate | Result |
|---|---|
| `cargo test` | 59 passed |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `pytest tests/ -q` (Rust backend) | 1476 passed |
| `DATAGRUNT_DISABLE_RUST=1 pytest tests/ -q` | 1476 passed |
| `pytest tests/parity/ -q` | 666 passed, **0 xfailed** |
| `ruff check src tests` / `ruff format --check .` | clean |
| `mypy` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)