### PR TITLE
refactor(types): widen the mypy gate to the whole src tree, annotate the oracle, gate stub drift with stubtest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
       - name: "mypy (blocking — scoped, see #314)" # quoted: bare `#` starts a YAML comment
         run: .venv/bin/mypy
 
+      # The pytest stub guard compares name sets only; stubtest compares
+      # signatures, so a Rust arity/type change cannot ship a stale stub.
+      - name: "stubtest (blocking — _native.pyi vs compiled module)"
+        run: .venv/bin/python -m mypy.stubtest datagrunt._native --ignore-positional-only
+
   python-compat:
     # The main test job covers 3.12; this proves the rest of the advertised
     # range (requires-python >= 3.10, classifiers through 3.14). The native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
       - name: ruff format check (blocking)
         run: .venv/bin/ruff format --check .
 
-      # Scoped to the compute-backend contract (files listed under [tool.mypy]),
-      # not the whole tree. #314 tracks widening it.
-      - name: "mypy (blocking — scoped, see #314)" # quoted: bare `#` starts a YAML comment
+      # Whole-tree gate: files = ["src/datagrunt"] under [tool.mypy] covers
+      # every module, with check_untyped_defs on for unannotated bodies.
+      - name: "mypy (blocking — whole tree)"
         run: .venv/bin/mypy
 
       # The pytest stub guard compares name sets only; stubtest compares

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ For any substantive change, follow this end-to-end. (Trivial 1–2 line fixes ma
 - When Rust changed: `cd rust && cargo test`, plus the differential parity suite `uv run pytest tests/parity/ -q` (Rust == Python over the corpus)
 - `ruff check src/datagrunt/core/csv_io` (CI gates on this; check the broader tree too)
 - `ruff format --check .` (CI gates on this, blocking)
-- `mypy` (CI gates on this, blocking; scoped to the compute-backend contract — see #314)
+- `mypy` (CI gates on this, blocking; scoped to the compute-backend contract — see #314) plus `stubtest` for `_native.pyi` signature drift (blocking)
 - After Rust changes, **rebuild the extension** so tests see it: `uv pip install -e ".[dev,pdf]"` (or `maturin develop`)
 
 ### Hygiene

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ For any substantive change, follow this end-to-end. (Trivial 1–2 line fixes ma
 - When Rust changed: `cd rust && cargo test`, plus the differential parity suite `uv run pytest tests/parity/ -q` (Rust == Python over the corpus)
 - `ruff check src/datagrunt/core/csv_io` (CI gates on this; check the broader tree too)
 - `ruff format --check .` (CI gates on this, blocking)
-- `mypy` (CI gates on this, blocking; scoped to the compute-backend contract — see #314) plus `stubtest` for `_native.pyi` signature drift (blocking)
+- `mypy` + `stubtest` (CI gates on these, blocking; whole `src/datagrunt` tree)
 - After Rust changes, **rebuild the extension** so tests see it: `uv pip install -e ".[dev,pdf]"` (or `maturin develop`)
 
 ### Hygiene

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ mypy_path = "src"
 files = [
     "src/datagrunt/core/csv_io/_compute.py",
     "src/datagrunt/core/csv_io/_compute_protocol.py",
+    "src/datagrunt/core/csv_io/_compute_python.py",
     "src/datagrunt/_native.pyi",
     "src/datagrunt/core/csv_io/csvcomponents.py",
     "src/datagrunt/core/excel_io/excelcomponents.py",
@@ -158,13 +159,15 @@ warn_redundant_casts = true
 # Listed explicitly rather than as `..._compute*`: mypy only accepts `*` as a
 # whole dotted component, and rejects a partial-component pattern with a
 # *warning* while still exiting 0 — a silently unenforced override. These are
-# the scoped modules above; `_compute_python` is excluded on purpose (the
-# oracle is unannotated, and annotating it is #314's job, not this gate's).
+# the scoped modules above, now including `_compute_python`: the oracle is
+# annotated to the ComputeBackendProtocol, so the TYPE_CHECKING conformance
+# assignment in _compute.py enforces its signatures, not just its members (#314).
 [[tool.mypy.overrides]]
 module = [
     "datagrunt._native",
     "datagrunt.core.csv_io._compute",
     "datagrunt.core.csv_io._compute_protocol",
+    "datagrunt.core.csv_io._compute_python",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,13 +140,17 @@ exclude = ["*.md"]
 [tool.mypy]
 python_version = "3.10"
 mypy_path = "src"
-# Scoped deliberately. #314 tracks widening this to the public API surface;
+# Scoped deliberately. #314 tracks widening this to cover the compute contract
+# plus the backend() call sites, and to eventually cover the whole tree;
 # checking the whole tree today surfaces 42 mypy errors (13 import-untyped
 # for third-party libs without stubs, 29 substantive) in one change.
 files = [
     "src/datagrunt/core/csv_io/_compute.py",
     "src/datagrunt/core/csv_io/_compute_protocol.py",
     "src/datagrunt/_native.pyi",
+    "src/datagrunt/core/csv_io/csvcomponents.py",
+    "src/datagrunt/core/excel_io/excelcomponents.py",
+    "src/datagrunt/core/parquet_io/parquetcomponents.py",
 ]
 warn_unused_ignores = true
 warn_redundant_casts = true
@@ -163,3 +167,11 @@ module = [
     "datagrunt.core.csv_io._compute_protocol",
 ]
 disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = [
+    "datagrunt.core.csv_io.csvcomponents",
+    "datagrunt.core.excel_io.excelcomponents",
+    "datagrunt.core.parquet_io.parquetcomponents",
+]
+check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,28 +140,21 @@ exclude = ["*.md"]
 [tool.mypy]
 python_version = "3.10"
 mypy_path = "src"
-# Scoped deliberately. #314 tracks widening this to cover the compute contract
-# plus the backend() call sites, and to eventually cover the whole tree;
-# checking the whole tree today surfaces 42 mypy errors (13 import-untyped
-# for third-party libs without stubs, 29 substantive) in one change.
-files = [
-    "src/datagrunt/core/csv_io/_compute.py",
-    "src/datagrunt/core/csv_io/_compute_protocol.py",
-    "src/datagrunt/core/csv_io/_compute_python.py",
-    "src/datagrunt/_native.pyi",
-    "src/datagrunt/core/csv_io/csvcomponents.py",
-    "src/datagrunt/core/excel_io/excelcomponents.py",
-    "src/datagrunt/core/parquet_io/parquetcomponents.py",
-]
+# Whole-tree, blocking (the ratchet from the original 3-file compute-contract
+# scope is now complete). check_untyped_defs keeps unannotated bodies
+# checked; the strict disallow_untyped_defs override below holds the
+# compute contract to full annotations.
+files = ["src/datagrunt"]
+check_untyped_defs = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 
 # Listed explicitly rather than as `..._compute*`: mypy only accepts `*` as a
 # whole dotted component, and rejects a partial-component pattern with a
 # *warning* while still exiting 0 — a silently unenforced override. These are
-# the scoped modules above, now including `_compute_python`: the oracle is
+# the compute-backend-contract modules held to the stricter bar: the oracle is
 # annotated to the ComputeBackendProtocol, so the TYPE_CHECKING conformance
-# assignment in _compute.py enforces its signatures, not just its members (#314).
+# assignment in _compute.py enforces its signatures, not just its members.
 [[tool.mypy.overrides]]
 module = [
     "datagrunt._native",
@@ -171,10 +164,9 @@ module = [
 ]
 disallow_untyped_defs = true
 
+# Third-party libraries with no stubs/py.typed marker. Silenced here (never
+# via inline `# type: ignore`) so every suppression is visible in one place.
+# Extend this list only when the whole-tree run actually names a new one.
 [[tool.mypy.overrides]]
-module = [
-    "datagrunt.core.csv_io.csvcomponents",
-    "datagrunt.core.excel_io.excelcomponents",
-    "datagrunt.core.parquet_io.parquetcomponents",
-]
-check_untyped_defs = true
+module = ["pytesseract.*", "pypdfium2.*", "xlsxwriter.*"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,13 @@ disallow_untyped_defs = true
 # Third-party libraries with no stubs/py.typed marker. Silenced here (never
 # via inline `# type: ignore`) so every suppression is visible in one place.
 # Extend this list only when the whole-tree run actually names a new one.
+# pyarrow is the odd one out: its py.typed marker is version-dependent, not
+# absent outright. The dependency floor is pyarrow>=24.0.0 (unbounded); 24.0.0
+# ships py.typed (mypy sees it locally and uses real types — this override is
+# inert there), but a fresh resolve can land on a newer release (e.g. 25.0.0)
+# whose py.typed isn't visible to mypy, which is exactly what CI hit. Safe in
+# both cases: ignore_missing_imports only silences the "missing stubs"
+# diagnostic, it never substitutes Any for a type mypy can actually resolve.
 [[tool.mypy.overrides]]
-module = ["pytesseract.*", "pypdfium2.*", "xlsxwriter.*"]
+module = ["pytesseract.*", "pypdfium2.*", "xlsxwriter.*", "pyarrow.*"]
 ignore_missing_imports = true

--- a/src/datagrunt/_native.pyi
+++ b/src/datagrunt/_native.pyi
@@ -14,6 +14,20 @@ differ from the oracle's, so no keyword call is portable across backends.
 
 from datagrunt.core.csv_io._compute_protocol import HeaderProbe, SniffedDialect, StrPath
 
+__all__ = [
+    "is_legacy_mac_newlines",
+    "leading_rows",
+    "first_row",
+    "count_leading_comments",
+    "count_leading_physical_lines_before_header",
+    "normalize_columns",
+    "infer_delimiter",
+    "row_count_with_header",
+    "check_ragged",
+    "sniff_dialect",
+    "probe_csv_header",
+]
+
 def is_legacy_mac_newlines(path: StrPath, /) -> bool: ...
 def leading_rows(path: StrPath, limit: int, /) -> list[str]: ...
 def first_row(path: StrPath, /) -> str: ...

--- a/src/datagrunt/core/csv_io/_compute_python.py
+++ b/src/datagrunt/core/csv_io/_compute_python.py
@@ -11,8 +11,9 @@ serves two roles as one body of code:
 
 Workflow: change CSV-compute behavior HERE first, validate against the test
 suite, then port the change to Rust and let the parity suite confirm they agree.
-This module must stand alone in pure Python — standard library + FileProperties
-only; it must never import ``datagrunt._native`` or ``_compute``.
+This module must stand alone in pure Python — standard library + FileProperties,
+plus the typing-only ``_compute_protocol`` import below (it imports nothing back,
+so this is not a cycle); it must never import ``datagrunt._native`` or ``_compute``.
 """
 
 # standard library
@@ -20,8 +21,11 @@ import csv
 import re
 import sys
 from collections import Counter
+from collections.abc import Iterator
+from typing import TextIO, cast
 
 # local libraries
+from datagrunt.core.csv_io._compute_protocol import HeaderProbe, SniffedDialect, StrPath
 from datagrunt.core.file_io import FileProperties
 
 # --- delimiter inference constants (from CSVDelimiter) ---
@@ -49,7 +53,7 @@ EMPTY_NAME_PLACEHOLDER = "column"
 MAX_LINE_CHARS = 2 * 1024 * 1024
 
 
-def _capped_lines(f):
+def _capped_lines(f: TextIO) -> Iterator[str]:
     """Yield each line from a text file, truncated to ``MAX_LINE_CHARS`` chars.
 
     Mirrors the Rust line readers' per-line cap so the two backends agree on
@@ -60,7 +64,7 @@ def _capped_lines(f):
         yield line if len(line) <= MAX_LINE_CHARS else line[:MAX_LINE_CHARS]
 
 
-def is_legacy_mac_newlines(filepath):
+def is_legacy_mac_newlines(filepath: StrPath) -> bool:
     """True if the file uses legacy Mac OS carriage returns (\\r) as line endings."""
     try:
         with open(filepath, "rb") as f:
@@ -70,7 +74,7 @@ def is_legacy_mac_newlines(filepath):
         return False
 
 
-def count_leading_comments(filepath):
+def count_leading_comments(filepath: StrPath) -> int:
     """Count leading ``#``-prefixed comment lines before the header (blanks skipped)."""
     count = 0
     with open(filepath, "r", encoding=FileProperties(filepath).DEFAULT_ENCODING, errors="ignore") as f:
@@ -85,7 +89,7 @@ def count_leading_comments(filepath):
     return count
 
 
-def count_leading_physical_lines_before_header(filepath):
+def count_leading_physical_lines_before_header(filepath: StrPath) -> int:
     """Count every leading physical line up to and including the header line."""
     count = 0
     with open(filepath, "r", encoding=FileProperties(filepath).DEFAULT_ENCODING, errors="ignore") as f:
@@ -97,9 +101,9 @@ def count_leading_physical_lines_before_header(filepath):
     return count
 
 
-def leading_rows(filepath, limit):
+def leading_rows(filepath: StrPath, limit: int) -> list[str]:
     """Up to ``limit`` leading non-blank, non-comment rows, each stripped."""
-    rows = []
+    rows: list[str] = []
     with open(filepath, "r", encoding=FileProperties(filepath).DEFAULT_ENCODING, errors="ignore") as f:
         for line in _capped_lines(f):
             stripped = line.strip()
@@ -110,13 +114,13 @@ def leading_rows(filepath, limit):
     return rows
 
 
-def first_row(filepath):
+def first_row(filepath: StrPath) -> str:
     """The first non-comment row, stripped, or "" if none."""
     rows = leading_rows(filepath, 1)
     return rows[0] if rows else ""
 
 
-def _nul_safe_lines(f):
+def _nul_safe_lines(f: TextIO) -> Iterator[str]:
     """Line stream safe for ``csv.reader`` on every supported Python.
 
     Python < 3.11's csv module rejects NUL characters ("line contains NUL");
@@ -129,7 +133,7 @@ def _nul_safe_lines(f):
     return (line.replace("\0", "�") for line in f)
 
 
-def check_ragged(filepath, delimiter):
+def check_ragged(filepath: StrPath, delimiter: str) -> bool:
     """Return True if the CSV has ragged rows in the first 10,000 data rows.
 
     Bool only (no warning — that stays in the csvcomponents wrapper). Best-effort:
@@ -162,7 +166,7 @@ def check_ragged(filepath, delimiter):
     return False
 
 
-def row_count_with_header(filepath, delimiter):
+def row_count_with_header(filepath: StrPath, delimiter: str) -> int:
     """Number of CSV records including the header (quoted newlines = one record)."""
     newline_param = None if is_legacy_mac_newlines(filepath) else ""
     encoding = FileProperties(filepath).DEFAULT_ENCODING
@@ -176,25 +180,25 @@ def row_count_with_header(filepath, delimiter):
     return count
 
 
-def _candidates_most_common(first_row_str):
+def _candidates_most_common(first_row_str: str) -> list[str]:
     """Non-alphanumeric header characters, most common first (Counter.most_common)."""
     columns_no_spaces = first_row_str.replace(" ", "")
     counts = Counter(DELIMITER_REGEX.findall(columns_no_spaces))
     return [char for char, _ in counts.most_common()]
 
 
-def _split_row(row, char):
+def _split_row(row: str, char: str) -> list[str]:
     return row.split() if char == SPACE_DELIMITER else row.split(char)
 
 
-def _splits_rows_consistently(sample_rows, char):
+def _splits_rows_consistently(sample_rows: list[str], char: str) -> bool:
     if len(sample_rows) < 2:
         return False
     field_counts = {len(_split_row(r, char)) for r in sample_rows}
     return len(field_counts) == 1 and field_counts.pop() >= MIN_CONSISTENT_FIELDS
 
 
-def probe_csv_header(filepath):
+def probe_csv_header(filepath: StrPath) -> HeaderProbe:
     """Single-pass header probe shared by delimiter + dialect inference.
 
     One read captures everything both inference paths need, replacing the
@@ -213,8 +217,8 @@ def probe_csv_header(filepath):
     if props.is_empty:
         return {"empty": True, "blank": False, "first_row": "", "sample_rows": [], "sample_lines": []}
 
-    sample_lines = []
-    sample_rows = []
+    sample_lines: list[str] = []
+    sample_rows: list[str] = []
     saw_nonblank = False
     # NOTE on blankness semantics: this probe derives ``blank`` from
     # ``saw_nonblank`` over lines decoded with ``errors="ignore"``. An
@@ -250,7 +254,7 @@ def probe_csv_header(filepath):
     }
 
 
-def infer_delimiter(filepath):
+def infer_delimiter(filepath: StrPath) -> str:
     """Infer the delimiter (safe > consistent punctuation > space > comma)."""
     props = FileProperties(filepath)
     if props.is_tsv:
@@ -271,7 +275,7 @@ def infer_delimiter(filepath):
     return DEFAULT_DELIMITER
 
 
-def sniff_dialect(filepath, delimiter=None):
+def sniff_dialect(filepath: StrPath, delimiter: str | None = None) -> SniffedDialect | None:
     """Sniff the CSV dialect, returning the native dict shape (or None).
 
     None for empty/blank files and undeterminable samples. The constant fields
@@ -289,18 +293,23 @@ def sniff_dialect(filepath, delimiter=None):
             dialect = csv.Sniffer().sniff(sample)
     except csv.Error:
         return None
-    return {
+    sniffed: SniffedDialect = {
         "delimiter": dialect.delimiter,
-        "quotechar": dialect.quotechar,
+        # typeshed types Dialect.quotechar as `str | None` for the general case
+        # (a hand-rolled dialect could set it to None), but CPython's own
+        # Sniffer.sniff() unconditionally sets `quotechar = quotechar or '"'`
+        # before returning — never None. The cast reflects that guarantee.
+        "quotechar": cast(str, dialect.quotechar),
         "escapechar": None,
         "doublequote": dialect.doublequote,
         "lineterminator": "\r\n",
         "skipinitialspace": dialect.skipinitialspace,
         "quoting": 0,
     }
+    return sniffed
 
 
-def _normalize_single(name):
+def _normalize_single(name: str) -> str:
     name = name.lower()
     name = SPECIAL_CHARS_PATTERN.sub("_", name)
     name = name.strip("_")
@@ -310,9 +319,9 @@ def _normalize_single(name):
     return f"_{name}" if name[0].isdigit() else name
 
 
-def _make_unique(columns_list):
-    emitted = set()
-    unique_names = []
+def _make_unique(columns_list: list[str]) -> list[str]:
+    emitted: set[str] = set()
+    unique_names: list[str] = []
     for name in columns_list:
         candidate = name
         suffix = 0
@@ -324,6 +333,6 @@ def _make_unique(columns_list):
     return unique_names
 
 
-def normalize_columns(names):
+def normalize_columns(names: list[str]) -> list[str]:
     """Normalize then collision-safe-uniquify a list of column names."""
     return _make_unique([_normalize_single(c) for c in names])

--- a/src/datagrunt/core/csv_io/engines.py
+++ b/src/datagrunt/core/csv_io/engines.py
@@ -721,6 +721,10 @@ class CSVWriterPolarsEngine(CSVBaseWriterEngine):
 class _PyArrowEngineMixin:
     """Helpers shared by the PyArrow reader and writer engines."""
 
+    # Declared, not assigned: always mixed into a _DuckDBBackedEngine
+    # subclass, which sets this instance attribute in its own __init__.
+    filepath: Path
+
     @cached_property
     def _midfile_comments(self):
         """Whether the file has a mid-file ``#`` comment, scanned once per instance.

--- a/src/datagrunt/core/csv_io/factories.py
+++ b/src/datagrunt/core/csv_io/factories.py
@@ -2,10 +2,13 @@
 
 # standard library
 from pathlib import Path
+from typing import Callable, ClassVar
 
 # third party libraries
 # local libraries
 from datagrunt.core.csv_io.engines import (
+    CSVBaseReaderEngine,
+    CSVBaseWriterEngine,
     CSVEngineProperties,
     CSVReaderDuckDBEngine,
     CSVReaderPolarsEngine,
@@ -20,13 +23,20 @@ from datagrunt.core.databases import DuckDBQueries
 class CSVEngineFactory:
     """Factory class for creating CSV reader and writer engine instances."""
 
-    READER_ENGINES = {
+    # Typed as Callable rather than type[CSVBaseReaderEngine]: mypy widens a
+    # dict literal of several concrete subclasses to their common base type,
+    # and the base is abstract, so a type[...]-typed dict trips mypy's
+    # abstract-instantiation check even though every stored value is one of
+    # the three concrete subclasses below (never the abstract base itself).
+    # Callable[..., Base] describes the same runtime values without going
+    # through that check. No instance ever assigns these, so ClassVar.
+    READER_ENGINES: ClassVar[dict[str, Callable[..., CSVBaseReaderEngine]]] = {
         "duckdb": CSVReaderDuckDBEngine,
         "polars": CSVReaderPolarsEngine,
         "pyarrow": CSVReaderPyArrowEngine,
     }
 
-    WRITER_ENGINES = {
+    WRITER_ENGINES: ClassVar[dict[str, Callable[..., CSVBaseWriterEngine]]] = {
         "duckdb": CSVWriterDuckDBEngine,
         "polars": CSVWriterPolarsEngine,
         "pyarrow": CSVWriterPyArrowEngine,

--- a/src/datagrunt/core/csv_io/protocol.py
+++ b/src/datagrunt/core/csv_io/protocol.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Optional, Protocol, Union, runtime_checkable
+from typing import Callable, Dict, List, Optional, Protocol, Union, runtime_checkable
 
 import polars as pl
 import pyarrow as pa
@@ -113,6 +113,10 @@ class CSVWriterEngineProtocol(Protocol):
 
 class DataFrameDerivedReaderMixin:
     """Default Arrow/dict conversions for engines centered on Polars DataFrames."""
+
+    # Declared, not assigned: the concrete engine this is mixed into (e.g.
+    # CSVReaderPolarsEngine) provides the real to_dataframe implementation.
+    to_dataframe: Callable[..., pl.DataFrame]
 
     def to_arrow_table(self, normalize_columns=None):
         return self.to_dataframe(normalize_columns).to_arrow()

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -409,9 +409,9 @@ class PDFBaseWriterEngine(ABC):
         self.properties = PDFEngineProperties(filepath=self.filepath)
         if not self.filepath.exists():
             raise FileNotFoundError
-        self._reader_engine = None
-        self._cached_document = None
-        self._cached_parse_key = None
+        self._reader_engine: Optional[PDFBaseReaderEngine] = None
+        self._cached_document: Optional[dict] = None
+        self._cached_parse_key: Optional[tuple] = None
 
     def _parse_document(self, image_output_dir, drop_layout_tables):
         """Parse once per (image_output_dir, drop_layout_tables) and reuse the dict."""

--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -168,7 +168,7 @@ class PDFBaseReaderEngine(ABC):
         self.extraction_config = extraction_config or _PDFExtractionConfig()
         if not self.filepath.exists():
             raise FileNotFoundError
-        self._parsed_cache = {}
+        self._parsed_cache: dict[bool, dict] = {}
 
     def _parse_to_dicts(self, drop_layout_tables: bool = False) -> dict:
         """Parse once per drop_layout_tables value, shared by the conversions.
@@ -412,6 +412,11 @@ class PDFBaseWriterEngine(ABC):
         self._reader_engine: Optional[PDFBaseReaderEngine] = None
         self._cached_document: Optional[dict] = None
         self._cached_parse_key: Optional[tuple] = None
+
+    @abstractmethod
+    def _reader(self) -> PDFBaseReaderEngine:
+        """Return (creating and caching on first call) this writer's reader engine."""
+        pass
 
     def _parse_document(self, image_output_dir, drop_layout_tables):
         """Parse once per (image_output_dir, drop_layout_tables) and reuse the dict."""

--- a/src/datagrunt/core/pdf_io/extraction/_doc_session.py
+++ b/src/datagrunt/core/pdf_io/extraction/_doc_session.py
@@ -1,5 +1,7 @@
 """Shared thread-local, depth-counted document session for PDF backends."""
 
+import threading
+
 
 class _ThreadLocalDocSession:
     """Mixin providing a reused, per-thread document handle.
@@ -16,6 +18,10 @@ class _ThreadLocalDocSession:
     """
 
     _lazy_open = False
+    # Declared, not assigned: every subclass sets this in its own __init__
+    # (see docstring contract above). A bare annotation gives mypy the type
+    # without adding a class-level default that would be wrong to share.
+    _local: threading.local
 
     def _open_resource(self):
         raise NotImplementedError

--- a/src/datagrunt/core/pdf_io/extraction/base.py
+++ b/src/datagrunt/core/pdf_io/extraction/base.py
@@ -45,14 +45,16 @@ class ExtractionBackend(ABC):
         """Return classified text blocks for the page."""
 
     @abstractmethod
-    def extract_images(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> list[ImageBlock]:
+    def extract_images(
+        self, page_number: int, output_dir: str | None = None, name_prefix: str = "page"
+    ) -> list[ImageBlock]:
         """Return embedded images; write files when ``output_dir`` is given."""
 
     @abstractmethod
     def ocr_page(self, page_number: int, dpi: int = 300) -> list[OcrBlock]:
         """Return OCR-recovered text lines for the page."""
 
-    def extract_page(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> tuple:
+    def extract_page(self, page_number: int, output_dir: str | None = None, name_prefix: str = "page") -> tuple:
         """Single-pass extraction: ``(PageAnalysis, list[TextBlock], list[ImageBlock])``.
 
         Default implementation calls the three primitives separately; concrete

--- a/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
+++ b/src/datagrunt/core/pdf_io/extraction/layout_sorter.py
@@ -238,7 +238,7 @@ class PageLayoutSorter:
     def _group_spanning_intervals(self, spanning: list) -> list[dict]:
         """Group overlapping spanning items into intervals."""
         spanning.sort(key=lambda it: self.adapter.get_bounds(it)[1])
-        intervals = []
+        intervals: list[dict] = []
         for it in spanning:
             x0, y_top, x1, y_bot = self.adapter.get_bounds(it)
             if not intervals or y_top > intervals[-1]["y_bot"]:

--- a/src/datagrunt/core/pdf_io/extraction/ocr.py
+++ b/src/datagrunt/core/pdf_io/extraction/ocr.py
@@ -27,7 +27,7 @@ def _import_ocr_deps():
 def _data_to_blocks(data: dict, dpi: int) -> list:
     """Group a pytesseract image_to_data DICT into ``OcrBlock`` lines (point bboxes)."""
     scale = 72.0 / dpi
-    lines = {}
+    lines: dict[tuple[int, int, int], list[dict]] = {}
     for i in range(len(data["text"])):
         conf = int(data["conf"][i])
         text = data["text"][i].strip()

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_backend.py
@@ -47,7 +47,7 @@ class PdfiumBackend(_ThreadLocalDocSession, ExtractionBackend):
             if should_close:
                 doc.close()
 
-    def extract_page(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> tuple:
+    def extract_page(self, page_number: int, output_dir: str | None = None, name_prefix: str = "page") -> tuple:
         """Parse the page once (single pdfium page/textpage open), returning
         analysis + text blocks + images, instead of opening the page three times.
         """
@@ -99,7 +99,7 @@ class PdfiumBackend(_ThreadLocalDocSession, ExtractionBackend):
                 doc.close()
         return TextBlockBuilder().build(items)
 
-    def extract_images(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> list:
+    def extract_images(self, page_number: int, output_dir: str | None = None, name_prefix: str = "page") -> list:
         """Return embedded images at or above the configured minimum dimension; write when output_dir set."""
         doc, should_close = self._get_doc()
         try:

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_document.py
@@ -178,7 +178,7 @@ class PdfiumPage:
 
     def image_items(
         self,
-        output_dir: str = None,
+        output_dir: str | None = None,
         name_prefix: str = "page",
         page_number: int = 0,
         min_image_dimension: int = _DEFAULT_MIN_IMAGE_DIMENSION,
@@ -233,6 +233,7 @@ class PdfiumPage:
 
                 # Try to convert using PIL
                 try:
+                    img: Image.Image
                     with Image.open(path) as img:
                         if img.mode not in ("RGB", "RGBA", "L"):
                             img = img.convert("RGB")

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -31,7 +31,7 @@ class PdfiumNativeReader(_ThreadLocalDocSession):
     def _open_resource(self):
         return PdfiumDocument(self.filepath)
 
-    def parse_page(self, page_index: int, image_output_dir: str = None) -> dict:
+    def parse_page(self, page_index: int, image_output_dir: str | None = None) -> dict:
         """Parse one page into the native schema dict."""
         doc, should_close = self._get_doc()
         try:

--- a/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
+++ b/src/datagrunt/core/pdf_io/extraction/pymupdf_backend.py
@@ -146,7 +146,7 @@ class PyMuPDFBackend(_ThreadLocalDocSession, ExtractionBackend):
             reading_order=order,
         )
 
-    def extract_page(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> tuple:
+    def extract_page(self, page_number: int, output_dir: str | None = None, name_prefix: str = "page") -> tuple:
         """Parse the page once, returning analysis + text blocks + images.
 
         Shares a single ``get_text("dict", sort=True)`` and a single
@@ -203,7 +203,7 @@ class PyMuPDFBackend(_ThreadLocalDocSession, ExtractionBackend):
             if should_close:
                 doc.close()
 
-    def extract_images(self, page_number: int, output_dir: str = None, name_prefix: str = "page") -> list:
+    def extract_images(self, page_number: int, output_dir: str | None = None, name_prefix: str = "page") -> list:
         """Return embedded images (ported from extractors.extract_images)."""
         doc, should_close = self._get_doc()
         try:
@@ -230,7 +230,7 @@ class PyMuPDFBackend(_ThreadLocalDocSession, ExtractionBackend):
         # differ from the content/display order. Resolve each image's bbox by
         # its xref so positions never get swapped; track per-xref occurrences
         # so an image drawn multiple times maps to the correct rect each time.
-        xref_occurrence = {}
+        xref_occurrence: dict[int, int] = {}
         for idx, img_info in enumerate(image_list):
             xref = img_info[0]
             occurrence = xref_occurrence.get(xref, 0)
@@ -315,7 +315,11 @@ class PyMuPDFBackend(_ThreadLocalDocSession, ExtractionBackend):
             page = doc[page_number]
             pix = page.get_pixmap(dpi=dpi)
             mode = "RGBA" if pix.alpha else "RGB"
-            img = Image.frombytes(mode, [pix.width, pix.height], pix.samples)
+            # pymupdf ships no stubs, so pix.width/height read as Any; bind the
+            # size honestly at the pymupdf boundary instead of annotating a
+            # list literal (frombytes wants tuple[int, int], not list[Any]).
+            size: tuple[int, int] = (pix.width, pix.height)
+            img = Image.frombytes(mode, size, pix.samples)
         finally:
             if should_close:
                 doc.close()

--- a/src/datagrunt/core/pdf_io/extraction/text_block_builder.py
+++ b/src/datagrunt/core/pdf_io/extraction/text_block_builder.py
@@ -117,8 +117,8 @@ class TextBlockBuilder:
         # only to bound the binary search, never to decide membership.
         max_tol = max(2.0, max_item_size * 0.5)
 
-        lines = []
-        line_keys = []  # round(anchor_y, 0) per line, ascending by construction
+        lines: list[dict] = []
+        line_keys: list[float] = []  # round(anchor_y, 0) per line, ascending by construction
         for it in sorted(items, key=lambda i: (round(i.y_top, 0), i.x0)):
             lo = bisect_left(line_keys, round(it.y_top - max_tol, 0))
             placed = False
@@ -156,7 +156,7 @@ class TextBlockBuilder:
     def _merge_lines(self, line_recs: list) -> list:
         """Merge adjacent lines of similar size, small gap, and x-overlap."""
         line_recs = sorted(line_recs, key=lambda r: (r["y_top"], r["x0"]))
-        merged = []
+        merged: list[dict] = []
         for ln in line_recs:
             if merged and self._should_merge(merged[-1], ln):
                 self._absorb(merged[-1], ln)

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -21,6 +21,7 @@ from datagrunt.core.pdf_io.extraction.markdown_escape import (
 from datagrunt.core.pdf_io.extraction.ocr import dpi_for_page
 from datagrunt.core.pdf_io.extraction.pdfium_native import PdfiumNativeReader
 from datagrunt.core.pdf_io.extraction.pymupdf_backend import PyMuPDFBackend
+from datagrunt.core.pdf_io.extraction.shapes import TableBlock
 
 PIPELINE_TYPE = "pure_python_local_v1"
 
@@ -62,7 +63,7 @@ class DocumentAssembler:
                 counter["n"] += 1
                 return elem_id
 
-            tables = []
+            tables: list[TableBlock] = []
             if analysis.has_line_drawings or not analysis.has_text_layer:
                 tables = self.table_extractor.extract(page_index)
 

--- a/src/datagrunt/csv_api/_engine_backed.py
+++ b/src/datagrunt/csv_api/_engine_backed.py
@@ -1,6 +1,7 @@
 """Shared engine lifecycle for the CSV public API (CSVReader/CSVWriter)."""
 
 from functools import cached_property
+from typing import ClassVar
 
 from datagrunt.core import CSVComponents, CSVEngineFactory
 
@@ -14,7 +15,7 @@ class _CSVEngineBacked(CSVComponents):
     factory builder and add any role-specific state in their own ``__init__``.
     """
 
-    _engine_role = None  # "reader" or "writer"
+    _engine_role: ClassVar[str | None] = None  # "reader" or "writer"
 
     def __init__(self, filepath, engine, lenient=False, normalize_columns=False):
         self.lenient = lenient

--- a/src/datagrunt/excel_api/_engine_backed.py
+++ b/src/datagrunt/excel_api/_engine_backed.py
@@ -1,6 +1,7 @@
 """Shared engine lifecycle for the Excel public API (ExcelReader/ExcelWriter)."""
 
 from functools import cached_property
+from typing import ClassVar
 
 from datagrunt.core import ExcelComponents, ExcelEngineFactory
 
@@ -13,7 +14,7 @@ class _ExcelEngineBacked(ExcelComponents):
     ``.sheets`` is inherited from ``ExcelComponents`` and needs no engine.
     """
 
-    _engine_role = None  # "reader" or "writer"
+    _engine_role: ClassVar[str | None] = None  # "reader" or "writer"
 
     def __init__(self, filepath, normalize_columns=False, **read_options):
         self.normalize_columns = normalize_columns

--- a/src/datagrunt/parquet_api/_engine_backed.py
+++ b/src/datagrunt/parquet_api/_engine_backed.py
@@ -1,6 +1,7 @@
 """Shared engine lifecycle for the Parquet public API (ParquetReader/Writer)."""
 
 from functools import cached_property
+from typing import ClassVar
 
 from datagrunt.core import ParquetComponents, ParquetEngineFactory
 
@@ -12,7 +13,7 @@ class _ParquetEngineBacked(ParquetComponents):
     semantics. Subclasses set ``_engine_role`` to choose the factory builder.
     """
 
-    _engine_role = None  # "reader" or "writer"
+    _engine_role: ClassVar[str | None] = None  # "reader" or "writer"
 
     def __init__(self, filepath, normalize_columns=False, **read_options):
         self.normalize_columns = normalize_columns

--- a/src/datagrunt/pdf_api/_engine_backed.py
+++ b/src/datagrunt/pdf_api/_engine_backed.py
@@ -2,6 +2,7 @@
 
 from functools import cached_property
 from pathlib import Path
+from typing import ClassVar
 
 from datagrunt.core import PDFComponents, PDFEngineFactory
 from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
@@ -17,7 +18,7 @@ class _PDFEngineBacked(PDFComponents):
     ``close()``/context-manager here.
     """
 
-    _engine_role = None  # "reader" or "writer"
+    _engine_role: ClassVar[str | None] = None  # "reader" or "writer"
 
     def __init__(self, filepath, engine="pdfium", workers=1, native=False, *, min_image_dimension=None):
         """Initialize a PDF reader/writer.


### PR DESCRIPTION
Widens the blocking mypy gate from 3 files to the whole `src/datagrunt` tree in five ratchet commits, each proven non-vacuous before being trusted (inject an error → gate goes red → revert → green).

## What

1. **`backend()` call sites under the gate** — the 12 call sites in `csvcomponents`/`excelcomponents`/`parquetcomponents` were unchecked (not in `files`, bodies unannotated with `check_untyped_defs` off). Zero findings once checked.
2. **The Python parity oracle is fully annotated** to `ComputeBackendProtocol` (keeping its `filepath` name — the Protocol is positional-only by design) and moved into the strict `disallow_untyped_defs` override. The `TYPE_CHECKING` conformance assignments in `_compute.py:34-35` are now signature-strict for **both** backends, not just member-presence-strict.
3. **`stubtest` gates `_native.pyi` in CI (blocking)** — the pytest stub guard compares name sets only; a Rust arity change shipped a green test and a wrong stub. `__all__` added to the stub (its one finding). Delivers the stubtest item of #315.
4. **Public API packages clean** — the dominant defect was the bare `= None` class-attribute sentinel (mypy infers type `None`); annotated `ClassVar[str | None]` at the bases, with grep evidence that no instance assignments exist.
5. **Whole-tree flip** — `files = ["src/datagrunt"]`, global `check_untyped_defs = true`, third-party stubless imports silenced per-module in config (`pytesseract.*`, `pypdfium2.*`, `xlsxwriter.*` — exactly the libs the run named; never inline ignores). All four in-code `#314` references retired.

Since `src/datagrunt/py.typed` already ships, downstream type-checkers now consume a fully verified surface rather than an unverified promise.

## Honest disclosures

- **Two edits go beyond pure annotation**, both behaviorally inert with evidence:
  - `pymupdf_backend.py`: PIL `Image.frombytes` size argument, list literal → tuple literal (PIL only indexes it; observationally identical).
  - `pdf_io/engines.py`: `_reader` is now a *declared* `@abstractmethod` on `PDFBaseWriterEngine` — the base's `_parse_document` already called `self._reader()`; the class was already abstract (`render_pages_as_images`), both engine subclasses implement it, and nothing instantiates the base directly (src + tests).
- **stubtest scoping fact:** against a PyO3 compiled module under `--ignore-positional-only`, stubtest catches **arity/name** drift only — compiled positional-only params expose no runtime type info to compare. Type-level stub correctness is enforced by the mypy Protocol conformance line instead. (The plan's original type-swap vacuity proof was itself vacuous; the landed proof breaks arity and was reproduced by review.)
- One `cast(str, dialect.quotechar)`: justified by CPython's `Sniffer.sniff` (`dialect.quotechar = quotechar or '"'` — never `None`), with a why-comment; `warn_redundant_casts` will flag it if typeshed ever narrows.
- Task 4/5 review also traced the pre-existing `engines.py` `[arg-type]` suspicion end-to-end: **mis-declared, not mishandled** — `None` flows through a 5-hop chain that branches on truthiness at every step; fixed at the true source (`pdfium_native.py` implicit-Optional signature), no behavior touched.

## Verification

| Gate | Result |
|---|---|
| `uv run mypy` (whole tree, config-driven) | ✅ Success, 60 source files |
| `uv run python -m mypy.stubtest datagrunt._native --ignore-positional-only` | ✅ Success |
| `uv run pytest tests/ -q` (Rust backend) | ✅ 1476 passed |
| `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` | ✅ 1476 passed |
| `uv run pytest tests/parity/ -q` | ✅ 666 passed |
| `uv run ruff check src/datagrunt` + `ruff format --check .` | ✅ clean |
| Non-vacuity | ✅ proven at every ratchet step (inject → red → revert → green) |

Both pytest counts identical to pre-branch baseline — the expected signature of a zero-runtime-change branch. No Rust source changed (`cargo` gates untouched).

Process: 5 fresh implementer subagents (TDD-style red/green on the gate itself), 5 independent per-task reviews (all Approved), final whole-branch review on the most capable model: **Ready to merge — Yes**, zero Critical/Important findings.

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
