### PR TITLE
test(rust): proptest property suite for datagrunt-core (panic-freedom + structural invariants)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +77,7 @@ version = "0.1.0"
 dependencies = [
  "csv",
  "fancy-regex",
+ "proptest",
  "tempfile",
 ]
 
@@ -116,10 +123,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
 
 [[package]]
 name = "getrandom"
@@ -129,7 +154,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -210,6 +235,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +254,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -238,6 +281,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -298,6 +360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,9 +376,53 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "regex-automata"
@@ -340,6 +452,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -420,11 +544,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -437,6 +567,15 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"
@@ -597,6 +736,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rust/datagrunt-core/Cargo.toml
+++ b/rust/datagrunt-core/Cargo.toml
@@ -10,3 +10,4 @@ fancy-regex = "0.18"
 
 [dev-dependencies]
 tempfile = "3"
+proptest = "1"

--- a/rust/datagrunt-core/tests/props_files.rs
+++ b/rust/datagrunt-core/tests/props_files.rs
@@ -1,0 +1,151 @@
+//! Panic-freedom battery over datagrunt-core's path-based entry points (#315).
+//!
+//! CLAUDE.md's rule — a panic reachable from user input is a DoS across the
+//! PyO3 boundary — stated as an executable property: every public path-based
+//! function must return (Ok, Err, or a value), never panic, for arbitrary
+//! file bytes. Value-level Rust==Python agreement lives in tests/parity/.
+
+use std::io::{Read, Write};
+
+use proptest::prelude::*;
+use tempfile::NamedTempFile;
+
+use datagrunt_core::io::MAX_LINE_CHARS;
+
+/// Write arbitrary bytes to a temp file and hand back the live handle
+/// (dropping it deletes the file).
+fn file_with(bytes: &[u8]) -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("create temp file");
+    f.write_all(bytes).expect("write temp bytes");
+    f.flush().expect("flush temp bytes");
+    f
+}
+
+/// Byte soup biased toward CSV-relevant structure: raw arbitrary bytes, a
+/// variant guaranteed to contain delimiters/quotes/newlines so the deeper
+/// parsing paths are actually reached, a non-empty whitespace-only variant
+/// (targets `HeaderProbe::blank`), and the deterministic empty file (targets
+/// `HeaderProbe::empty`'s dedicated fast path, rows.rs:43-51).
+///
+/// The last two arms exist because neither `empty` nor `blank` is likely to
+/// fall out of the first two arms within 256 cases: an empirical check
+/// without them found `probe.empty`/`probe.blank` hit 0 times across 257
+/// cases in `probe_header_shape_is_consistent`, which would have made that
+/// property's `empty`/`blank` assertions vacuously untested despite reading
+/// as real coverage.
+fn csvish_bytes() -> impl Strategy<Value = Vec<u8>> {
+    prop_oneof![
+        proptest::collection::vec(any::<u8>(), 0..2048),
+        "[a-z0-9,;|\t \"'\r\n#=+-]{0,2048}".prop_map(|s| s.into_bytes()),
+        "[ \t\r\n]{1,64}".prop_map(|s| s.into_bytes()),
+        Just(Vec::new()),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn path_entry_points_never_panic(bytes in csvish_bytes(), delim in any::<u8>(), limit in 0usize..64) {
+        let f = file_with(&bytes);
+        let p = f.path();
+
+        let _ = datagrunt_core::delimiter::infer_delimiter(p);
+        let _ = datagrunt_core::io::is_legacy_mac_newlines(p);
+        let _ = datagrunt_core::io::is_empty(p);
+        let _ = datagrunt_core::io::is_tsv(p);
+        let _ = datagrunt_core::rows::probe_csv_header(p);
+        let _ = datagrunt_core::rows::leading_rows(p, limit);
+        let _ = datagrunt_core::rows::first_row(p);
+        let _ = datagrunt_core::rows::count_leading_comments(p);
+        let _ = datagrunt_core::rows::count_leading_physical_lines_before_header(p);
+        let _ = datagrunt_core::rows::row_count_with_header(p, delim);
+        let _ = datagrunt_core::ragged::check_ragged(p, delim);
+    }
+
+    #[test]
+    fn universal_lines_never_panics_and_caps_line_length(bytes in csvish_bytes()) {
+        let f = file_with(&bytes);
+        let lines = datagrunt_core::io::universal_lines(f.path())
+            .expect("open succeeds on existing file");
+        // ADAPTATION (marked spot 1a): `UniversalLines` implements
+        // `Iterator<Item = std::io::Result<String>>` (io.rs:576-577), not a
+        // bare `String` as the sketch's placeholder loop implied. A genuine
+        // IO error mid-stream is a valid non-panic outcome the property must
+        // tolerate, so only the decoded `Ok` payload is checked against the
+        // per-line cap — `Result::into_iter()` (what `.flatten()` uses here)
+        // yields the `Ok` value or nothing, so this is exactly "skip Err".
+        for s in lines.flatten() {
+            prop_assert!(line_len_chars(&s) <= MAX_LINE_CHARS);
+        }
+    }
+
+    #[test]
+    fn decoded_reader_never_panics_in_both_modes(bytes in csvish_bytes(), translate in any::<bool>()) {
+        let f = file_with(&bytes);
+        let mut reader = datagrunt_core::io::DecodedReader::open(f.path(), translate)
+            .expect("open succeeds");
+        let mut out = String::new();
+        // ADAPTATION (marked spot 1b): consumption pattern mirrors io.rs's
+        // own `drain()` test helper (io.rs:865-874) — `read_to_string` via
+        // the `Read` impl (io.rs:336-353). DecodedReader's internal `pending`
+        // buffer is always built from a `String` (io.rs:236, :330), so the
+        // bytes handed to `read_to_string` are always valid UTF-8; the only
+        // possible `Err` here is a genuine IO error, which the property
+        // tolerates (the assertion under test is "never panics", not
+        // "never errors").
+        let _ = reader.read_to_string(&mut out);
+    }
+
+    #[test]
+    fn leading_rows_respects_limit(bytes in csvish_bytes(), limit in 0usize..64) {
+        let f = file_with(&bytes);
+        if let Ok(rows) = datagrunt_core::rows::leading_rows(f.path(), limit) {
+            // KNOWN (issue #325): limit=0 currently returns 1 row — the cap is
+            // checked after the append in BOTH backends, so differential parity
+            // cannot see it. The fix PR for #325 must tighten this back to
+            // `rows.len() <= limit`; that flip is its red/green test.
+            prop_assert!(rows.len() <= limit.max(1));
+        }
+    }
+
+    #[test]
+    fn probe_header_shape_is_consistent(bytes in csvish_bytes()) {
+        let f = file_with(&bytes);
+        if let Ok(probe) = datagrunt_core::rows::probe_csv_header(f.path()) {
+            // ADAPTATION (marked spot 2): HeaderProbe's real field set
+            // (rows.rs:19-25) is `empty, blank, first_row, sample_rows,
+            // sample_lines`. The sketch's placeholder body already named
+            // real fields (`empty`, `first_row`, `sample_rows`) but left out
+            // `blank`/`sample_lines`; both are wired in below, in the exact
+            // shape `probe_csv_header` (rows.rs:42-146) guarantees.
+            if probe.empty {
+                // The `is_empty()` fast path (rows.rs:43-51) hard-codes
+                // `blank: false` alongside `empty: true` and all three
+                // collections empty — a documented Python-parity quirk
+                // (mirrored by the `probe_empty_file` unit test), not a
+                // general "empty implies blank" rule, so it is asserted
+                // explicitly rather than assumed.
+                prop_assert!(!probe.blank);
+                prop_assert!(probe.first_row.is_empty());
+                prop_assert!(probe.sample_rows.is_empty());
+                prop_assert!(probe.sample_lines.is_empty());
+            }
+            if probe.blank {
+                // `blank` is `!saw_nonblank`, which only becomes `true` when
+                // a stripped line is non-empty (rows.rs:118-120) — the same
+                // guard that gates `sample_rows`/`first_row` population
+                // (rows.rs:128-130, :138) — so `blank` implies both are
+                // empty. `sample_lines` is deliberately NOT asserted empty
+                // here: non-comment blank lines are still appended to it
+                // (rows.rs:124-126), as the `probe_blank_file` unit test
+                // confirms (sample_lines non-empty while blank is true).
+                prop_assert!(probe.first_row.is_empty());
+                prop_assert!(probe.sample_rows.is_empty());
+            }
+        }
+    }
+}
+
+/// Char count without allocating; mirrors the cap's unit (chars, not bytes).
+fn line_len_chars(s: &str) -> usize {
+    s.chars().count()
+}

--- a/rust/datagrunt-core/tests/props_pure.rs
+++ b/rust/datagrunt-core/tests/props_pure.rs
@@ -1,0 +1,104 @@
+//! Property-based tests over datagrunt-core's pure functions (#315).
+//!
+//! Deliberately NOT differential: Rust==Python agreement is proven by
+//! tests/parity/ on the Python side. These lock in panic-freedom and the
+//! structural invariants each function must satisfy in isolation.
+
+use proptest::prelude::*;
+
+use datagrunt_core::dialect::sniff;
+use datagrunt_core::io::{decode_ignore, take_chars, universal_newlines};
+use datagrunt_core::normalize::normalize_columns;
+
+proptest! {
+    // ---- io::take_chars ------------------------------------------------
+    // Char-boundary safety is the whole reason this helper exists; naive
+    // byte slicing panics mid-codepoint.
+    #[test]
+    fn take_chars_never_panics_and_bounds_hold(s in ".*", n in 0usize..(3 * 1024)) {
+        let out = take_chars(&s, n);
+        prop_assert!(out.chars().count() <= n);
+        // Prefix property, char-wise.
+        prop_assert!(s.starts_with(&out));
+    }
+
+    #[test]
+    fn take_chars_is_identity_when_n_covers_input(s in ".*") {
+        let n = s.chars().count();
+        prop_assert_eq!(take_chars(&s, n), s);
+    }
+
+    // ---- io::decode_ignore ---------------------------------------------
+    #[test]
+    fn decode_ignore_never_panics(bytes in proptest::collection::vec(any::<u8>(), 0..4096)) {
+        let _ = decode_ignore(&bytes);
+    }
+
+    #[test]
+    fn decode_ignore_is_identity_on_valid_utf8(s in ".*") {
+        prop_assert_eq!(decode_ignore(s.as_bytes()), s);
+    }
+
+    // ---- io::universal_newlines ----------------------------------------
+    #[test]
+    fn universal_newlines_removes_all_carriage_returns(s in ".*") {
+        let out = universal_newlines(&s);
+        prop_assert!(!out.contains('\r'));
+    }
+
+    #[test]
+    fn universal_newlines_is_idempotent(s in ".*") {
+        let once = universal_newlines(&s);
+        prop_assert_eq!(universal_newlines(&once), once);
+    }
+
+    #[test]
+    fn universal_newlines_preserves_non_newline_content(s in "[^\r\n]*") {
+        // A string with no newline chars at all passes through untouched.
+        prop_assert_eq!(universal_newlines(&s), s);
+    }
+
+    // ---- dialect::sniff -------------------------------------------------
+    #[test]
+    fn sniff_never_panics_on_arbitrary_samples(sample in ".*") {
+        let _ = sniff(&sample, None);
+    }
+
+    #[test]
+    fn sniff_never_panics_with_candidate_delimiters(sample in ".*", delims in "[,;|\t: ]{1,4}") {
+        let _ = sniff(&sample, Some(&delims));
+    }
+
+    #[test]
+    fn sniff_output_invariants(sample in ".*") {
+        if let Some(d) = sniff(&sample, None) {
+            prop_assert_eq!(d.delimiter.chars().count(), 1);
+            // csv.Sniffer only ever yields '"' or '\'' as quotechar.
+            prop_assert!(d.quotechar == "\"" || d.quotechar == "'");
+        }
+    }
+
+    // ---- normalize::normalize_columns -----------------------------------
+    #[test]
+    fn normalize_columns_structural_invariants(
+        names in proptest::collection::vec(".*", 0..24)
+    ) {
+        let out = normalize_columns(&names);
+        // Length preserved.
+        prop_assert_eq!(out.len(), names.len());
+        // Every output is a nonempty lowercase identifier: [a-z0-9_]+.
+        for name in &out {
+            prop_assert!(!name.is_empty());
+            prop_assert!(name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'));
+        }
+        // All outputs are unique.
+        let unique: std::collections::HashSet<&String> = out.iter().collect();
+        prop_assert_eq!(unique.len(), out.len());
+    }
+
+    #[test]
+    fn normalize_columns_is_idempotent(names in proptest::collection::vec(".*", 0..24)) {
+        let once = normalize_columns(&names);
+        prop_assert_eq!(normalize_columns(&once), once.clone());
+    }
+}


### PR DESCRIPTION
Completes #315. The Hypothesis differential layer landed in #320 and `stubtest` landed via #324; this adds the remaining piece — `proptest` over `datagrunt-core` from below, without the PyO3 round-trip.

## What

- **`rust/datagrunt-core/tests/props_pure.rs`** — 12 properties over the pure functions: `take_chars` (char-boundary safety + prefix/identity), `decode_ignore` (panic-freedom + identity on valid UTF-8), `universal_newlines` (no `\r` survives, idempotence, non-newline passthrough), `sniff` (panic-freedom + single-char delimiter + quotechar ∈ {`"`, `'`}), `normalize_columns` (length preservation, nonempty `[a-z0-9_]+` outputs, uniqueness, idempotence).
- **`rust/datagrunt-core/tests/props_files.rs`** — 5-property panic-freedom battery: arbitrary and CSV-biased bytes through **every** pub path-based entry point (13 across `delimiter`, `io`, `rows`, `ragged`), plus the per-line char cap, the `leading_rows` limit bound, and header-probe shape consistency. States CLAUDE.md's no-panic-across-the-PyO3-boundary rule as an executable property.
- `proptest = "1"` as a dev-dependency; integration tests are compiled, run, and linted by the existing CI Rust job with no workflow changes.

**Deliberately not differential:** Rust==Python agreement already lives in `tests/parity/`. Re-deriving expected values here would duplicate the oracle. These properties assert what must hold of the Rust implementation in isolation.

## It found a real bug on its first run

`leading_rows(path, limit=0)` returns **1 row instead of 0** — the cap is checked *after* the append, **identically in both backends**, so the differential parity suite is structurally blind to it (the backends agree while both are wrong). Exactly the common-mode failure class #315 predicted. Filed as #325 with repro and a Python-first fix sketch; pinned here at the documented-current bound (`rows.len() <= limit.max(1)`) with an issue-linked comment. **#325's fix must re-tighten the bound — that flip is its red/green test** (obligation recorded in the issue).

## Determinism stance

proptest runs 256 fresh cases per property per run (no derandomized profile). Any failure it ever finds is a real bug and persists to a committed regression file, becoming a permanent deterministic case — mirroring the Hypothesis suite's philosophy; the weekly deep search remains the long-exploration venue. Every property was vacuity-checked: the two initially-unreachable header-probe assertions were caught by measurement (0 hits/257 cases) and the generator strengthened until they fire (62/69 cases).

## Verification

| Gate | Result |
|---|---|
| `cargo test` (workspace) | ✅ 59 unit + 12 props_pure + 5 props_files |
| `cargo clippy --all-targets -- -D warnings` | ✅ clean |
| `cargo fmt --check` | ✅ clean |
| `props_files` runtime | 0.86s (budget 30s) |
| `uv run pytest tests/ -q` ×2 backends, parity, ruff | ✅ unchanged (no Python/src edits) |
| Non-vacuity | ✅ broken-assertion drill produced a minimal counterexample + regression artifact (deleted); seam reachability measured |

Final whole-branch review (most capable model): **Ready to merge — Yes**; confirmed clean merge against post-#324 main (`git merge-tree` exit 0, zero file overlap), no CI-flake vectors (BOM/idempotence/quotechar edge cases chased to source), and full #315 scope closure.

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)
