### PR TITLE
feat(pdf): configurable OCR and page-render DPI [minor]

### DIFF
--- a/src/datagrunt/core/pdf_io/engines.py
+++ b/src/datagrunt/core/pdf_io/engines.py
@@ -494,8 +494,18 @@ class PDFBaseWriterEngine(ABC):
             pdfcomponents.dedupe_document_images(document, directory)
         return pdfcomponents.collect_image_paths(document)
 
+    def _resolve_dpi(self, dpi: Optional[int]) -> int:
+        """Resolve the effective render DPI for a ``render_pages_as_images`` call.
+
+        An explicit ``dpi`` argument always wins; ``None`` falls back to the
+        ``render_dpi`` extraction-config default (300 unless overridden).
+        Shared here so both writer engines apply the identical precedence
+        rule from one place rather than each re-deriving it.
+        """
+        return dpi if dpi is not None else self.extraction_config.render_dpi
+
     @abstractmethod
-    def render_pages_as_images(self, output_dir=None, dpi=300, image_format="png") -> list:
+    def render_pages_as_images(self, output_dir=None, dpi=None, image_format="png") -> list:
         """Render each page of the PDF as an image and save to disk."""
         pass
 
@@ -510,8 +520,10 @@ class PDFWriterPyMuPDFEngine(PDFBaseWriterEngine):
             )
         return self._reader_engine
 
-    def render_pages_as_images(self, output_dir=None, dpi=300, image_format="png") -> list:
+    def render_pages_as_images(self, output_dir=None, dpi=None, image_format="png") -> list:
         from datagrunt.core.pdf_io.extraction.pymupdf_backend import _import_pymupdf
+
+        dpi = self._resolve_dpi(dpi)
 
         if self.workers > 1:
             logger.warning(
@@ -567,7 +579,8 @@ class PDFWriterPdfiumEngine(PDFBaseWriterEngine):
             )
         return self._reader_engine
 
-    def render_pages_as_images(self, output_dir=None, dpi=300, image_format="png") -> list:
+    def render_pages_as_images(self, output_dir=None, dpi=None, image_format="png") -> list:
+        dpi = self._resolve_dpi(dpi)
         # Validate the format before any filesystem side effects (fail fast).
         ext, pil_format = _normalize_image_format(image_format)
         directory = Path(output_dir if output_dir else "page_images")

--- a/src/datagrunt/core/pdf_io/extraction/config.py
+++ b/src/datagrunt/core/pdf_io/extraction/config.py
@@ -2,7 +2,9 @@
 
 Not public API: the leading underscore and absence from every ``__all__`` keep
 ``_PDFExtractionConfig`` an internal detail. The public surface is the
-``min_image_dimension`` keyword argument on ``PDFReader``/``PDFWriter``.
+``min_image_dimension``, ``ocr_standard_dpi``, ``ocr_large_format_dpi``,
+``ocr_large_format_dimension``, and ``render_dpi`` keyword arguments on
+``PDFReader``/``PDFWriter``.
 """
 
 from dataclasses import dataclass
@@ -10,6 +12,17 @@ from dataclasses import dataclass
 # Single source of truth for the default minimum kept image dimension (px).
 # Images smaller than this on either side are dropped as layout artifacts.
 _DEFAULT_MIN_IMAGE_DIMENSION = 40
+
+# Single source of truth for the OCR dynamic-DPI scaling thresholds and the
+# default render DPI. These used to live in ocr.py; they moved here so that
+# ocr.py can import both them and `_PDFExtractionConfig` from one place.
+# ocr.py's `dpi_for_page` takes a `_PDFExtractionConfig`, so the dependency
+# must run config -> ocr, never the reverse, or the two modules would import
+# each other.
+STANDARD_DPI = 150
+LARGE_FORMAT_DPI = 75
+LARGE_FORMAT_DIMENSION = 1500
+_DEFAULT_RENDER_DPI = 300
 
 
 @dataclass(frozen=True)
@@ -21,12 +34,27 @@ class _PDFExtractionConfig:
     """
 
     min_image_dimension: int = _DEFAULT_MIN_IMAGE_DIMENSION
+    ocr_standard_dpi: int = STANDARD_DPI
+    ocr_large_format_dpi: int = LARGE_FORMAT_DPI
+    ocr_large_format_dimension: int = LARGE_FORMAT_DIMENSION
+    render_dpi: int = _DEFAULT_RENDER_DPI
 
-    def __post_init__(self):
-        value = self.min_image_dimension
+    def __post_init__(self) -> None:
+        # min_image_dimension alone allows 0 (a documented way to disable the
+        # small-image filter); every DPI/threshold field must be >= 1 since a
+        # zero or negative DPI or dimension threshold is nonsense.
+        self._validate_int_field("min_image_dimension", min_value=0)
+        self._validate_int_field("ocr_standard_dpi", min_value=1)
+        self._validate_int_field("ocr_large_format_dpi", min_value=1)
+        self._validate_int_field("ocr_large_format_dimension", min_value=1)
+        self._validate_int_field("render_dpi", min_value=1)
+
+    def _validate_int_field(self, name: str, *, min_value: int) -> None:
+        """Reject bool, non-int, and below-``min_value`` values for field ``name``."""
+        value = getattr(self, name)
         # bool is a subclass of int; reject it explicitly so True/False cannot
         # masquerade as 1/0.
         if isinstance(value, bool) or not isinstance(value, int):
-            raise TypeError(f"min_image_dimension must be an int, got {value!r} ({type(value).__name__})")
-        if value < 0:
-            raise ValueError(f"min_image_dimension must be >= 0, got {value}")
+            raise TypeError(f"{name} must be an int, got {value!r} ({type(value).__name__})")
+        if value < min_value:
+            raise ValueError(f"{name} must be >= {min_value}, got {value}")

--- a/src/datagrunt/core/pdf_io/extraction/ocr.py
+++ b/src/datagrunt/core/pdf_io/extraction/ocr.py
@@ -1,17 +1,17 @@
 """Shared OCR: render-agnostic Tesseract block construction."""
 
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.shapes import BBox, OcrBlock
 
-# Dynamic DPI scaling thresholds for scanned (OCR) pages.
-LARGE_FORMAT_DIMENSION = 1500
-LARGE_FORMAT_DPI = 75
-STANDARD_DPI = 150
 
-
-def dpi_for_page(width: float, height: float) -> int:
+def dpi_for_page(width: float, height: float, config: "_PDFExtractionConfig | None" = None) -> int:
     """Return the OCR render DPI for a page of the given size (points)."""
-    is_large = width > LARGE_FORMAT_DIMENSION or height > LARGE_FORMAT_DIMENSION
-    return LARGE_FORMAT_DPI if is_large else STANDARD_DPI
+    # No config -> module defaults, which are the historical STANDARD_DPI /
+    # LARGE_FORMAT_DPI / LARGE_FORMAT_DIMENSION constants (now defined once in
+    # config.py) — so behavior is unchanged for existing no-config callers.
+    cfg = config if config is not None else _PDFExtractionConfig()
+    is_large = width > cfg.ocr_large_format_dimension or height > cfg.ocr_large_format_dimension
+    return cfg.ocr_large_format_dpi if is_large else cfg.ocr_standard_dpi
 
 
 def _import_ocr_deps():

--- a/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
+++ b/src/datagrunt/core/pdf_io/extraction/pdfium_native.py
@@ -107,7 +107,7 @@ class PdfiumNativeReader(_ThreadLocalDocSession):
 
         Reuses the already-open ``page`` rather than opening a second handle.
         """
-        page_dpi = dpi_for_page(width, height)
+        page_dpi = dpi_for_page(width, height, self._config)
         img = page.render_pil(dpi=page_dpi)
         blocks = ocr_data_to_blocks(img, page_dpi)
         if not blocks:

--- a/src/datagrunt/core/pdf_io/pdfcomponents.py
+++ b/src/datagrunt/core/pdf_io/pdfcomponents.py
@@ -87,7 +87,9 @@ class DocumentAssembler:
                         elements.append(self._text_element(block, gen_elem_id(), page_index))
             elif analysis.is_scanned:
                 try:
-                    ocr_blocks = self.backend.ocr_page(page_index, dpi=dpi_for_page(analysis.width, analysis.height))
+                    ocr_blocks = self.backend.ocr_page(
+                        page_index, dpi=dpi_for_page(analysis.width, analysis.height, self._extraction_config)
+                    )
                 except Exception as exc:  # noqa: BLE001 - soft per-category failure
                     # OCR failed (e.g. missing tesseract). Keep the page with its
                     # already-extracted images/tables rather than dropping it, and

--- a/src/datagrunt/pdf_api/_engine_backed.py
+++ b/src/datagrunt/pdf_api/_engine_backed.py
@@ -20,7 +20,19 @@ class _PDFEngineBacked(PDFComponents):
 
     _engine_role: ClassVar[str | None] = None  # "reader" or "writer"
 
-    def __init__(self, filepath, engine="pdfium", workers=1, native=False, *, min_image_dimension=None):
+    def __init__(
+        self,
+        filepath,
+        engine="pdfium",
+        workers=1,
+        native=False,
+        *,
+        min_image_dimension=None,
+        ocr_standard_dpi=None,
+        ocr_large_format_dpi=None,
+        ocr_large_format_dimension=None,
+        render_dpi=None,
+    ):
         """Initialize a PDF reader/writer.
 
         Args:
@@ -37,6 +49,17 @@ class _PDFEngineBacked(PDFComponents):
             min_image_dimension (int, optional, keyword-only): Minimum embedded-image
                 pixel size (either side) to keep; smaller images are dropped as
                 layout artifacts. Defaults to 40. Use 0 to keep every image.
+            ocr_standard_dpi (int, optional, keyword-only): OCR render DPI used for
+                normal-sized pages. Defaults to 150.
+            ocr_large_format_dpi (int, optional, keyword-only): OCR render DPI used
+                for large-format pages (see ``ocr_large_format_dimension``).
+                Defaults to 75.
+            ocr_large_format_dimension (int, optional, keyword-only): Page width/height
+                threshold (points); a page with either side above this is treated as
+                large-format and rendered at ``ocr_large_format_dpi`` instead of
+                ``ocr_standard_dpi``. Defaults to 1500.
+            render_dpi (int, optional, keyword-only): Default DPI for rendering pages
+                to images. Defaults to 300.
         """
         if not isinstance(filepath, dict):
             filepath = Path(filepath)
@@ -44,7 +67,17 @@ class _PDFEngineBacked(PDFComponents):
         self.engine = engine.lower().replace(" ", "")
         self.workers = workers
         self.native = native
-        overrides = {k: v for k, v in {"min_image_dimension": min_image_dimension}.items() if v is not None}
+        overrides = {
+            k: v
+            for k, v in {
+                "min_image_dimension": min_image_dimension,
+                "ocr_standard_dpi": ocr_standard_dpi,
+                "ocr_large_format_dpi": ocr_large_format_dpi,
+                "ocr_large_format_dimension": ocr_large_format_dimension,
+                "render_dpi": render_dpi,
+            }.items()
+            if v is not None
+        }
         # Validates immediately (fail-fast at construction).
         self._extraction_config = _PDFExtractionConfig(**overrides)
 

--- a/src/datagrunt/pdf_api/pdfreader.py
+++ b/src/datagrunt/pdf_api/pdfreader.py
@@ -14,6 +14,9 @@ class PDFReader(_PDFEngineBacked):
 
     Pass ``min_image_dimension`` (keyword-only) to control the minimum embedded
     image pixel size kept during extraction (default 40; 0 keeps everything).
+    Pass ``ocr_standard_dpi`` / ``ocr_large_format_dpi`` / ``ocr_large_format_dimension``
+    (keyword-only) to control the OCR render DPI policy, and ``render_dpi``
+    (keyword-only) to control the default page-rendering DPI.
     """
 
     _engine_role = "reader"

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -14,6 +14,9 @@ class PDFWriter(_PDFEngineBacked):
 
     Pass ``min_image_dimension`` (keyword-only) to control the minimum embedded
     image pixel size kept during extraction (default 40; 0 keeps everything).
+    Pass ``ocr_standard_dpi`` / ``ocr_large_format_dpi`` / ``ocr_large_format_dimension``
+    (keyword-only) to control the OCR render DPI policy, and ``render_dpi``
+    (keyword-only) to control the default page-rendering DPI.
     """
 
     _engine_role = "writer"

--- a/src/datagrunt/pdf_api/pdfwriter.py
+++ b/src/datagrunt/pdf_api/pdfwriter.py
@@ -141,12 +141,14 @@ class PDFWriter(_PDFEngineBacked):
             return []
         return self._engine.extract_images(output_dir, dedupe)
 
-    def render_pages_as_images(self, output_dir=None, dpi=300, image_format="png"):
+    def render_pages_as_images(self, output_dir=None, dpi=None, image_format="png"):
         """Render each page of the PDF as an image and save to disk.
 
         Args:
             output_dir (optional, str): Output directory; defaults to page_images.
-            dpi (int, default 300): The resolution in DPI to render the pages.
+            dpi (optional, int): The resolution in DPI to render the pages.
+                None (default) uses the `render_dpi` configuration (300 unless
+                overridden).
             image_format (str, default 'png'): The image format to save. One of
                 'png', 'jpg', or 'jpeg' (case-insensitive); other values raise
                 ValueError.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,6 +237,36 @@ def scanned_pdf(tmp_path):
 
 
 @pytest.fixture
+def multipage_scanned_pdf(tmp_path):
+    """Create a 2-page PDF whose pages are each a rendered-text image.
+
+    Mirrors ``scanned_pdf`` (no extractable text layer, only OCR can recover
+    the words) but with two pages, so a ``workers>1`` process pool actually
+    splits OCR work across page workers instead of falling back to the
+    single-page sequential path.
+    """
+    import pymupdf
+
+    doc = pymupdf.open()
+    for n in (1, 2):
+        src = pymupdf.open()
+        src_page = src.new_page(width=612, height=792)
+        src_page.insert_text((72, 100), f"HELLO WORLD {n}", fontsize=48)
+        pix = src_page.get_pixmap(dpi=150)
+        src.close()
+
+        img_path = tmp_path / f"_scan_{n}.png"
+        pix.save(str(img_path))
+
+        page = doc.new_page(width=612, height=792)
+        page.insert_image(pymupdf.Rect(0, 0, 612, 792), filename=str(img_path))
+    pdf_path = tmp_path / "multipage_scanned.pdf"
+    doc.save(str(pdf_path))
+    doc.close()
+    return str(pdf_path)
+
+
+@pytest.fixture
 def multipage_pdf(tmp_path):
     """Create a 3-page PDF with distinct, identifiable text on each page."""
     import pymupdf

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_extraction_config.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_extraction_config.py
@@ -41,3 +41,35 @@ class TestPDFExtractionConfig:
     def test_is_picklable_and_round_trips(self):
         cfg = _PDFExtractionConfig(min_image_dimension=15)
         assert pickle.loads(pickle.dumps(cfg)) == cfg
+
+
+class TestPDFExtractionConfigDPIFields:
+    def test_defaults_match_legacy_constants(self):
+        cfg = _PDFExtractionConfig()
+        assert cfg.ocr_standard_dpi == 150
+        assert cfg.ocr_large_format_dpi == 75
+        assert cfg.ocr_large_format_dimension == 1500
+        assert cfg.render_dpi == 300
+
+    @pytest.mark.parametrize(
+        "field", ["ocr_standard_dpi", "ocr_large_format_dpi", "ocr_large_format_dimension", "render_dpi"]
+    )
+    def test_rejects_bool(self, field):
+        with pytest.raises(TypeError):
+            _PDFExtractionConfig(**{field: True})
+
+    @pytest.mark.parametrize(
+        "field", ["ocr_standard_dpi", "ocr_large_format_dpi", "ocr_large_format_dimension", "render_dpi"]
+    )
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_rejects_non_positive(self, field, bad):
+        with pytest.raises(ValueError):
+            _PDFExtractionConfig(**{field: bad})
+
+    def test_remains_picklable_with_overrides(self):
+        # Same-process round-trip of a locally-constructed, trusted instance
+        # (not deserialization of untrusted/external data) — this proves the
+        # picklability contract the config relies on to cross the pdfium
+        # process-pool worker boundary.
+        cfg = _PDFExtractionConfig(ocr_standard_dpi=300, render_dpi=600)
+        assert pickle.loads(pickle.dumps(cfg)) == cfg

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_ocr.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_ocr.py
@@ -1,6 +1,7 @@
 """Tests for the shared OCR data->blocks helper."""
 
-from datagrunt.core.pdf_io.extraction.ocr import _data_to_blocks
+from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
+from datagrunt.core.pdf_io.extraction.ocr import _data_to_blocks, dpi_for_page
 from datagrunt.core.pdf_io.extraction.shapes import OcrBlock
 
 
@@ -22,3 +23,21 @@ def test_data_to_blocks_groups_line():
     assert isinstance(b, OcrBlock)
     assert b.text == "Hello World" and b.word_count == 2 and b.confidence == 92.5
     assert b.bbox.x == 24.0
+
+
+class TestDpiForPageConfig:
+    def test_no_config_preserves_legacy_behavior(self):
+        assert dpi_for_page(1000, 1000) == 150
+        assert dpi_for_page(1501, 100) == 75
+        assert dpi_for_page(100, 1501) == 75
+        assert dpi_for_page(1500, 1500) == 150  # boundary: strict >
+
+    def test_config_drives_all_three_knobs(self):
+        cfg = _PDFExtractionConfig(ocr_standard_dpi=300, ocr_large_format_dpi=100, ocr_large_format_dimension=2000)
+        assert dpi_for_page(1999, 100, cfg) == 300
+        assert dpi_for_page(2001, 100, cfg) == 100
+        assert dpi_for_page(100, 2001, cfg) == 100
+
+    def test_uniform_dpi_via_equal_knobs(self):
+        cfg = _PDFExtractionConfig(ocr_standard_dpi=300, ocr_large_format_dpi=300)
+        assert dpi_for_page(100, 100, cfg) == dpi_for_page(9999, 9999, cfg) == 300

--- a/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
+++ b/tests/core_tests/pdf_io_tests/extraction_tests/test_pdfium_native.py
@@ -1,5 +1,7 @@
 """Tests for PdfiumNativeReader (native pdfium schema)."""
 
+import pytest
+
 from datagrunt.core.pdf_io.extraction.config import _PDFExtractionConfig
 from datagrunt.core.pdf_io.extraction.pdfium_native import PdfiumNativeReader
 
@@ -98,3 +100,54 @@ def test_native_lowered_threshold_keeps_small_image(small_image_pdf):
     reader = PdfiumNativeReader(small_image_pdf, extraction_config=_PDFExtractionConfig(min_image_dimension=10))
     page = reader.parse_page(0)
     assert len(page["images"]) == 1
+
+
+class TestPdfiumNativeReaderOcrDpiConfig:
+    """PdfiumNativeReader passes its held config's OCR DPI to render_pil (issue #246).
+
+    ``_ocr_fallback`` is the pdfium-native OCR fallback path (the third of the
+    three OCR paths alongside the pymupdf and pdfium-structured backends that
+    ``DocumentAssembler`` drives) -- it renders the page itself via
+    ``PdfiumPage.render_pil`` rather than going through an ``ExtractionBackend``.
+    """
+
+    def test_ocr_fallback_passes_config_dpi_to_render_pil(self, scanned_pdf, tesseract_available, monkeypatch):
+        if not tesseract_available:
+            pytest.skip("tesseract not available")
+        from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumPage
+
+        recorded = []
+        original_render_pil = PdfiumPage.render_pil
+
+        def spy_render_pil(self, dpi=300):
+            recorded.append(dpi)
+            return original_render_pil(self, dpi=dpi)
+
+        monkeypatch.setattr(PdfiumPage, "render_pil", spy_render_pil)
+
+        reader = PdfiumNativeReader(scanned_pdf, extraction_config=_PDFExtractionConfig(ocr_standard_dpi=300))
+        page = reader.parse_page(0)
+
+        assert recorded == [300]
+        # Sanity: OCR actually ran and found the embedded text, so this isn't
+        # a vacuous spy call on a path that produced nothing.
+        assert page["ocr"] is True
+
+    def test_ocr_fallback_default_config_uses_module_default_dpi(self, scanned_pdf, tesseract_available, monkeypatch):
+        """No explicit extraction_config -> the historical STANDARD_DPI (150) still applies."""
+        if not tesseract_available:
+            pytest.skip("tesseract not available")
+        from datagrunt.core.pdf_io.extraction.pdfium_document import PdfiumPage
+
+        recorded = []
+        original_render_pil = PdfiumPage.render_pil
+
+        def spy_render_pil(self, dpi=300):
+            recorded.append(dpi)
+            return original_render_pil(self, dpi=dpi)
+
+        monkeypatch.setattr(PdfiumPage, "render_pil", spy_render_pil)
+
+        PdfiumNativeReader(scanned_pdf).parse_page(0)
+
+        assert recorded == [150]

--- a/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
+++ b/tests/core_tests/pdf_io_tests/test_pdfcomponents.py
@@ -372,6 +372,56 @@ class TestDocumentAssemblerConfig:
         assert image_elems == []
 
 
+class TestDocumentAssemblerOcrDpiConfig:
+    """DocumentAssembler passes its held config's OCR DPI to the backend (issue #246).
+
+    ``parse_page`` calls ``self.backend.ocr_page(page_index, dpi=...)`` on
+    whichever backend it holds (pymupdf here, or pdfium via
+    ``TestParsePageBackend``'s explicit-backend style) -- the DPI policy lives
+    in the assembler, not the backend, so this one call site covers both.
+    """
+
+    def test_assembler_passes_config_dpi_to_backend_ocr_page(self, scanned_pdf, tesseract_available, monkeypatch):
+        if not tesseract_available:
+            pytest.skip("tesseract not available")
+        assembler = pdfcomponents.DocumentAssembler(
+            scanned_pdf, extraction_config=_PDFExtractionConfig(ocr_standard_dpi=300)
+        )
+        calls = []
+        original_ocr_page = assembler.backend.ocr_page
+
+        def spy_ocr_page(page_index, dpi=300):
+            calls.append(dpi)
+            return original_ocr_page(page_index, dpi=dpi)
+
+        monkeypatch.setattr(assembler.backend, "ocr_page", spy_ocr_page)
+
+        page = assembler.parse_page(0)
+
+        assert calls == [300]
+        # Sanity: OCR actually ran and found the embedded text, so this isn't
+        # a vacuous spy call on a path that produced nothing.
+        assert any(e["type"] == "body_text" for e in page["elements"])
+
+    def test_assembler_default_config_uses_module_default_dpi(self, scanned_pdf, tesseract_available, monkeypatch):
+        """No explicit extraction_config -> the historical STANDARD_DPI (150) still applies."""
+        if not tesseract_available:
+            pytest.skip("tesseract not available")
+        assembler = pdfcomponents.DocumentAssembler(scanned_pdf)
+        calls = []
+        original_ocr_page = assembler.backend.ocr_page
+
+        def spy_ocr_page(page_index, dpi=300):
+            calls.append(dpi)
+            return original_ocr_page(page_index, dpi=dpi)
+
+        monkeypatch.setattr(assembler.backend, "ocr_page", spy_ocr_page)
+
+        assembler.parse_page(0)
+
+        assert calls == [150]
+
+
 class TestParsePageBackend:
     """DocumentAssembler.parse_page consumes an ExtractionBackend + table extractor."""
 

--- a/tests/pdf_api_tests/test_pdfreader.py
+++ b/tests/pdf_api_tests/test_pdfreader.py
@@ -394,3 +394,55 @@ class TestPDFReaderMinImageDimension:
     def test_min_image_dimension_is_keyword_only(self, small_image_pdf):
         with pytest.raises(TypeError):
             PDFReader(small_image_pdf, "pdfium", 1, False, 10)  # 5th positional rejected
+
+
+class TestPDFReaderOcrDpiKwargs:
+    """Tests for the keyword-only OCR/render DPI parameters on PDFReader (issue #246)."""
+
+    @pytest.mark.parametrize(
+        "kwarg,value",
+        [
+            ("ocr_standard_dpi", 300),
+            ("ocr_large_format_dpi", 400),
+            ("ocr_large_format_dimension", 2000),
+            ("render_dpi", 600),
+        ],
+    )
+    def test_kwarg_reaches_engine_config(self, sample_pdf, kwarg, value):
+        reader = PDFReader(sample_pdf, **{kwarg: value})
+        assert getattr(reader._engine.extraction_config, kwarg) == value
+
+    def test_invalid_ocr_standard_dpi_raises_at_construction(self, sample_pdf):
+        with pytest.raises(ValueError):
+            PDFReader(sample_pdf, ocr_standard_dpi=0)
+
+    def test_ocr_dpi_kwargs_are_keyword_only(self, sample_pdf):
+        with pytest.raises(TypeError):
+            PDFReader(sample_pdf, "pdfium", 1, False, 300)  # 5th positional rejected
+
+
+class TestPDFReaderOcrDpiProcessPool:
+    """workers>1 uses a ProcessPoolExecutor; the OCR DPI config must survive pickling."""
+
+    def test_default_dpi_finds_text_across_process_pool(self, multipage_scanned_pdf, tesseract_available):
+        if not tesseract_available:
+            pytest.skip("tesseract not available")
+        reader = PDFReader(multipage_scanned_pdf, engine="pdfium", native=True, workers=2)
+        doc = reader.to_dicts()
+        pages = doc["document"]["pages"]
+        assert len(pages) == 2
+        assert all(page["ocr"] is True for page in pages)
+
+    def test_low_dpi_prevents_ocr_recognition_across_process_pool(self, multipage_scanned_pdf, tesseract_available):
+        if not tesseract_available:
+            pytest.skip("tesseract not available")
+        # Rendering this low makes each page's raster far too small for
+        # tesseract to recognize any characters (see the sibling default-dpi
+        # test above for the "it normally reads fine" baseline), so both
+        # pages coming back with ocr=False only happens if the override
+        # reached the worker processes.
+        reader = PDFReader(multipage_scanned_pdf, engine="pdfium", native=True, workers=2, ocr_standard_dpi=5)
+        doc = reader.to_dicts()
+        pages = doc["document"]["pages"]
+        assert len(pages) == 2
+        assert all(page["ocr"] is False for page in pages)

--- a/tests/pdf_api_tests/test_pdfwriter.py
+++ b/tests/pdf_api_tests/test_pdfwriter.py
@@ -677,3 +677,61 @@ class TestPDFWriterRenderPagesAsImages:
         writer = PDFWriter(parsed)
         with pytest.raises(ValueError):
             writer.render_pages_as_images(output_dir=str(tmp_path / "nope"))
+
+
+class TestRenderDpiConfig:
+    """dpi=None resolution precedence: explicit dpi= > constructor render_dpi= > 300.
+
+    sample_pdf is a 612x792pt (US Letter) single page, so the rendered image's
+    pixel width is exactly ``round(612 * dpi / 72)`` -- used to prove which DPI
+    actually drove the render, rather than just asserting a path exists.
+    """
+
+    def test_render_default_comes_from_config(self, sample_pdf, tmp_path):
+        """No explicit dpi= falls back to the constructor's render_dpi (pdfium)."""
+        from PIL import Image
+
+        out = tmp_path / "config_default"
+        writer = PDFWriter(sample_pdf, render_dpi=72)
+        paths = writer.render_pages_as_images(output_dir=str(out))
+        with Image.open(paths[0]) as img:
+            assert img.width == round(612 * 72 / 72)
+
+    def test_explicit_dpi_beats_config(self, sample_pdf, tmp_path):
+        """An explicit dpi= argument always wins over the constructor's render_dpi (pdfium)."""
+        from PIL import Image
+
+        out = tmp_path / "explicit_wins"
+        writer = PDFWriter(sample_pdf, render_dpi=72)
+        paths = writer.render_pages_as_images(output_dir=str(out), dpi=144)
+        with Image.open(paths[0]) as img:
+            assert img.width == round(612 * 144 / 72)
+
+    def test_no_kwargs_preserves_300_default(self, sample_pdf, tmp_path):
+        """No render_dpi config and no explicit dpi= still renders at 300 (pdfium)."""
+        from PIL import Image
+
+        out = tmp_path / "no_kwargs_default"
+        paths = PDFWriter(sample_pdf).render_pages_as_images(output_dir=str(out))
+        with Image.open(paths[0]) as img:
+            assert img.width == round(612 * 300 / 72)
+
+    def test_render_default_comes_from_config_pymupdf(self, sample_pdf, tmp_path):
+        """No explicit dpi= falls back to the constructor's render_dpi (pymupdf)."""
+        from PIL import Image
+
+        out = tmp_path / "config_default_pymupdf"
+        writer = PDFWriter(sample_pdf, engine="pymupdf", render_dpi=72)
+        paths = writer.render_pages_as_images(output_dir=str(out))
+        with Image.open(paths[0]) as img:
+            assert img.width == round(612 * 72 / 72)
+
+    def test_no_kwargs_preserves_300_default_pymupdf(self, sample_pdf, tmp_path):
+        """No render_dpi config and no explicit dpi= still renders at 300 (pymupdf)."""
+        from PIL import Image
+
+        out = tmp_path / "no_kwargs_default_pymupdf"
+        writer = PDFWriter(sample_pdf, engine="pymupdf")
+        paths = writer.render_pages_as_images(output_dir=str(out))
+        with Image.open(paths[0]) as img:
+            assert img.width == round(612 * 300 / 72)


### PR DESCRIPTION
Makes OCR render DPI (#246) and page-to-image render DPI (#247) configurable through the public PDF API, riding the exact `min_image_dimension` config precedent. **The no-kwargs path is byte-identical to today** — OCR at 150 DPI, 75 for pages over 1500pt on either side (strict `>`, boundary-tested), rendering at 300.

## Public surface

```python
PDFReader(path, ocr_standard_dpi=300)                      # sharper OCR everywhere
PDFReader(path, ocr_large_format_dpi=150)                  # raise the big-page floor
PDFReader(path, ocr_large_format_dimension=3000)           # move the threshold
PDFWriter(path, render_dpi=600).render_pages_as_images()   # config-backed render default
PDFWriter(path).render_pages_as_images(dpi=72)             # explicit dpi= always wins
```

All keyword-only, all validated like `min_image_dimension` (bool rejected, int required, `>= 1`), all carried by the frozen picklable `_PDFExtractionConfig` that already crosses the pdfium process-pool worker boundary.

## Naming deviation from #246's literal proposal (deliberate)

#246 proposed `standard_dpi`/`large_format_dpi`/`large_format_dimension`; this PR ships them prefixed `ocr_*`, because #247 adds `render_dpi` to the same namespace and the two issues explicitly wanted OCR policy and rasterization resolution decoupled. Unprefixed names would read as governing both.

## How all three OCR paths are covered by two call-site edits

DPI policy stays centralized (within-domain DRY): `DocumentAssembler.parse_page`'s single backend-agnostic `ocr_page(..., dpi=dpi_for_page(..., config))` call covers **pymupdf** and **pdfium-structured** (paths 1–2, spy-tested per backend); the **pdfium-native** fallback's own `dpi_for_page` call covers path 3. Backend `ocr_page` signatures are untouched. `workers>1` is proven by a differential process-pool test: default DPI finds the fixture's text, `ocr_standard_dpi=5` provably can't — a result only possible if the config actually crossed the pool boundary.

## Render half (#247)

`render_pages_as_images(dpi=None)` resolves via a shared `PDFBaseWriterEngine._resolve_dpi` (single point; explicit argument wins; resolution happens before the sequential/parallel branch so pool workers get the resolved value). Pixel-dimension tests on real rendered PNGs for both engines: `round(612 * dpi / 72)` at 72/144/300.

## Internal notes (disclosures)

- The three OCR constants moved from `extraction/ocr.py` into `extraction/config.py` (single source of truth; the reverse import direction would cycle). Zero importers existed outside the module; `datagrunt.core.*` is internal namespace.
- Anyone monkeypatching `ocr.STANDARD_DPI` (never supported) loses that lever — the supported knob this PR ships replaces it.
- Follow-up candidate (review Minor, accepted-deferred): a `workers=2` + `render_dpi=` pixel test to make #247's pool clause non-compositional.

## Verification

| Gate | Result |
|---|---|
| `uv run pytest tests/ -q` (Rust backend) | ✅ 1510 passed (+34 new DPI tests, zero skips — tesseract live) |
| `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` | ✅ 1510 passed |
| `uv run mypy` (whole tree) | ✅ clean |
| `uv run ruff check` + `ruff format --check .` | ✅ clean |
| Legacy-behavior locks | ✅ 150/75/1500 strict-`>` boundary + 300 render pixel-verified |

Process: 3 fresh implementer subagents (TDD, red/green reconciled), 3 per-task reviews (all Approved; the per-task reviewers independently re-ran the gates), final whole-branch review on the most capable model: **Ready to merge — Yes**, zero Critical/Important findings.

Closes #246
Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
