### PR TITLE
fix(ci): stop auto-publish-site racing itself on batch-approved publishes

### DIFF
--- a/.github/workflows/auto-publish-site.yml
+++ b/.github/workflows/auto-publish-site.yml
@@ -21,6 +21,16 @@ on:
 permissions:
   contents: read
 
+# Publishes approved in a batch complete seconds apart and each completion
+# triggers a run; without a group, the twins race the datagrunt-site push
+# (#328). No cancel-in-progress: a queued run must still execute so the
+# newest release is always documented. GitHub keeps at most one pending run
+# per group — a superseded middle run is auto-canceled, which is correct
+# here (every run documents the CURRENT version anyway).
+concurrency:
+  group: auto-publish-site
+  cancel-in-progress: false
+
 jobs:
   update-docs:
     runs-on: ubuntu-latest
@@ -59,7 +69,28 @@ jobs:
           token: ${{ steps.site-token.outputs.token }}
           path: datagrunt-site
 
+      # A re-trigger for an already-documented version (a late-approved stale
+      # publish, or the loser of a race) has nothing real to do — the AI
+      # generator is content-idempotent but re-stamps the post date, which is
+      # exactly the no-op diff that raced in #328. Skip the whole generation
+      # when the current version's post exists. Fails open: an unexpected
+      # post filename just means a regeneration, which the concurrency group
+      # and push retry make safe. To deliberately regenerate a post, delete
+      # its file in datagrunt-site first (or let a new version supersede it).
+      - name: Check whether this version is already posted
+        id: postcheck
+        run: |
+          VERSION=$(grep -m1 '^current_version = ' datagrunt/pyproject.toml | cut -d'"' -f2)
+          V_SLUG=$(echo "$VERSION" | tr . -)
+          if find datagrunt-site/content/blog -type f -name "datagrunt-${V_SLUG}-*.md" | grep -q .; then
+            echo "Release post for $VERSION already exists; skipping regeneration."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup uv
+        if: steps.postcheck.outputs.exists != 'true'
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           python-version: "3.12"
@@ -70,12 +101,14 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
+        if: steps.postcheck.outputs.exists != 'true'
         # Pinned: these feed an AI agent that commits to datagrunt-site, so an
         # unpinned install is a supply-chain soft spot. Dependabot bumps them.
         run: |
           uv pip install google-antigravity==0.1.7 python-dotenv==1.2.2
 
       - name: Run Antigravity Workflow
+        if: steps.postcheck.outputs.exists != 'true'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         # Diff against the previous release tag so the post covers the whole
@@ -90,6 +123,7 @@ jobs:
           python datagrunt/scripts/antigravity_workflow.py --pre-merge-commit "$PREV_TAG"
 
       - name: Commit and Push Docs Update
+        if: steps.postcheck.outputs.exists != 'true'
         working-directory: datagrunt-site
         # Read the version from the datagrunt checkout — this step runs inside
         # datagrunt-site, where `git log` would return the site's own history.
@@ -99,4 +133,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add content/
           git diff-index --quiet HEAD || git commit -m "docs: release blog post for version $VERSION"
-          git push origin main
+          # Belt-and-braces for any writer that lands between our clone and
+          # push (#328): one rebase-retry. A conflicting rebase still fails,
+          # which is the correct outcome for a genuine content collision.
+          git push origin main || { git pull --rebase origin main && git push origin main; }

--- a/.github/workflows/auto-publish-site.yml
+++ b/.github/workflows/auto-publish-site.yml
@@ -28,7 +28,10 @@ permissions:
 # per group — a superseded middle run is auto-canceled, which is correct
 # here (every run documents the CURRENT version anyway).
 concurrency:
-  group: auto-publish-site
+  # Manual dispatches get their own group (run_id is unique) so a burst of
+  # chain triggers can never silently cancel a maintainer's pending run —
+  # GitHub cancels PENDING runs in a group regardless of cancel-in-progress.
+  group: auto-publish-site-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'chain' }}
   cancel-in-progress: false
 
 jobs:
@@ -82,7 +85,7 @@ jobs:
         run: |
           VERSION=$(grep -m1 '^current_version = ' datagrunt/pyproject.toml | cut -d'"' -f2)
           V_SLUG=$(echo "$VERSION" | tr . -)
-          if find datagrunt-site/content/blog -type f -name "datagrunt-${V_SLUG}-*.md" | grep -q .; then
+          if find datagrunt-site/content/blog -type f -name "datagrunt-${V_SLUG}-*.md" -print -quit | grep -q .; then
             echo "Release post for $VERSION already exists; skipping regeneration."
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
Fixes the docs-workflow failure from 2026-07-31 ([run 30665596323](https://github.com/pmgraham/datagrunt/actions/runs/30665596323)).

## What happened

Two PyPI publishes (4.5.11, 4.5.12) sat behind the approval gate for ~3 hours while 4.6.0 was approved and published normally. Batch-approving the stale pair completed them **6 seconds apart**; each completion triggered this workflow; both twins checked out main (already 4.6.0), regenerated the *existing* 4.6.0 post — differing only by a re-stamped `date:` — and raced the push to datagrunt-site. The loser died with `! [rejected] main -> main (fetch first)`.

No content damage: the winning twin pushed the identical change. But the failure class is live, and the same delay left 4.5.11/4.5.12 with no release post at all (both late runs read the *current* version, 4.6.0, not the one their trigger released).

## Three independent guards

1. **Concurrency group** — serializes racing triggers so twins can never push concurrently. `cancel-in-progress: false` because a queued run must still execute. Dispatches are scoped into their own group (`run_id` is unique) so a burst of chain triggers can never silently cancel a maintainer's pending manual run — GitHub cancels *pending* runs in a group regardless of `cancel-in-progress`.
2. **Skip-if-already-posted** — a re-trigger for an already-documented version now skips generation entirely instead of producing a date-only no-op commit. This kills the race at its root: the late twins had nothing real to push. Written to **fail open** (`!= 'true'`), so an unexpected filename regenerates rather than silently skipping. To force a rebuild, delete the post file in datagrunt-site.
3. **Push retry** — one `git pull --rebase` retry for any other writer landing between clone and push. A genuine content conflict still fails, which is correct.

## Verification

- `actionlint` clean; YAML parses; guard plumbing confirmed on all four downstream steps.
- Finding from review, fixed here: `find ... | grep -q .` isn't pipefail-safe (runner shell is `bash -eo pipefail`) — `grep -q`'s early exit SIGPIPEs `find`, surfacing 141 and silently writing `exists=false` for an already-posted version. Empirically reproduced at a 600-file corpus (wrong answer 20/20, `PIPESTATUS: 141 0`); `-print -quit` fixes it (correct 20/20). Latent at this site's ~29 posts, closed anyway.
- Normal path unchanged: for a fresh release the post is absent, all steps run as before, and the retry's right-hand side never evaluates.

Deferred to a follow-up (review minors, non-blocking): `current_version` is now extracted in three steps and could be a single output; `Checkout datagrunt-site` is shallow and the new rebase path has never exercised that combination.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
