### PR TITLE
fix(csv): leading_rows(limit=0) must return no rows

### DIFF
--- a/rust/datagrunt-core/src/rows.rs
+++ b/rust/datagrunt-core/src/rows.rs
@@ -149,7 +149,14 @@ pub fn probe_csv_header(path: &Path) -> std::io::Result<HeaderProbe> {
 /// each stripped. Streams the file and stops once `limit` rows are found.
 pub fn leading_rows(path: &Path, limit: usize) -> std::io::Result<Vec<String>> {
     let mut rows = Vec::new();
-    for line in universal_lines(path)? {
+    let lines = universal_lines(path)?;
+    // A zero limit asks for nothing. The check sits after the open so an
+    // unreadable path still errors here, exactly as it does for every other
+    // limit (issue #325).
+    if limit == 0 {
+        return Ok(rows);
+    }
+    for line in lines {
         let line = line?;
         let stripped = py_strip(&line);
         if !stripped.is_empty() && !stripped.starts_with('#') {
@@ -324,6 +331,26 @@ mod tests {
         assert_eq!(p.sample_rows[0], "name,age");
         // sample_lines include trailing \n to match Python text-mode
         assert_eq!(p.sample_lines[0], "name,age\n");
+    }
+
+    /// Regression (issue #325): the cap was checked after the append, so a
+    /// zero limit yielded one row. Mirrors the Python oracle's own guard.
+    #[test]
+    fn leading_rows_limit_zero_returns_nothing() {
+        let f = tmp(b"a\nb\n");
+        assert!(leading_rows(f.path(), 0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn leading_rows_honors_its_cap() {
+        let f = tmp(b"a\nb\nc\n");
+        assert_eq!(leading_rows(f.path(), 2).unwrap(), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn leading_rows_limit_zero_still_reports_a_bad_path() {
+        // Asking for nothing must not turn a bad path into a silent empty result.
+        assert!(leading_rows(Path::new("/no/such/datagrunt-325.csv"), 0).is_err());
     }
 
     #[test]

--- a/rust/datagrunt-core/tests/props_files.rs
+++ b/rust/datagrunt-core/tests/props_files.rs
@@ -99,11 +99,7 @@ proptest! {
     fn leading_rows_respects_limit(bytes in csvish_bytes(), limit in 0usize..64) {
         let f = file_with(&bytes);
         if let Ok(rows) = datagrunt_core::rows::leading_rows(f.path(), limit) {
-            // KNOWN (issue #325): limit=0 currently returns 1 row — the cap is
-            // checked after the append in BOTH backends, so differential parity
-            // cannot see it. The fix PR for #325 must tighten this back to
-            // `rows.len() <= limit`; that flip is its red/green test.
-            prop_assert!(rows.len() <= limit.max(1));
+            prop_assert!(rows.len() <= limit);
         }
     }
 

--- a/src/datagrunt/core/csv_io/_compute_python.py
+++ b/src/datagrunt/core/csv_io/_compute_python.py
@@ -105,6 +105,11 @@ def leading_rows(filepath: StrPath, limit: int) -> list[str]:
     """Up to ``limit`` leading non-blank, non-comment rows, each stripped."""
     rows: list[str] = []
     with open(filepath, "r", encoding=FileProperties(filepath).DEFAULT_ENCODING, errors="ignore") as f:
+        # A non-positive limit asks for nothing. The check sits inside the
+        # `with` so an unreadable path still raises here, exactly as it does
+        # for every other limit (issue #325).
+        if limit <= 0:
+            return rows
         for line in _capped_lines(f):
             stripped = line.strip()
             if stripped and not stripped.startswith("#"):

--- a/tests/core_tests/csv_io_tests/test_leading_rows_limit.py
+++ b/tests/core_tests/csv_io_tests/test_leading_rows_limit.py
@@ -1,0 +1,44 @@
+"""Regression tests for issue #325.
+
+``leading_rows`` promises "up to ``limit``" rows but checked the cap *after*
+appending, so ``limit=0`` returned one row. Both backends carried the defect
+identically, which is exactly what differential parity cannot see — so these
+tests assert the contract against each backend directly rather than against
+their agreement.
+"""
+
+import pytest
+
+from datagrunt import _native
+from datagrunt.core.csv_io import _compute_python
+
+backends = pytest.mark.parametrize("backend", (_native, _compute_python), ids=("rust", "python"))
+
+ROWS = ["name,age", "Alice,30", "Bob,25"]
+
+
+@pytest.fixture
+def sample(tmp_path):
+    path = tmp_path / "sample.csv"
+    path.write_text("\n".join(ROWS) + "\n")
+    return str(path)
+
+
+@backends
+def test_limit_zero_returns_no_rows(backend, sample):
+    assert backend.leading_rows(sample, 0) == []
+
+
+@backends
+@pytest.mark.parametrize("limit", (1, 2, 3, 4))
+def test_never_returns_more_rows_than_the_limit(backend, sample, limit):
+    rows = backend.leading_rows(sample, limit)
+    assert len(rows) <= limit
+    assert rows == ROWS[:limit]
+
+
+@backends
+def test_limit_zero_still_reports_an_unreadable_path(backend, tmp_path):
+    """Asking for nothing must not turn a bad path into a silent empty result."""
+    with pytest.raises(OSError):
+        backend.leading_rows(str(tmp_path / "missing.csv"), 0)


### PR DESCRIPTION
## Problem

`leading_rows(path, limit=0)` returned **1 row instead of 0**. Both backends checked the cap *after* the append:

```python
rows.append(stripped)
if len(rows) >= limit:   # 1 >= 0 — one row too late
    break
```

Both the Protocol docstring ("Up to `limit` stripped, non-blank, non-comment rows") and each implementation's own docstring promise at most `limit` rows, so this is a contract violation reachable from the public PyO3 surface (`datagrunt._native.leading_rows(path, 0)`).

The differential parity suite could never see it: Python and Rust agreed *while both being wrong*. The Rust `proptest` battery from #315 caught it on its first run.

## Fix

Python-first, then ported: return early on a non-positive limit in `_compute_python.leading_rows`, then mirror the guard in `rows::leading_rows`.

The guard sits **after** the file is opened in both backends, so an unreadable path still raises/errors at `limit=0` exactly as it does for every other limit, rather than silently returning an empty list. That behaviour is now locked in by a test on each side.

## Tests

- `tests/core_tests/csv_io_tests/test_leading_rows_limit.py` — new. Asserts the cap against **each backend directly** (`_native` and `_compute_python`), not against their agreement, since shared-ancestry bugs are invisible to the oracle. Covers `limit=0`, caps 1–4, and the bad-path contract.
- `rust/datagrunt-core/tests/props_files.rs` — `leading_rows_respects_limit` tightened from the pinned `rows.len() <= limit.max(1)` back to `rows.len() <= limit`. That flip was this fix's red/green test, as #325 specified.
- `rows.rs` — three deterministic unit tests (zero limit, cap honoured, bad path at zero).

## Blast radius

Nil for internal callers — `first_row` passes 1 and every other caller passes a small constant; no internal caller passes 0. External callers of `_native` get the documented behaviour.

## Out of scope

A **pre-existing** divergence on invalid input is untouched: a *negative* limit returns `[]` on the Python oracle and raises `OverflowError` from the Rust binding (`limit: usize`). It predates this change (Python previously returned 1 row there), sits outside the tested contract (the parity strategy generates `limit >= 0`), and neither backend returns wrong data. Say the word and I'll file it.

## Gates

| Gate | Result |
| --- | --- |
| `uv run pytest tests/ -q` (Rust) | 1522 passed |
| `DATAGRUNT_DISABLE_RUST=1 uv run pytest tests/ -q` | 1522 passed |
| `uv run pytest tests/parity/ -q` | 666 passed |
| `cargo test` | 79 passed |
| `cargo clippy --all-targets` | clean |
| `ruff check` (csv_io + tree) | passed |
| `ruff format --check .` | 142 files formatted |
| `mypy` / `stubtest` | clean |

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)